### PR TITLE
Add additional labels/annotations, and add unit tests for constructJobsFromTemplate

### DIFF
--- a/api/v1alpha1/jobset_types.go
+++ b/api/v1alpha1/jobset_types.go
@@ -19,10 +19,10 @@ import (
 )
 
 const (
-	JobIndexLabel string = "jobset.sigs.k8s.io/job-index"
-	ReplicasLabel string = "jobset.sigs.k8s.io/job-replicas"
-	RestartsLabel string = "jobset.sigs.k8s.io/restart-attempt"
-	JobNameKey    string = "job-name" // TODO(#26): Migrate to the fully qualified label name.
+	JobIndexKey string = "jobset.sigs.k8s.io/job-index"
+	ReplicasKey string = "jobset.sigs.k8s.io/job-replicas"
+	RestartsKey string = "jobset.sigs.k8s.io/restart-attempt"
+	JobNameKey  string = "job-name" // TODO(#26): Migrate to the fully qualified label name.
 )
 
 type JobSetConditionType string

--- a/api/v1alpha1/jobset_types.go
+++ b/api/v1alpha1/jobset_types.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	JobIndexLabel string = "jobset.sigs.k8s.io/job-index"
+	ReplicasLabel string = "jobset.sigs.k8s.io/job-replicas"
 	RestartsLabel string = "jobset.sigs.k8s.io/restart-attempt"
 	JobNameKey    string = "job-name" // TODO(#26): Migrate to the fully qualified label name.
 )

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -383,16 +383,22 @@ func (r *JobSetReconciler) constructJob(js *jobset.JobSet, rjob *jobset.Replicat
 		Spec: *rjob.Template.Spec.DeepCopy(),
 	}
 
-	// Add restart-attempt count label, it should be equal to jobSet restarts
-	// to indicate is part of the current jobSet run.
+	// Add replica count as label to the job.
+	job.Labels[jobset.ReplicasLabel] = strconv.Itoa(rjob.Replicas)
+
+	// Add restart-attempt count label to the job, it should be equal to
+	// jobSet restarts to indicate is part of the current jobSet run.
 	job.Labels[jobset.RestartsLabel] = strconv.Itoa(js.Status.Restarts)
 
-	// Add job index as a label and annotation.
+	// Add job index as a label and annotation to the job.
 	job.Labels[jobset.JobIndexLabel] = strconv.Itoa(jobIdx)
 	job.Annotations[jobset.JobIndexLabel] = strconv.Itoa(jobIdx)
 
