### PR TITLE
Update image-build cmd and installation instructions to reduce build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,6 @@ image-local-push: image-local-build
 .PHONY: image-build
 image-build:
 	$(IMAGE_BUILD_CMD) -t $(IMAGE_TAG) \
-		--platform=$(PLATFORMS) \
 		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
 		--build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) \
 		$(PUSH) \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To install the CRD and deploy the controller on the cluster selected on your `~/
 ```
 git clone https://github.com/kubernetes-sigs/jobset.git
 cd jobset
-IMAGE_REGISTRY=<registry>/<project> make image-local-push deploy
+IMAGE_REGISTRY=<registry>/<project> make image-push deploy
 ```
 
 ## Community, discussion, contribution, and support


### PR DESCRIPTION
The default installation instructions should use the standard `image-push` which targets only amd64, instead of `image-local-push` which targets amd64 and cross-compiles for arm64 using `docker buildx`, which takes way too long (anywhere from 10min to 1hour+ in experiments) and is not necessary for most users.

Tested this manually and the build step took 52 seconds instead of 10min.