### PR TITLE
Add e2e test

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,7 +12,7 @@ namePrefix: jobset-
 #commonLabels:
 #  someName: someValue
 
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,4 +7,3 @@ images:
 - name: controller
   newName: gcr.io/k8s-staging-jobset/jobset
   newTag: main
-

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -1,0 +1,30 @@
+export KUSTOMIZE=$PWD/bin/kustomize
+export GINKGO=$PWD/bin/ginkgo
+export KIND=$PWD/bin/kind
+function cleanup {
+    if [ $USE_EXISTING_CLUSTER == 'false' ] 
+    then 
+        $KIND delete cluster --name $KIND_CLUSTER_NAME
+    fi
+    (cd config/manager && $KUSTOMIZE edit set image controller=gcr.io/k8s-staging-jobset/jobset:main)
+}
+function startup {
+    if [ $USE_EXISTING_CLUSTER == 'false' ] 
+    then 
+        $KIND create cluster --name $KIND_CLUSTER_NAME --image $E2E_KIND_VERSION
+    fi
+}
+function kind_load {
+    $KIND load docker-image $IMAGE_TAG --name $KIND_CLUSTER_NAME
+}
+function jobset_deploy {
+    echo "cd config/manager && $KUSTOMIZE edit set image controller=$IMAGE_TAG"
+    (cd config/manager && $KUSTOMIZE edit set image controller=$IMAGE_TAG)
+    echo "$KUSTOMIZE build test/e2e/config | kubectl apply --server-side -f -" 
+    $KUSTOMIZE build test/e2e/config | kubectl apply --server-side -f -
+}
+trap cleanup EXIT
+startup
+kind_load
+jobset_deploy
+$GINKGO -v ./test/e2e/...

--- a/test/e2e/config/image_pull_policy.yaml
+++ b/test/e2e/config/image_pull_policy.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        imagePullPolicy: IfNotPresent

--- a/test/e2e/config/kustomization.yaml
+++ b/test/e2e/config/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../../config/default
+
+patchesStrategicMerge:
+- image_pull_policy.yaml

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	jobset "sigs.k8s.io/jobset/api/v1alpha1"
+	testutils "sigs.k8s.io/jobset/pkg/util/testing"
+	//+kubebuilder:scaffold:imports
+)
+
+const (
+	timeout  = 1 * time.Minute
+	interval = time.Millisecond * 250
+)
+
+var (
+	k8sClient client.Client
+	ctx       context.Context
+)
+
+func TestAPIs(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t,
+		"End To End Suite",
+	)
+}
+
+var _ = ginkgo.BeforeSuite(func() {
+	ctx = context.Background()
+	cfg := config.GetConfigOrDie()
+	gomega.ExpectWithOffset(1, cfg).NotTo(gomega.BeNil())
+
+	err := jobset.AddToScheme(scheme.Scheme)
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(k8sClient).NotTo(gomega.BeNil())
+
+	JobSetReadyForTesting(k8sClient)
+})
+
+func JobSetReadyForTesting(client client.Client) {
+	ginkgo.By("waiting for ")
+	// To verify that webhooks are ready, let's create a simple jobset.
+	js := testutils.MakeJobSet("js", "default").
+		ReplicatedJob(testutils.MakeReplicatedJob("rjob").
+			Job(testutils.MakeJobTemplate("job", "default").
+				PodSpec(testutils.TestPodSpec).Obj()).
+			Obj()).Obj()
+
+	// Once the creation succeeds, that means the webhooks are ready
+	// and we can begin testing.
+	gomega.Eventually(func() error {
+		return client.Create(context.Background(), js)
+	}, timeout, interval).Should(gomega.Succeed())
+
+	// Delete this jobset before beginning tests.
+	gomega.Expect(client.Delete(ctx, js))
+	gomega.Eventually(func() error {
+		return client.Get(ctx, types.NamespacedName{Name: js.Name, Namespace: js.Namespace}, &jobset.JobSet{})
+	}).ShouldNot(gomega.Succeed())
+}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	jobset "sigs.k8s.io/jobset/api/v1alpha1"
+)
+
+func CheckJobSetStatus(ctx context.Context, k8sClient client.Client, js *jobset.JobSet, condition jobset.JobSetConditionType) (bool, error) {
+	var fetchedJS jobset.JobSet
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: js.Namespace, Name: js.Name}, &fetchedJS); err != nil {
+		return false, err
+	}
+	for _, c := range fetchedJS.Status.Conditions {
+		if c.Type == string(condition) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func NumExpectedJobs(js *jobset.JobSet) int {
+	expectedJobs := 0
+	for _, rjob := range js.Spec.ReplicatedJobs {
+		expectedJobs += rjob.Replicas
+	}
+	return expectedJobs
+}
+
+func CheckNumJobs(ctx context.Context, k8sClient client.Client, js *jobset.JobSet) (int, error) {
+	var jobList batchv1.JobList
+	if err := k8sClient.List(ctx, &jobList, client.InNamespace(js.Namespace)); err != nil {
+		return -1, err
+	}
+	return len(jobList.Items), nil
+}


### PR DESCRIPTION
Part of #46 

Currently only 1 test case:
- Create JobSet with DNS hostnames enabled and ensure pods can reach each other via pod hostnames

Reviewer Notes:
- For some reason, after the Kind cluster has been created, it takes a long time for the CRD to be installed, JobSet controller manager pods to become ready (~30 seconds), etc. so I had to add a sleep after the `jobset_deploy` function in `./hack/e2e-test.sh`, otherwise the resources required for the e2e test were not ready yet.
- The bash script I wrote to wait until it can successfully ping all pods by hostnames seems to take ~30 seconds before pings are successful, so I set the e2e test timeout as 60 seconds. However, I find this strange since all pods are supposedly in a running state, so not sure what is causing the delay before pings work.