-	// Add replica count as label.
-	job.Labels[jobset.ReplicasLabel] = strconv.Itoa(rjob.Replicas)
+	// Add job index as a label and annotation to the pod template spec.
+	job.Spec.Template.Labels = cloneMap(job.Spec.Template.Labels)
+	job.Spec.Template.Annotations = cloneMap(job.Spec.Template.Annotations)
+	job.Spec.Template.Labels[jobset.JobIndexLabel] = strconv.Itoa(jobIdx)
+	job.Spec.Template.Annotations[jobset.JobIndexLabel] = strconv.Itoa(jobIdx)
 
 	// If enableDNSHostnames is set, update job spec to set subdomain as
 	// job name (a headless service with same name as job will be created later).

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -391,6 +391,9 @@ func (r *JobSetReconciler) constructJob(js *jobset.JobSet, rjob *jobset.Replicat
 	job.Labels[jobset.JobIndexLabel] = strconv.Itoa(jobIdx)
 	job.Annotations[jobset.JobIndexLabel] = strconv.Itoa(jobIdx)
 
+	// Add replica count as label.
+	job.Labels[jobset.ReplicasLabel] = strconv.Itoa(rjob.Replicas)
+
 	// If enableDNSHostnames is set, update job spec to set subdomain as
 	// job name (a headless service with same name as job will be created later).
 	if dnsHostnamesEnabled(rjob) {

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -357,7 +357,7 @@ func (r *JobSetReconciler) updateStatus(ctx context.Context, js *jobset.JobSet, 
 	return nil
 }
 
-// TODO: update condition in place if it exists.
+// TODO(#39): update condition in place if it exists.
 func (r *JobSetReconciler) updateStatusWithCondition(ctx context.Context, js *jobset.JobSet, eventType string, condition metav1.Condition) error {
 	condition.LastTransitionTime = metav1.Now()
 	js.Status.Conditions = append(js.Status.Conditions, condition)

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -170,9 +170,9 @@ func (r *JobSetReconciler) getChildJobs(ctx context.Context, js *jobset.JobSet) 
 	for i, job := range childJobList.Items {
 		// Jobs with jobset.sigs.k8s.io/restart-attempt < jobset.status.restarts are marked for
 		// deletion, as they were part of the previous JobSet run.
-		jobRestarts, err := strconv.Atoi(job.Labels[jobset.RestartsLabel])
+		jobRestarts, err := strconv.Atoi(job.Labels[jobset.RestartsKey])
 		if err != nil {
-			log.Error(err, fmt.Sprintf("invalid value for label %s, must be integer", jobset.RestartsLabel))
+			log.Error(err, fmt.Sprintf("invalid value for label %s, must be integer", jobset.RestartsKey))
 			ownedJobs.delete = append(ownedJobs.delete, &childJobList.Items[i])
 			return nil, err
 		}
@@ -200,12 +200,17 @@ func (r *JobSetReconciler) createJobs(ctx context.Context, js *jobset.JobSet, ow
 	log := ctrl.LoggerFrom(ctx)
 
 	for _, rjob := range js.Spec.Jobs {
-		jobs, err := r.constructJobsFromTemplate(js, &rjob, ownedJobs)
+		jobs, err := constructJobsFromTemplate(js, &rjob, ownedJobs)
 		if err != nil {
 			return err
 		}
 
 		for _, job := range jobs {
+			// Set controller owner reference for garbage collection and reconcilation.
+			if err := ctrl.SetControllerReference(js, job, r.Scheme); err != nil {
+				return err
+			}
+
 			// Create headless service if specified for this job.
 			if dnsHostnamesEnabled(&rjob) {
 				if err := r.createHeadlessSvcIfNotExist(ctx, js, job); err != nil {
@@ -336,87 +341,11 @@ func (r *JobSetReconciler) deleteJobs(ctx context.Context, js *jobset.JobSet, jo
 				finalErr = err
 				return
 			}
-			log.V(2).Info("successfully deleted job", "job", klog.KObj(job), "restart attempt", job.Labels[job.Labels[jobset.RestartsLabel]])
+			log.V(2).Info("successfully deleted job", "job", klog.KObj(job), "restart attempt", job.Labels[job.Labels[jobset.RestartsKey]])
 		}()
 	}
 	wg.Wait()
 	return finalErr
-}
-
-func (r *JobSetReconciler) constructJobsFromTemplate(js *jobset.JobSet, rjob *jobset.ReplicatedJob, ownedJobs *childJobs) ([]*batchv1.Job, error) {
-	var jobs []*batchv1.Job
-	for jobIdx := 0; jobIdx < rjob.Replicas; jobIdx++ {
-		jobName := genJobName(js, rjob, jobIdx)
-		if create := r.shouldCreateJob(jobName, ownedJobs); !create {
-			continue
-		}
-		job, err := r.constructJob(js, rjob, jobIdx)
-		if err != nil {
-			return nil, err
-		}
-		jobs = append(jobs, job)
-	}
-	return jobs, nil
-}
-
-func (r *JobSetReconciler) shouldCreateJob(jobName string, ownedJobs *childJobs) bool {
-	// Check if this job exists already.
-	// TODO: maybe we can use a job map here so we can do O(1) lookups
-	// to check if the job already exists, rather than a linear scan
-	// through all the jobs owned by the jobset.
-	for _, job := range concat(ownedJobs.active, ownedJobs.successful, ownedJobs.failed, ownedJobs.delete) {
-		if jobName == job.Name {
-			return false
-		}
-	}
-	return true
-}
-
-func (r *JobSetReconciler) constructJob(js *jobset.JobSet, rjob *jobset.ReplicatedJob, jobIdx int) (*batchv1.Job, error) {
-	job := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Labels:      cloneMap(rjob.Template.Labels),
-			Annotations: cloneMap(rjob.Template.Annotations),
-			Name:        genJobName(js, rjob, jobIdx),
-			Namespace:   js.Namespace,
-		},
-		Spec: *rjob.Template.Spec.DeepCopy(),
-	}
-
-	// Add replica count as label to the job.
-	job.Labels[jobset.ReplicasLabel] = strconv.Itoa(rjob.Replicas)
-
-	// Add restart-attempt count label to the job, it should be equal to
-	// jobSet restarts to indicate is part of the current jobSet run.
-	job.Labels[jobset.RestartsLabel] = strconv.Itoa(js.Status.Restarts)
-
-	// Add job index as a label and annotation to the job.
-	job.Labels[jobset.JobIndexLabel] = strconv.Itoa(jobIdx)
-	job.Annotations[jobset.JobIndexLabel] = strconv.Itoa(jobIdx)
-
-	// Add job index as a label and annotation to the pod template spec.
-	job.Spec.Template.Labels = cloneMap(job.Spec.Template.Labels)
-	job.Spec.Template.Annotations = cloneMap(job.Spec.Template.Annotations)
-	job.Spec.Template.Labels[jobset.JobIndexLabel] = strconv.Itoa(jobIdx)
-	job.Spec.Template.Annotations[jobset.JobIndexLabel] = strconv.Itoa(jobIdx)
-
-	// If enableDNSHostnames is set, update job spec to set subdomain as
-	// job name (a headless service with same name as job will be created later).
-	if dnsHostnamesEnabled(rjob) {
-		job.Spec.Template.Spec.Subdomain = job.Name
-	}
-
-	// If this job should be exclusive per topology, set the pod affinities/anti-affinities accordingly.
-	if rjob.Exclusive != nil {
-		setExclusiveAffinities(job, rjob.Exclusive.TopologyKey, rjob.Exclusive.NamespaceSelector)
-	}
-
-	// Set controller owner reference for garbage collection and reconcilation.
-	if err := ctrl.SetControllerReference(js, job, r.Scheme); err != nil {
-		return nil, err
-	}
-
-	return job, nil
 }
 
 // updateStatus updates the status of a JobSet.
@@ -448,6 +377,68 @@ func (r *JobSetReconciler) failJobSet(ctx context.Context, js *jobset.JobSet) er
 		Reason:  "FailedJobs",
 		Message: "jobset failed due to one or more job failures",
 	})
+}
+
+func constructJobsFromTemplate(js *jobset.JobSet, rjob *jobset.ReplicatedJob, ownedJobs *childJobs) ([]*batchv1.Job, error) {
+	var jobs []*batchv1.Job
+	for jobIdx := 0; jobIdx < rjob.Replicas; jobIdx++ {
+		jobName := genJobName(js, rjob, jobIdx)
+		if create := shouldCreateJob(jobName, ownedJobs); !create {
+			continue
+		}
+		job, err := constructJob(js, rjob, jobIdx)
+		if err != nil {
+			return nil, err
+		}
+		jobs = append(jobs, job)
+	}
+	return jobs, nil
+}
+
+func constructJob(js *jobset.JobSet, rjob *jobset.ReplicatedJob, jobIdx int) (*batchv1.Job, error) {
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:      cloneMap(rjob.Template.Labels),
+			Annotations: cloneMap(rjob.Template.Annotations),
+			Name:        genJobName(js, rjob, jobIdx),
+			Namespace:   js.Namespace,
+		},
+		Spec: *rjob.Template.Spec.DeepCopy(),
+	}
+
+	// Add restart-attempt count label to the job, it should be equal to
+	// jobSet restarts to indicate is part of the current jobSet run.
+	job.Labels[jobset.RestartsKey] = strconv.Itoa(js.Status.Restarts)
+
+	// Add replica count as label to the job.
+	job.Labels[jobset.ReplicasKey] = strconv.Itoa(rjob.Replicas)
+
+	// Add job index as a label and annotation to the job.
+	job.Labels[jobset.JobIndexKey] = strconv.Itoa(jobIdx)
+	job.Annotations[jobset.JobIndexKey] = strconv.Itoa(jobIdx)
+
+	// Add replica count as label and annotation to the pod spec.
+	job.Spec.Template.Labels = cloneMap(job.Spec.Template.Labels)
+	job.Spec.Template.Annotations = cloneMap(job.Spec.Template.Annotations)
+	job.Spec.Template.Labels[jobset.ReplicasKey] = strconv.Itoa(rjob.Replicas)
+	job.Spec.Template.Annotations[jobset.ReplicasKey] = strconv.Itoa(rjob.Replicas)
+
+	// Add job index as a label and annotation to the pod template spec.
+	job.Spec.Template.Labels[jobset.JobIndexKey] = strconv.Itoa(jobIdx)
+	job.Spec.Template.Annotations[jobset.JobIndexKey] = strconv.Itoa(jobIdx)
+
+	// If enableDNSHostnames is set, update job spec to set subdomain as
+	// job name (a headless service with same name as job will be created later).
+	if dnsHostnamesEnabled(rjob) {
+		job.Spec.Template.Spec.Subdomain = job.Name
+	}
+
+	// If this job should be exclusive per topology, set the pod affinities/anti-affinities accordingly.
+	if rjob.Exclusive != nil {
+		setExclusiveAffinities(job, rjob.Exclusive.TopologyKey, rjob.Exclusive.NamespaceSelector)
+	}
+
+	return job, nil
 }
 
 // Appends pod affinity/anti-affinity terms to the job pod template spec,
