### PR TITLE
Add more failure policy integration tests and refactor into table driven format

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,8 +1,2 @@
 resources:
 - manager.yaml
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-images:
-- name: controller
-  newName: gcr.io/yashks-gke-dev/jobset
-  newTag: latest

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: gcr.io/yashks-gke-dev/jobset
+  newTag: latest

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -404,18 +404,8 @@ func (r *JobSetReconciler) shouldCreateJob(jobName string, ownedJobs *childJobs)
 	// TODO: maybe we can use a job map here so we can do O(1) lookups
 	// to check if the job already exists, rather than a linear scan
 	// through all the jobs owned by the jobset.
-	for _, activeJob := range ownedJobs.active {
-		if activeJob.Name == jobName {
-			return false
-		}
-	}
-	for _, successfulJob := range ownedJobs.successful {
-		if successfulJob.Name == jobName {
-			return false
-		}
-	}
-	for _, failedJob := range ownedJobs.failed {
-		if failedJob.Name == jobName {
+	for _, job := range concat(ownedJobs.active, ownedJobs.successful, ownedJobs.failed, ownedJobs.delete) {
+		if jobName == job.Name {
 			return false
 		}
 	}
@@ -481,4 +471,12 @@ func isIndexedJob(job *batchv1.Job) bool {
 
 func dnsHostnamesEnabled(rjob *jobset.ReplicatedJob) bool {
 	return rjob.Network.EnableDNSHostnames != nil && *rjob.Network.EnableDNSHostnames
+}
+
+func concat[T any](slices ...[]T) []T {
+	var result []T
+	for _, slice := range slices {
+		result = append(result, slice...)
+	}
+	return result
 }

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -351,7 +351,7 @@ func (r *JobSetReconciler) constructJobsFromTemplate(js *jobset.JobSet, rjob *jo
 		if create := r.shouldCreateJob(jobName, ownedJobs); !create {
 			continue
 		}
-		job, err := r.makeJob(js, rjob, jobIdx)
+		job, err := r.constructJob(js, rjob, jobIdx)
 		if err != nil {
 			return nil, err
 		}
@@ -373,11 +373,11 @@ func (r *JobSetReconciler) shouldCreateJob(jobName string, ownedJobs *childJobs)
 	return true
 }
 
-func (r *JobSetReconciler) makeJob(js *jobset.JobSet, rjob *jobset.ReplicatedJob, jobIdx int) (*batchv1.Job, error) {
+func (r *JobSetReconciler) constructJob(js *jobset.JobSet, rjob *jobset.ReplicatedJob, jobIdx int) (*batchv1.Job, error) {
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:      copyMap(rjob.Template.Labels),
-			Annotations: copyMap(rjob.Template.Annotations),
+			Labels:      cloneMap(rjob.Template.Labels),
+			Annotations: cloneMap(rjob.Template.Annotations),
 			Name:        genJobName(js, rjob, jobIdx),
 			Namespace:   js.Namespace,
 		},
@@ -474,7 +474,7 @@ func concat[T any](slices ...[]T) []T {
 	return result
 }
 
-func copyMap[K, V comparable](m map[K]V) map[K]V {
+func cloneMap[K, V comparable](m map[K]V) map[K]V {
 	copy := make(map[K]V)
 	for k, v := range m {
 		copy[k] = v

--- a/test/integration/jobset_controller_test.go
+++ b/test/integration/jobset_controller_test.go
@@ -131,7 +131,7 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 			}
 		},
 		// TODO: move validation tests to separate Describe + DescribeTable
-		ginkgo.Entry("jobset validation should fail if DNS hostnames is enabled and job completion mode is not indexed", &testCase{
+		ginkgo.Entry("validate enableDNSHostnames can't be set if job is not Indexed", &testCase{
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
 				return testing.MakeJobSet("js-hostnames-non-indexed", ns.Name).
 					AddReplicatedJob(testing.MakeReplicatedJob("test-job").


### PR DESCRIPTION
- Adds more failure policy integration tests and refactor into table driven format.
- Fixes a bug in the jobset controller causing it to try to recreate existing jobs marked for deletion that had not yet been deleted
- Refactor `constructJobsFromTemplate` method of `JobSetReconciler` to make it more concise and readable.