### PR TITLE
One headless service per replicatedJob when pod DNS hostnames is enabled

### DIFF
--- a/api/v1alpha1/jobset_types.go
+++ b/api/v1alpha1/jobset_types.go
@@ -99,7 +99,7 @@ type ReplicatedJob struct {
 type Network struct {
 	// EnableDNSHostnames allows pods to be reached via their hostnames.
 	// Pods will be reachable using the fully qualified pod hostname, which is in the format:
-	// <jobSet.name>-<spec.replicatedJob.name>-<job-index>-<pod-index>.<jobSet.name>-<spec.replicatedJob.name>-<job-index>
+	// <jobSet.name>-<spec.replicatedJob.name>-<job-index>-<pod-index>.<jobSet.name>-<spec.replicatedJob.name>
 	// +optional
 	EnableDNSHostnames *bool `json:"enableDNSHostnames,omitempty"`
 }

--- a/config/crd/bases/batch.x-k8s.io_jobsets.yaml
+++ b/config/crd/bases/batch.x-k8s.io_jobsets.yaml
@@ -129,7 +129,7 @@ spec:
                           description: 'EnableDNSHostnames allows pods to be reached
                             via their hostnames. Pods will be reachable using the
                             fully qualified pod hostname, which is in the format:
-                            <jobSet.name>-<spec.replicatedJob.name>-<job-index>-<pod-index>.<jobSet.name>-<spec.replicatedJob.name>-<job-index>'
+                            <jobSet.name>-<spec.replicatedJob.name>-<job-index>-<pod-index>.<jobSet.name>-<spec.replicatedJob.name>'
                           type: boolean
                       type: object
                     replicas:

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -503,7 +503,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 					jobName:  "test-jobset-replicated-job-0",
 					ns:       ns,
 					replicas: 1,
-					jobIdx:   0}).Subdomain("test-jobset-replicated-job-0").Obj(),
+					jobIdx:   0}).Subdomain("test-jobset-replicated-job").Obj(),
 			},
 		},
 	}

--- a/test/integration/jobset_controller_test.go
+++ b/test/integration/jobset_controller_test.go
@@ -277,13 +277,14 @@ func numExpectedJobs(js *jobset.JobSet) int {
 }
 
 func numExpectedServices(js *jobset.JobSet) int {
-	expectedJobs := 0
+	// Expect 1 headless service per replicatedJob.
+	expected := 0
 	for _, rjob := range js.Spec.Jobs {
 		if rjob.Network != nil && rjob.Network.EnableDNSHostnames != nil && *rjob.Network.EnableDNSHostnames {
-			expectedJobs += rjob.Replicas
+			expected += 1
 		}
 	}
-	return expectedJobs
+	return expected
 }
 
 func completeAllJobs(jobList *batchv1.JobList) {
@@ -352,7 +353,7 @@ func checkExpectedServices(js *jobset.JobSet) {
 // - one with 1 replica
 // - one with 3 replicas and DNS hostnames enabled
 func testJobSet(ns *corev1.Namespace) *testing.JobSetWrapper {
-	return testing.MakeJobSet("js-succeed", ns.Name).
+	return testing.MakeJobSet("test-js", ns.Name).
 		ReplicatedJob(testing.MakeReplicatedJob("replicated-job-a").
 			Job(testing.MakeJobTemplate("test-job-A", ns.Name).PodSpec(testing.TestPodSpec).Obj()).
 			Replicas(1).


### PR DESCRIPTION
Fixes #32 