@@ -495,6 +486,19 @@ func setExclusiveAffinities(job *batchv1.Job, topologyKey string, nsSelector *me
 			TopologyKey:       topologyKey,
 			NamespaceSelector: nsSelector,
 		})
+}
+
+func shouldCreateJob(jobName string, ownedJobs *childJobs) bool {
+	// Check if this job exists already.
+	// TODO: maybe we can use a job map here so we can do O(1) lookups
+	// to check if the job already exists, rather than a linear scan
+	// through all the jobs owned by the jobset.
+	for _, job := range concat(ownedJobs.active, ownedJobs.successful, ownedJobs.failed, ownedJobs.delete) {
+		if jobName == job.Name {
+			return false
+		}
+	}
+	return true
 }
 
 func isJobFinished(job *batchv1.Job) (bool, batchv1.JobConditionType) {

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -309,16 +309,16 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 					Obj()).Obj(),
 			ownedJobs: &childJobs{},
 			want: []*batchv1.Job{
-				makeJob(&expectedJobArgs{
+				makeJob(&makeJobArgs{
 					jobName:  "test-jobset-replicated-job-0",
 					ns:       ns,
 					replicas: 2,
-					jobIdx:   0}),
-				makeJob(&expectedJobArgs{
+					jobIdx:   0}).Obj(),
+				makeJob(&makeJobArgs{
 					jobName:  "test-jobset-replicated-job-1",
 					ns:       ns,
 					replicas: 2,
-					jobIdx:   1}),
+					jobIdx:   1}).Obj(),
 			},
 		},
 		{
@@ -334,11 +334,11 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 				},
 			},
 			want: []*batchv1.Job{
-				makeJob(&expectedJobArgs{
+				makeJob(&makeJobArgs{
 					jobName:  "test-jobset-replicated-job-1",
 					ns:       ns,
 					replicas: 2,
-					jobIdx:   1}),
+					jobIdx:   1}).Obj(),
 			},
 		},
 		{
@@ -354,11 +354,11 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 				},
 			},
 			want: []*batchv1.Job{
-				makeJob(&expectedJobArgs{
+				makeJob(&makeJobArgs{
 					jobName:  "test-jobset-replicated-job-1",
 					ns:       ns,
 					replicas: 2,
-					jobIdx:   1}),
+					jobIdx:   1}).Obj(),
 			},
 		},
 		{
@@ -374,11 +374,11 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 				},
 			},
 			want: []*batchv1.Job{
-				makeJob(&expectedJobArgs{
+				makeJob(&makeJobArgs{
 					jobName:  "test-jobset-replicated-job-1",
 					ns:       ns,
 					replicas: 2,
-					jobIdx:   1}),
+					jobIdx:   1}).Obj(),
 			},
 		},
 		{
@@ -394,11 +394,11 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 				},
 			},
 			want: []*batchv1.Job{
-				makeJob(&expectedJobArgs{
+				makeJob(&makeJobArgs{
 					jobName:  "test-jobset-replicated-job-1",
 					ns:       ns,
 					replicas: 2,
-					jobIdx:   1}),
+					jobIdx:   1}).Obj(),
 			},
 		},
 		{
@@ -415,24 +415,24 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 				Obj(),
 			ownedJobs: &childJobs{
 				active: []*batchv1.Job{
-					makeJob(&expectedJobArgs{
+					makeJob(&makeJobArgs{
 						jobName:  "test-jobset-replicated-job-B-0",
 						ns:       ns,
 						replicas: 2,
-						jobIdx:   0}),
+						jobIdx:   0}).Obj(),
 				},
 			},
 			want: []*batchv1.Job{
-				makeJob(&expectedJobArgs{
+				makeJob(&makeJobArgs{
 					jobName:  "test-jobset-replicated-job-A-0",
 					ns:       ns,
 					replicas: 1,
-					jobIdx:   0}),
-				makeJob(&expectedJobArgs{
+					jobIdx:   0}).Obj(),
+				makeJob(&makeJobArgs{
 					jobName:  "test-jobset-replicated-job-B-1",
 					ns:       ns,
 					replicas: 2,
-					jobIdx:   1}),
+					jobIdx:   1}).Obj(),
 			},
 		},
 		{
@@ -446,12 +446,46 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 				Obj(),
 			ownedJobs: &childJobs{},
 			want: []*batchv1.Job{
-				makeJob(&expectedJobArgs{
-					jobName:   "test-jobset-replicated-job-0",
-					ns:        ns,
-					replicas:  1,
-					exclusive: exclusive,
-					jobIdx:    0}),
+				makeJob(&makeJobArgs{
+					jobName:  "test-jobset-replicated-job-0",
+					ns:       ns,
+					replicas: 1,
+					jobIdx:   0}).Affinity(&corev1.Affinity{
+					PodAffinity: &corev1.PodAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+							{
+								LabelSelector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      jobset.JobNameKey,
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{"test-jobset-replicated-job-0"},
+									},
+								}},
+								TopologyKey:       exclusive.TopologyKey,
+								NamespaceSelector: exclusive.NamespaceSelector,
+							},
+						},
+					},
+					PodAntiAffinity: &corev1.PodAntiAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+							{
+								LabelSelector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      jobset.JobNameKey,
+										Operator: metav1.LabelSelectorOpExists,
+									},
+									{
+										Key:      jobset.JobNameKey,
+										Operator: metav1.LabelSelectorOpNotIn,
+										Values:   []string{"test-jobset-replicated-job-0"},
+									},
+								}},
+								TopologyKey:       exclusive.TopologyKey,
+								NamespaceSelector: exclusive.NamespaceSelector,
+							},
+						},
+					},
+				}).Obj(),
 			},
 		},
 		{
@@ -465,12 +499,11 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 				Obj(),
 			ownedJobs: &childJobs{},
 			want: []*batchv1.Job{
-				makeJob(&expectedJobArgs{
-					jobName:   "test-jobset-replicated-job-0",
-					ns:        ns,
-					replicas:  1,
-					subdomain: "test-jobset-replicated-job-0",
-					jobIdx:    0}),
+				makeJob(&makeJobArgs{
+					jobName:  "test-jobset-replicated-job-0",
+					ns:       ns,
+					replicas: 1,
+					jobIdx:   0}).Subdomain("test-jobset-replicated-job-0").Obj(),
 			},
 		},
 	}
