### PR TITLE
Use jobset and replicated job names as selectors for headless svc

### DIFF
--- a/api/v1alpha1/jobset_types.go
+++ b/api/v1alpha1/jobset_types.go
@@ -19,10 +19,12 @@ import (
 )
 
 const (
-	JobIndexKey string = "jobset.sigs.k8s.io/job-index"
-	ReplicasKey string = "jobset.sigs.k8s.io/job-replicas"
-	RestartsKey string = "jobset.sigs.k8s.io/restart-attempt"
-	JobNameKey  string = "job-name" // TODO(#26): Migrate to the fully qualified label name.
+	JobSetKey        string = "jobset.sigs.k8s.io/jobset"
+	JobIndexKey      string = "jobset.sigs.k8s.io/job-index"
+	ReplicasKey      string = "jobset.sigs.k8s.io/job-replicas"
+	RestartsKey      string = "jobset.sigs.k8s.io/restart-attempt"
+	ReplicatedJobKey string = "jobset.sigs.k8s.io/replicated-job"
+	JobNameKey       string = "job-name" // TODO(#26): Migrate to the fully qualified label name.
 )
 
 type JobSetConditionType string

--- a/api/v1alpha1/jobset_types.go
+++ b/api/v1alpha1/jobset_types.go
@@ -19,11 +19,11 @@ import (
 )
 
 const (
-	JobSetKey        string = "jobset.sigs.k8s.io/jobset"
+	JobSetKey        string = "jobset.sigs.k8s.io/jobset-name"
 	JobIndexKey      string = "jobset.sigs.k8s.io/job-index"
-	ReplicasKey      string = "jobset.sigs.k8s.io/job-replicas"
+	ReplicasKey      string = "jobset.sigs.k8s.io/replicatedjob-replicas"
 	RestartsKey      string = "jobset.sigs.k8s.io/restart-attempt"
-	ReplicatedJobKey string = "jobset.sigs.k8s.io/replicated-job"
+	ReplicatedJobKey string = "jobset.sigs.k8s.io/replicatedjob-name"
 	JobNameKey       string = "job-name" // TODO(#26): Migrate to the fully qualified label name.
 )
 