@@ -494,17 +527,15 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 	}
 }
 
-type expectedJobArgs struct {
-	jobName   string
-	ns        string
-	subdomain string
-	replicas  int
-	jobIdx    int
-	restarts  int
-	exclusive *jobset.Exclusive
+type makeJobArgs struct {
+	jobName  string
+	ns       string
+	replicas int
+	jobIdx   int
+	restarts int
 }
 
-func makeJob(args *expectedJobArgs) *batchv1.Job {
+func makeJob(args *makeJobArgs) *testutils.JobWrapper {
 	jobWrapper := testutils.MakeJob(args.jobName, args.ns).
 		JobLabels(map[string]string{
 			jobset.ReplicasKey: strconv.Itoa(args.replicas),
@@ -522,48 +553,5 @@ func makeJob(args *expectedJobArgs) *batchv1.Job {
 			jobset.ReplicasKey: strconv.Itoa(args.replicas),
 			jobset.JobIndexKey: strconv.Itoa(args.jobIdx),
 		})
-
-	if args.subdomain != "" {
-		jobWrapper = jobWrapper.Subdomain(args.subdomain)
-	}
-
-	if args.exclusive != nil {
-		jobWrapper = jobWrapper.Affinity(&corev1.Affinity{
-			PodAffinity: &corev1.PodAffinity{
-				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-					{
-						LabelSelector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
-							{
-								Key:      jobset.JobNameKey,
-								Operator: metav1.LabelSelectorOpIn,
-								Values:   []string{args.jobName},
-							},
-						}},
-						TopologyKey:       args.exclusive.TopologyKey,
-						NamespaceSelector: args.exclusive.NamespaceSelector,
-					},
-				},
-			},
-			PodAntiAffinity: &corev1.PodAntiAffinity{
-				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-					{
-						LabelSelector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
-							{
-								Key:      jobset.JobNameKey,
-								Operator: metav1.LabelSelectorOpExists,
-							},
-							{
-								Key:      jobset.JobNameKey,
-								Operator: metav1.LabelSelectorOpNotIn,
-								Values:   []string{args.jobName},
-							},
-						}},
-						TopologyKey:       args.exclusive.TopologyKey,
-						NamespaceSelector: args.exclusive.NamespaceSelector,
-					},
-				},
-			},
-		})
-	}
-	return jobWrapper.Obj()
+	return jobWrapper
 }

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -291,7 +291,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			name: "no jobs created",
 			js: testutils.MakeJobSet(jobSetName, ns).
 				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job").
-					Job(testutils.MakeJobTemplate(jobName, ns).PodSpec(corev1.PodSpec{}).Obj()).
+					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
 					Replicas(1).
 					Obj()).Obj(),
 			ownedJobs: &childJobs{
@@ -304,7 +304,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			name: "all jobs created",
 			js: testutils.MakeJobSet(jobSetName, ns).
 				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job").
-					Job(testutils.MakeJobTemplate(jobName, ns).PodSpec(corev1.PodSpec{}).Obj()).
+					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
 					Replicas(2).
 					Obj()).Obj(),
 			ownedJobs: &childJobs{},
@@ -325,7 +325,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			name: "one job created, one job not created (already active)",
 			js: testutils.MakeJobSet(jobSetName, ns).
 				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job").
-					Job(testutils.MakeJobTemplate(jobName, ns).PodSpec(corev1.PodSpec{}).Obj()).
+					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
 					Replicas(2).
 					Obj()).Obj(),
 			ownedJobs: &childJobs{
@@ -345,7 +345,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			name: "one job created, one job not created (already succeeded)",
 			js: testutils.MakeJobSet(jobSetName, ns).
 				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job").
-					Job(testutils.MakeJobTemplate(jobName, ns).PodSpec(corev1.PodSpec{}).Obj()).
+					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
 					Replicas(2).
 					Obj()).Obj(),
 			ownedJobs: &childJobs{
@@ -365,7 +365,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			name: "one job created, one job not created (already failed)",
 			js: testutils.MakeJobSet(jobSetName, ns).
 				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job").
-					Job(testutils.MakeJobTemplate(jobName, ns).PodSpec(corev1.PodSpec{}).Obj()).
+					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
 					Replicas(2).
 					Obj()).Obj(),
 			ownedJobs: &childJobs{
@@ -385,7 +385,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			name: "one job created, one job not created (marked for deletion)",
 			js: testutils.MakeJobSet(jobSetName, ns).
 				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job").
-					Job(testutils.MakeJobTemplate(jobName, ns).PodSpec(corev1.PodSpec{}).Obj()).
+					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
 					Replicas(2).
 					Obj()).Obj(),
 			ownedJobs: &childJobs{
@@ -405,11 +405,11 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			name: "multiple replicated jobs",
 			js: testutils.MakeJobSet(jobSetName, ns).
 				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job-A").
-					Job(testutils.MakeJobTemplate(jobName, ns).PodSpec(corev1.PodSpec{}).Obj()).
+					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
 					Replicas(1).
 					Obj()).
 				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job-B").
-					Job(testutils.MakeJobTemplate(jobName, ns).PodSpec(corev1.PodSpec{}).Obj()).
+					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
 					Replicas(2).
 					Obj()).
 				Obj(),
@@ -439,7 +439,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			name: "exclusive affinities",
 			js: testutils.MakeJobSet(jobSetName, ns).
 				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job").
-					Job(testutils.MakeJobTemplate(jobName, ns).PodSpec(corev1.PodSpec{}).Obj()).
+					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
 					Replicas(1).
 					Exclusive(exclusive).
 					Obj()).
@@ -458,7 +458,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			name: "pod dns hostnames enabled",
 			js: testutils.MakeJobSet(jobSetName, ns).
 				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job").
-					Job(testutils.MakeJobTemplate(jobName, ns).PodSpec(corev1.PodSpec{}).Obj()).
+					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
 					Replicas(1).
 					EnableDNSHostnames(true).
 					Obj()).

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -291,7 +291,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			name: "no jobs created",
 			js: testutils.MakeJobSet(jobSetName, ns).
 				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job").
-					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
+					Job(testutils.MakeJobTemplate(jobName, ns).PodSpec(corev1.PodSpec{}).Obj()).
 					Replicas(1).
 					Obj()).Obj(),
 			ownedJobs: &childJobs{
@@ -304,7 +304,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			name: "all jobs created",
 			js: testutils.MakeJobSet(jobSetName, ns).
 				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job").
-					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
+					Job(testutils.MakeJobTemplate(jobName, ns).PodSpec(corev1.PodSpec{}).Obj()).
 					Replicas(2).
 					Obj()).Obj(),
 			ownedJobs: &childJobs{},
@@ -325,7 +325,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			name: "one job created, one job not created (already active)",
 			js: testutils.MakeJobSet(jobSetName, ns).
 				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job").