--- a/api/v1alpha1/jobset_types.go
+++ b/api/v1alpha1/jobset_types.go
@@ -19,12 +19,11 @@ import (
 )
 
 const (
-	JobSetKey        string = "jobset.sigs.k8s.io/jobset-name"
-	JobIndexKey      string = "jobset.sigs.k8s.io/job-index"
-	ReplicasKey      string = "jobset.sigs.k8s.io/replicatedjob-replicas"
-	RestartsKey      string = "jobset.sigs.k8s.io/restart-attempt"
-	ReplicatedJobKey string = "jobset.sigs.k8s.io/replicatedjob-name"
-	JobNameKey       string = "job-name" // TODO(#26): Migrate to the fully qualified label name.
+	JobSetNameKey         string = "jobset.sigs.k8s.io/jobset-name"
+	ReplicatedJobReplicas string = "jobset.sigs.k8s.io/replicatedjob-replicas"
+	ReplicatedJobNameKey  string = "jobset.sigs.k8s.io/replicatedjob-name"
+	JobIndexKey           string = "jobset.sigs.k8s.io/job-index"
+	JobNameKey            string = "job-name" // TODO(#26): Migrate to the fully qualified label name.
 )
 
 type JobSetConditionType string

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -239,10 +239,11 @@ func (r *JobSetReconciler) createHeadlessSvcIfNotExist(ctx context.Context, js *
 	// Check if service already exists. Service name is <jobSetName>-<replicatedJobName>.
 	// If the service does not exist, create it.
 	var headlessSvc corev1.Service
-	if err := r.Get(ctx, types.NamespacedName{Name: genSubdomain(js, rjob), Namespace: js.Namespace}, &headlessSvc); err != nil {
+	subdomain := genSubdomain(js, rjob)
+	if err := r.Get(ctx, types.NamespacedName{Name: subdomain, Namespace: js.Namespace}, &headlessSvc); err != nil {
 		headlessSvc := corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      genSubdomain(js, rjob),
+				Name:      subdomain,
 				Namespace: js.Namespace,
 			},
 			Spec: corev1.ServiceSpec{

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -570,6 +570,7 @@ func makeJob(args *makeJobArgs) *testutils.JobWrapper {
 			jobset.RestartsKey:      strconv.Itoa(args.restarts),
 		}).
 		JobAnnotations(map[string]string{
+			jobset.ReplicasKey: strconv.Itoa(args.replicas),
 			jobset.JobIndexKey: strconv.Itoa(args.jobIdx),
 		}).
 		PodLabels(map[string]string{
@@ -577,6 +578,7 @@ func makeJob(args *makeJobArgs) *testutils.JobWrapper {
 			jobset.ReplicatedJobKey: args.replicatedJobName,
 			jobset.ReplicasKey:      strconv.Itoa(args.replicas),
 			jobset.JobIndexKey:      strconv.Itoa(args.jobIdx),
+			jobset.RestartsKey:      strconv.Itoa(args.restarts),
 		}).
 		PodAnnotations(map[string]string{
 			jobset.ReplicasKey: strconv.Itoa(args.replicas),

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -563,26 +563,26 @@ type makeJobArgs struct {
 func makeJob(args *makeJobArgs) *testutils.JobWrapper {
 	jobWrapper := testutils.MakeJob(args.jobName, args.ns).
 		JobLabels(map[string]string{
-			jobset.JobSetKey:        args.jobSetName,
-			jobset.ReplicatedJobKey: args.replicatedJobName,
-			jobset.ReplicasKey:      strconv.Itoa(args.replicas),
-			jobset.JobIndexKey:      strconv.Itoa(args.jobIdx),
-			jobset.RestartsKey:      strconv.Itoa(args.restarts),
+			jobset.JobSetNameKey:         args.jobSetName,
+			jobset.ReplicatedJobNameKey:  args.replicatedJobName,
+			jobset.ReplicatedJobReplicas: strconv.Itoa(args.replicas),
+			jobset.JobIndexKey:           strconv.Itoa(args.jobIdx),
+			RestartsKey:                  strconv.Itoa(args.restarts),
 		}).
 		JobAnnotations(map[string]string{
-			jobset.ReplicasKey: strconv.Itoa(args.replicas),
-			jobset.JobIndexKey: strconv.Itoa(args.jobIdx),
+			jobset.ReplicatedJobReplicas: strconv.Itoa(args.replicas),
+			jobset.JobIndexKey:           strconv.Itoa(args.jobIdx),
 		}).
 		PodLabels(map[string]string{
-			jobset.JobSetKey:        args.jobSetName,
-			jobset.ReplicatedJobKey: args.replicatedJobName,
-			jobset.ReplicasKey:      strconv.Itoa(args.replicas),
-			jobset.JobIndexKey:      strconv.Itoa(args.jobIdx),
-			jobset.RestartsKey:      strconv.Itoa(args.restarts),
+			jobset.JobSetNameKey:         args.jobSetName,
+			jobset.ReplicatedJobNameKey:  args.replicatedJobName,
+			jobset.ReplicatedJobReplicas: strconv.Itoa(args.replicas),
+			jobset.JobIndexKey:           strconv.Itoa(args.jobIdx),
+			RestartsKey:                  strconv.Itoa(args.restarts),
 		}).
 		PodAnnotations(map[string]string{
-			jobset.ReplicasKey: strconv.Itoa(args.replicas),
-			jobset.JobIndexKey: strconv.Itoa(args.jobIdx),
+			jobset.ReplicatedJobReplicas: strconv.Itoa(args.replicas),
+			jobset.JobIndexKey:           strconv.Itoa(args.jobIdx),
 		})
 	return jobWrapper
 }

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -268,10 +268,11 @@ func TestSetExclusiveAffinities(t *testing.T) {
 
 func TestConstructJobsFromTemplate(t *testing.T) {
 	var (
-		jobSetName = "test-jobset"
-		jobName    = "test-job"
-		ns         = "default"
-		exclusive  = &jobset.Exclusive{
+		jobSetName        = "test-jobset"
+		replicatedJobName = "replicated-job"
+		jobName           = "test-job"
+		ns                = "default"
+		exclusive         = &jobset.Exclusive{
 			TopologyKey: "test-topology-key",
 			NamespaceSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
@@ -290,7 +291,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 		{
 			name: "no jobs created",
 			js: testutils.MakeJobSet(jobSetName, ns).
-				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job").
+				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName).
 					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
 					Replicas(1).
 					Obj()).Obj(),
@@ -303,28 +304,32 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 		{
 			name: "all jobs created",
 			js: testutils.MakeJobSet(jobSetName, ns).
-				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job").
+				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName).
 					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
 					Replicas(2).
 					Obj()).Obj(),
 			ownedJobs: &childJobs{},
 			want: []*batchv1.Job{
 				makeJob(&makeJobArgs{
-					jobName:  "test-jobset-replicated-job-0",
-					ns:       ns,
-					replicas: 2,
-					jobIdx:   0}).Obj(),
+					jobSetName:        jobSetName,
+					replicatedJobName: replicatedJobName,
+					jobName:           "test-jobset-replicated-job-0",
+					ns:                ns,
+					replicas:          2,
+					jobIdx:            0}).Obj(),
 				makeJob(&makeJobArgs{
-					jobName:  "test-jobset-replicated-job-1",
-					ns:       ns,
-					replicas: 2,
-					jobIdx:   1}).Obj(),
+					jobSetName:        jobSetName,
+					replicatedJobName: replicatedJobName,
+					jobName:           "test-jobset-replicated-job-1",
+					ns:                ns,
+					replicas:          2,
+					jobIdx:            1}).Obj(),
 			},
 		},
 		{
 			name: "one job created, one job not created (already active)",
 			js: testutils.MakeJobSet(jobSetName, ns).
-				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job").
+				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName).
 					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
 					Replicas(2).
 					Obj()).Obj(),
@@ -335,16 +340,18 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			},
 			want: []*batchv1.Job{
 				makeJob(&makeJobArgs{
-					jobName:  "test-jobset-replicated-job-1",
-					ns:       ns,
-					replicas: 2,
-					jobIdx:   1}).Obj(),
+					jobSetName:        jobSetName,
+					replicatedJobName: replicatedJobName,
+					jobName:           "test-jobset-replicated-job-1",
+					ns:                ns,
+					replicas:          2,
+					jobIdx:            1}).Obj(),
 			},
 		},
 		{
 			name: "one job created, one job not created (already succeeded)",
 			js: testutils.MakeJobSet(jobSetName, ns).
-				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job").
+				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName).
 					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
 					Replicas(2).
 					Obj()).Obj(),
@@ -355,16 +362,18 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			},
 			want: []*batchv1.Job{
 				makeJob(&makeJobArgs{
-					jobName:  "test-jobset-replicated-job-1",
-					ns:       ns,
-					replicas: 2,
-					jobIdx:   1}).Obj(),
+					jobSetName:        jobSetName,
+					replicatedJobName: replicatedJobName,
+					jobName:           "test-jobset-replicated-job-1",
+					ns:                ns,
+					replicas:          2,
+					jobIdx:            1}).Obj(),
 			},
 		},
 		{
 			name: "one job created, one job not created (already failed)",
 			js: testutils.MakeJobSet(jobSetName, ns).
-				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job").
+				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName).
 					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
 					Replicas(2).
 					Obj()).Obj(),
@@ -375,16 +384,18 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			},
 			want: []*batchv1.Job{
 				makeJob(&makeJobArgs{
-					jobName:  "test-jobset-replicated-job-1",
-					ns:       ns,
-					replicas: 2,
-					jobIdx:   1}).Obj(),
+					jobSetName:        jobSetName,
+					replicatedJobName: replicatedJobName,
+					jobName:           "test-jobset-replicated-job-1",
+					ns:                ns,
+					replicas:          2,
+					jobIdx:            1}).Obj(),
 			},
 		},
 		{
 			name: "one job created, one job not created (marked for deletion)",
 			js: testutils.MakeJobSet(jobSetName, ns).
-				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job").
+				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName).
 					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
 					Replicas(2).
 					Obj()).Obj(),