-					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
+					Job(testutils.MakeJobTemplate(jobName, ns).PodSpec(corev1.PodSpec{}).Obj()).
 					Replicas(2).
 					Obj()).Obj(),
 			ownedJobs: &childJobs{
@@ -345,7 +345,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			name: "one job created, one job not created (already succeeded)",
 			js: testutils.MakeJobSet(jobSetName, ns).
 				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job").
-					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
+					Job(testutils.MakeJobTemplate(jobName, ns).PodSpec(corev1.PodSpec{}).Obj()).
 					Replicas(2).
 					Obj()).Obj(),
 			ownedJobs: &childJobs{
@@ -365,7 +365,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			name: "one job created, one job not created (already failed)",
 			js: testutils.MakeJobSet(jobSetName, ns).
 				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job").
-					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
+					Job(testutils.MakeJobTemplate(jobName, ns).PodSpec(corev1.PodSpec{}).Obj()).
 					Replicas(2).
 					Obj()).Obj(),
 			ownedJobs: &childJobs{
@@ -385,7 +385,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			name: "one job created, one job not created (marked for deletion)",
 			js: testutils.MakeJobSet(jobSetName, ns).
 				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job").
-					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
+					Job(testutils.MakeJobTemplate(jobName, ns).PodSpec(corev1.PodSpec{}).Obj()).
 					Replicas(2).
 					Obj()).Obj(),
 			ownedJobs: &childJobs{
@@ -405,11 +405,11 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			name: "multiple replicated jobs",
 			js: testutils.MakeJobSet(jobSetName, ns).
 				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job-A").
-					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
+					Job(testutils.MakeJobTemplate(jobName, ns).PodSpec(corev1.PodSpec{}).Obj()).
 					Replicas(1).
 					Obj()).
 				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job-B").
-					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
+					Job(testutils.MakeJobTemplate(jobName, ns).PodSpec(corev1.PodSpec{}).Obj()).
 					Replicas(2).
 					Obj()).
 				Obj(),
@@ -439,7 +439,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			name: "exclusive affinities",
 			js: testutils.MakeJobSet(jobSetName, ns).
 				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job").
-					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
+					Job(testutils.MakeJobTemplate(jobName, ns).PodSpec(corev1.PodSpec{}).Obj()).
 					Replicas(1).
 					Exclusive(exclusive).
 					Obj()).
@@ -458,7 +458,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			name: "pod dns hostnames enabled",
 			js: testutils.MakeJobSet(jobSetName, ns).
 				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job").
-					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
+					Job(testutils.MakeJobTemplate(jobName, ns).PodSpec(corev1.PodSpec{}).Obj()).
 					Replicas(1).
 					EnableDNSHostnames(true).
 					Obj()).

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -42,8 +42,8 @@ func MakeJobSet(name, ns string) *JobSetWrapper {
 	}
 }
 
-// SetFailurePolicy sets the value of jobSet.spec.failurePolicy
-func (j *JobSetWrapper) SetFailurePolicy(policy *jobset.FailurePolicy) *JobSetWrapper {
+// FailurePolicy sets the value of jobSet.spec.failurePolicy
+func (j *JobSetWrapper) FailurePolicy(policy *jobset.FailurePolicy) *JobSetWrapper {
 	j.Spec.FailurePolicy = policy
 	return j
 }
@@ -53,8 +53,8 @@ func (j *JobSetWrapper) Obj() *jobset.JobSet {
 	return &j.JobSet
 }
 
-// AddReplicatedJob adds a single ReplicatedJob to the JobSet.
-func (j *JobSetWrapper) AddReplicatedJob(job jobset.ReplicatedJob) *JobSetWrapper {
+// ReplicatedJob adds a single ReplicatedJob to the JobSet.
+func (j *JobSetWrapper) ReplicatedJob(job jobset.ReplicatedJob) *JobSetWrapper {
 	j.JobSet.Spec.Jobs = append(j.JobSet.Spec.Jobs, job)
 	return j
 }
@@ -74,21 +74,27 @@ func MakeReplicatedJob(name string) *ReplicatedJobWrapper {
 	}
 }
 
-// SetJob sets the Job spec for the ReplicatedJob template.
-func (r *ReplicatedJobWrapper) SetJob(jobSpec batchv1.JobTemplateSpec) *ReplicatedJobWrapper {
+// Job sets the Job spec for the ReplicatedJob template.
+func (r *ReplicatedJobWrapper) Job(jobSpec batchv1.JobTemplateSpec) *ReplicatedJobWrapper {
 	r.Template = jobSpec
 	return r
 }
 
-// SetEnableDNSHostnames sets the value of ReplicatedJob.Network.EnableDNSHostnames.
-func (r *ReplicatedJobWrapper) SetEnableDNSHostnames(val bool) *ReplicatedJobWrapper {
+// EnableDNSHostnames sets the value of ReplicatedJob.Network.EnableDNSHostnames.
+func (r *ReplicatedJobWrapper) EnableDNSHostnames(val bool) *ReplicatedJobWrapper {
 	r.ReplicatedJob.Network.EnableDNSHostnames = pointer.Bool(val)
 	return r
 }
 
-// SetReplicas sets the value of the ReplicatedJob.Replicas.
-func (r *ReplicatedJobWrapper) SetReplicas(val int) *ReplicatedJobWrapper {
+// Replicas sets the value of the ReplicatedJob.Replicas.
+func (r *ReplicatedJobWrapper) Replicas(val int) *ReplicatedJobWrapper {
 	r.ReplicatedJob.Replicas = val
+	return r
+}
+
+// Exclusive sets the value of ReplicatedJob.Exclusive.
+func (r *ReplicatedJobWrapper) Exclusive(e *jobset.Exclusive) *ReplicatedJobWrapper {
+	r.ReplicatedJob.Exclusive = e
 	return r
 }
 
@@ -112,23 +118,15 @@ func MakeJobTemplate(name, ns string) *JobTemplateWrapper {
 			},
 			Spec: batchv1.JobSpec{
 				Template: corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						RestartPolicy: "Never",
-						Containers: []corev1.Container{
-							{
-								Name:  "test-container",
-								Image: "busybox:latest",
-							},
-						},
-					},
+					Spec: corev1.PodSpec{},
 				},
 			},
 		},
 	}
 }
 