@@ -395,10 +406,12 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			},
 			want: []*batchv1.Job{
 				makeJob(&makeJobArgs{
-					jobName:  "test-jobset-replicated-job-1",
-					ns:       ns,
-					replicas: 2,
-					jobIdx:   1}).Obj(),
+					jobSetName:        jobSetName,
+					replicatedJobName: replicatedJobName,
+					jobName:           "test-jobset-replicated-job-1",
+					ns:                ns,
+					replicas:          2,
+					jobIdx:            1}).Obj(),
 			},
 		},
 		{
@@ -416,29 +429,35 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			ownedJobs: &childJobs{
 				active: []*batchv1.Job{
 					makeJob(&makeJobArgs{
-						jobName:  "test-jobset-replicated-job-B-0",
-						ns:       ns,
-						replicas: 2,
-						jobIdx:   0}).Obj(),
+						jobSetName:        jobSetName,
+						replicatedJobName: "replicated-job-B",
+						jobName:           "test-jobset-replicated-job-B-0",
+						ns:                ns,
+						replicas:          2,
+						jobIdx:            0}).Obj(),
 				},
 			},
 			want: []*batchv1.Job{
 				makeJob(&makeJobArgs{
-					jobName:  "test-jobset-replicated-job-A-0",
-					ns:       ns,
-					replicas: 1,
-					jobIdx:   0}).Obj(),
+					jobSetName:        jobSetName,
+					replicatedJobName: "replicated-job-A",
+					jobName:           "test-jobset-replicated-job-A-0",
+					ns:                ns,
+					replicas:          1,
+					jobIdx:            0}).Obj(),
 				makeJob(&makeJobArgs{
-					jobName:  "test-jobset-replicated-job-B-1",
-					ns:       ns,
-					replicas: 2,
-					jobIdx:   1}).Obj(),
+					jobSetName:        jobSetName,
+					replicatedJobName: "replicated-job-B",
+					jobName:           "test-jobset-replicated-job-B-1",
+					ns:                ns,
+					replicas:          2,
+					jobIdx:            1}).Obj(),
 			},
 		},
 		{
 			name: "exclusive affinities",
 			js: testutils.MakeJobSet(jobSetName, ns).
-				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job").
+				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName).
 					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
 					Replicas(1).
 					Exclusive(exclusive).