-// SetCompletionMode sets the value of job.spec.completionMode
-func (j *JobTemplateWrapper) SetCompletionMode(mode batchv1.CompletionMode) *JobTemplateWrapper {
+// CompletionMode sets the value of job.spec.completionMode
+func (j *JobTemplateWrapper) CompletionMode(mode batchv1.CompletionMode) *JobTemplateWrapper {
 	j.Spec.CompletionMode = &mode
 	return j
 }
@@ -144,11 +142,12 @@ type JobWrapper struct {
 }
 
 // MakeJobWrapper creates a wrapper for a Job.
-func MakeJob(jobName string) *JobWrapper {
+func MakeJob(jobName, ns string) *JobWrapper {
 	return &JobWrapper{
 		batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: jobName,
+				Name:      jobName,
+				Namespace: ns,
 			},
 			Spec: batchv1.JobSpec{
 				Template: corev1.PodTemplateSpec{
@@ -159,9 +158,39 @@ func MakeJob(jobName string) *JobWrapper {
 	}
 }
 
-// SetAffinity sets the pod affinities/anti-affinities for the pod template spec.
-func (j *JobWrapper) SetAffinity(affinity *corev1.Affinity) *JobWrapper {
+// Affinity sets the pod affinities/anti-affinities for the pod template spec.
+func (j *JobWrapper) Affinity(affinity *corev1.Affinity) *JobWrapper {
 	j.Spec.Template.Spec.Affinity = affinity
+	return j
+}
+
+// JobLabels sets the Job labels.
+func (j *JobWrapper) JobLabels(labels map[string]string) *JobWrapper {
+	j.Labels = labels
+	return j
+}
+
+// JobAnnotations sets the Job annotations.
+func (j *JobWrapper) JobAnnotations(annotations map[string]string) *JobWrapper {
+	j.Annotations = annotations
+	return j
+}
+
+// PodLabels sets the pod template spec labels.
+func (j *JobWrapper) PodLabels(labels map[string]string) *JobWrapper {
+	j.Spec.Template.Labels = labels
+	return j
+}
+
+// PodAnnotations sets the pod template spec annotations.
+func (j *JobWrapper) PodAnnotations(annotations map[string]string) *JobWrapper {
+	j.Spec.Template.Annotations = annotations
+	return j
+}
+
+// Subdomain sets the pod template spec subdomain.
+func (j *JobWrapper) Subdomain(subdomain string) *JobWrapper {
+	j.Spec.Template.Spec.Subdomain = subdomain
 	return j
 }
 

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -118,7 +118,15 @@ func MakeJobTemplate(name, ns string) *JobTemplateWrapper {
 			},
 			Spec: batchv1.JobSpec{
 				Template: corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{},
+					Spec: corev1.PodSpec{
+						RestartPolicy: "Never",
+						Containers: []corev1.Container{
+							{
+								Name:  "test-container",
+								Image: "busybox:latest",
+							},
+						},
+					},
 				},
 			},
 		},
@@ -128,6 +136,12 @@ func MakeJobTemplate(name, ns string) *JobTemplateWrapper {
 // CompletionMode sets the value of job.spec.completionMode
 func (j *JobTemplateWrapper) CompletionMode(mode batchv1.CompletionMode) *JobTemplateWrapper {
 	j.Spec.CompletionMode = &mode
+	return j
+}
+
+// Containers sets the pod template spec containers.
+func (j *JobTemplateWrapper) PodSpec(podSpec corev1.PodSpec) *JobTemplateWrapper {
+	j.Spec.Template.Spec = podSpec
 	return j
 }
 

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -22,6 +22,17 @@ import (
 	jobset "sigs.k8s.io/jobset/api/v1alpha1"
 )
 
+// TestPodSpec is the default pod spec used for testing.
+var TestPodSpec = corev1.PodSpec{
+	RestartPolicy: "Never",
+	Containers: []corev1.Container{
+		{
+			Name:  "test-container",
+			Image: "busybox:latest",
+		},
+	},
+}
+
 // JobSetWrapper wraps a JobSet.
 type JobSetWrapper struct {
 	jobset.JobSet
@@ -118,15 +129,7 @@ func MakeJobTemplate(name, ns string) *JobTemplateWrapper {
 			},
 			Spec: batchv1.JobSpec{
 				Template: corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						RestartPolicy: "Never",
-						Containers: []corev1.Container{
-							{
-								Name:  "test-container",
-								Image: "busybox:latest",
-							},
-						},
-					},
+					Spec: corev1.PodSpec{},
 				},
 			},
 		},
@@ -199,6 +202,12 @@ func (j *JobWrapper) PodLabels(labels map[string]string) *JobWrapper {
 // PodAnnotations sets the pod template spec annotations.
 func (j *JobWrapper) PodAnnotations(annotations map[string]string) *JobWrapper {
 	j.Spec.Template.Annotations = annotations
+	return j
+}
+
+// PodSpec sets the pod template spec.
+func (j *JobWrapper) PodSpec(podSpec corev1.PodSpec) *JobWrapper {
+	j.Spec.Template.Spec = podSpec
 	return j
 }
 

--- a/test/integration/jobset_controller_test.go
+++ b/test/integration/jobset_controller_test.go
@@ -134,9 +134,9 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 		ginkgo.Entry("validate enableDNSHostnames can't be set if job is not Indexed", &testCase{
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
 				return testing.MakeJobSet("js-hostnames-non-indexed", ns.Name).
-					AddReplicatedJob(testing.MakeReplicatedJob("test-job").
-						SetJob(testing.MakeJobTemplate("test-job", ns.Name).Obj()).
-						SetEnableDNSHostnames(true).
+					ReplicatedJob(testing.MakeReplicatedJob("test-job").
+						Job(testing.MakeJobTemplate("test-job", ns.Name).Obj()).
+						EnableDNSHostnames(true).
 						Obj())
 			},
 			jobSetCreationShouldFail: true,
@@ -202,7 +202,7 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 		ginkgo.Entry("jobset fails after reaching max restarts", &testCase{
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
 				return testJobSet(ns).
-					SetFailurePolicy(&jobset.FailurePolicy{
+					FailurePolicy(&jobset.FailurePolicy{
 						Operator:      jobset.TerminationPolicyTargetAny,
 						RestartPolicy: jobset.RestartPolicyRecreateAll,
 						MaxRestarts:   1,
@@ -229,7 +229,7 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 		ginkgo.Entry("job succeeds after one failure", &testCase{
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
 				return testJobSet(ns).
-					SetFailurePolicy(&jobset.FailurePolicy{
+					FailurePolicy(&jobset.FailurePolicy{
 						Operator:      jobset.TerminationPolicyTargetAny,
 						RestartPolicy: jobset.RestartPolicyRecreateAll,
 						MaxRestarts:   1,
@@ -322,7 +322,7 @@ func checkJobsRecreated(js *jobset.JobSet, expectedRestarts int) (bool, error) {
 	}
 	// Check all the jobs restart counter has been incremented.
 	for _, job := range jobList.Items {
-		if job.Labels[jobset.RestartsLabel] != strconv.Itoa(expectedRestarts) {
+		if job.Labels[jobset.RestartsKey] != strconv.Itoa(expectedRestarts) {
 			return false, nil
 		}
 	}
@@ -353,13 +353,13 @@ func checkExpectedServices(js *jobset.JobSet) {
 // - one with 3 replicas and DNS hostnames enabled
 func testJobSet(ns *corev1.Namespace) *testing.JobSetWrapper {
 	return testing.MakeJobSet("js-succeed", ns.Name).
-		AddReplicatedJob(testing.MakeReplicatedJob("replicated-job-a").
-			SetJob(testing.MakeJobTemplate("test-job-A", ns.Name).Obj()).
-			SetReplicas(1).
+		ReplicatedJob(testing.MakeReplicatedJob("replicated-job-a").
+			Job(testing.MakeJobTemplate("test-job-A", ns.Name).Obj()).
+			Replicas(1).
 			Obj()).
-		AddReplicatedJob(testing.MakeReplicatedJob("replicated-job-b").
-			SetJob(testing.MakeJobTemplate("test-job-B", ns.Name).SetCompletionMode(batchv1.IndexedCompletion).Obj()).
-			SetEnableDNSHostnames(true).
-			SetReplicas(3).
+		ReplicatedJob(testing.MakeReplicatedJob("replicated-job-b").
+			Job(testing.MakeJobTemplate("test-job-B", ns.Name).CompletionMode(batchv1.IndexedCompletion).Obj()).
+			EnableDNSHostnames(true).
+			Replicas(3).
 			Obj())
 }

--- a/test/integration/jobset_controller_test.go
+++ b/test/integration/jobset_controller_test.go
@@ -354,11 +354,11 @@ func checkExpectedServices(js *jobset.JobSet) {
 func testJobSet(ns *corev1.Namespace) *testing.JobSetWrapper {
 	return testing.MakeJobSet("js-succeed", ns.Name).
 		ReplicatedJob(testing.MakeReplicatedJob("replicated-job-a").
-			Job(testing.MakeJobTemplate("test-job-A", ns.Name).Obj()).
+			Job(testing.MakeJobTemplate("test-job-A", ns.Name).PodSpec(testing.TestPodSpec).Obj()).
 			Replicas(1).
 			Obj()).
 		ReplicatedJob(testing.MakeReplicatedJob("replicated-job-b").
-			Job(testing.MakeJobTemplate("test-job-B", ns.Name).CompletionMode(batchv1.IndexedCompletion).Obj()).
+			Job(testing.MakeJobTemplate("test-job-B", ns.Name).PodSpec(testing.TestPodSpec).CompletionMode(batchv1.IndexedCompletion).Obj()).
 			EnableDNSHostnames(true).
 			Replicas(3).
 			Obj())


### PR DESCRIPTION
Fixes #35 
Fixes #30

- On every job created from a replicated job, add a label storing the total replica count.
- Add job index as a label and annotation to the pod template spec.
- Refactor `constructJobsFromTemplate` so it is more easily testable and add several unit tests for it.