@@ -447,10 +466,12 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			ownedJobs: &childJobs{},
 			want: []*batchv1.Job{
 				makeJob(&makeJobArgs{
-					jobName:  "test-jobset-replicated-job-0",
-					ns:       ns,
-					replicas: 1,
-					jobIdx:   0}).Affinity(&corev1.Affinity{
+					jobSetName:        jobSetName,
+					replicatedJobName: replicatedJobName,
+					jobName:           "test-jobset-replicated-job-0",
+					ns:                ns,
+					replicas:          1,
+					jobIdx:            0}).Affinity(&corev1.Affinity{
 					PodAffinity: &corev1.PodAffinity{
 						RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 							{
@@ -491,7 +512,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 		{
 			name: "pod dns hostnames enabled",
 			js: testutils.MakeJobSet(jobSetName, ns).
-				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job").
+				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName).
 					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
 					Replicas(1).
 					EnableDNSHostnames(true).
@@ -500,10 +521,12 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			ownedJobs: &childJobs{},
 			want: []*batchv1.Job{
 				makeJob(&makeJobArgs{
-					jobName:  "test-jobset-replicated-job-0",
-					ns:       ns,
-					replicas: 1,
-					jobIdx:   0}).Subdomain("test-jobset-replicated-job").Obj(),
+					jobSetName:        jobSetName,
+					replicatedJobName: replicatedJobName,
+					jobName:           "test-jobset-replicated-job-0",
+					ns:                ns,
+					replicas:          1,
+					jobIdx:            0}).Subdomain("test-jobset-replicated-job").Obj(),
 			},
 		},
 	}
@@ -528,26 +551,32 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 }
 
 type makeJobArgs struct {
-	jobName  string
-	ns       string
-	replicas int
-	jobIdx   int
-	restarts int
+	jobSetName        string
+	replicatedJobName string
+	jobName           string
+	ns                string
+	replicas          int
+	jobIdx            int
+	restarts          int
 }
 
 func makeJob(args *makeJobArgs) *testutils.JobWrapper {
 	jobWrapper := testutils.MakeJob(args.jobName, args.ns).
 		JobLabels(map[string]string{
-			jobset.ReplicasKey: strconv.Itoa(args.replicas),
-			jobset.JobIndexKey: strconv.Itoa(args.jobIdx),
-			jobset.RestartsKey: strconv.Itoa(args.restarts),
+			jobset.JobSetKey:        args.jobSetName,
+			jobset.ReplicatedJobKey: args.replicatedJobName,
+			jobset.ReplicasKey:      strconv.Itoa(args.replicas),
+			jobset.JobIndexKey:      strconv.Itoa(args.jobIdx),
+			jobset.RestartsKey:      strconv.Itoa(args.restarts),
 		}).
 		JobAnnotations(map[string]string{
 			jobset.JobIndexKey: strconv.Itoa(args.jobIdx),
 		}).
 		PodLabels(map[string]string{
-			jobset.ReplicasKey: strconv.Itoa(args.replicas),
-			jobset.JobIndexKey: strconv.Itoa(args.jobIdx),
+			jobset.JobSetKey:        args.jobSetName,
+			jobset.ReplicatedJobKey: args.replicatedJobName,
+			jobset.ReplicasKey:      strconv.Itoa(args.replicas),
+			jobset.JobIndexKey:      strconv.Itoa(args.jobIdx),
 		}).
 		PodAnnotations(map[string]string{
 			jobset.ReplicasKey: strconv.Itoa(args.replicas),

--- a/test/integration/jobset_controller_test.go
+++ b/test/integration/jobset_controller_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	jobset "sigs.k8s.io/jobset/api/v1alpha1"
+	"sigs.k8s.io/jobset/pkg/controllers"
 	"sigs.k8s.io/jobset/pkg/util/testing"
 )
 
@@ -323,7 +324,7 @@ func checkJobsRecreated(js *jobset.JobSet, expectedRestarts int) (bool, error) {
 	}
 	// Check all the jobs restart counter has been incremented.
 	for _, job := range jobList.Items {
-		if job.Labels[jobset.RestartsKey] != strconv.Itoa(expectedRestarts) {
+		if job.Labels[controllers.RestartsKey] != strconv.Itoa(expectedRestarts) {
 			return false, nil
 		}
 	}


### PR DESCRIPTION
During manual testing with a distributed pytorch training workload I discovered a bug (pods could not reach each other over the network via hostnames). Upon investigation I realize the generated subdomain name assigned to pods and name of the headless service selecting those pods did not match. 

In addition, in order for this headless service to select pods from all jobs within a replicated job (as was the goal of #42) we need to update the service's label selectors to use jobset name and replicated job name labels, rather than just a single `job-name` label.