### PR TITLE
Enable dns hostnames by default if job template uses indexed completion mode

### DIFF
--- a/api/v1alpha1/jobset_webhook.go
+++ b/api/v1alpha1/jobset_webhook.go
@@ -39,11 +39,11 @@ func (r *JobSet) Default() {
 		if r.Spec.ReplicatedJobs[i].Template.Spec.CompletionMode == nil {
 			r.Spec.ReplicatedJobs[i].Template.Spec.CompletionMode = completionModePtr(batchv1.IndexedCompletion)
 		}
-		// Enable DNS hostnames by default if job template uses indexed completion mode.
+		// Enable DNS hostnames by default.
 		if r.Spec.ReplicatedJobs[i].Network == nil {
 			r.Spec.ReplicatedJobs[i].Network = &Network{}
 		}
-		if r.Spec.ReplicatedJobs[i].Network.EnableDNSHostnames == nil && *r.Spec.ReplicatedJobs[i].Template.Spec.CompletionMode == batchv1.IndexedCompletion {
+		if r.Spec.ReplicatedJobs[i].Network.EnableDNSHostnames == nil {
 			r.Spec.ReplicatedJobs[i].Network.EnableDNSHostnames = pointer.Bool(true)
 		}
 	}

--- a/api/v1alpha1/jobset_webhook_test.go
+++ b/api/v1alpha1/jobset_webhook_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/utils/pointer"
 )
 
 func TestJobSetDefaulting(t *testing.T) {
@@ -22,6 +23,7 @@ func TestJobSetDefaulting(t *testing.T) {
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{},
 							},
+							Network: &Network{EnableDNSHostnames: pointer.Bool(true)},
 						},
 					},
 				},
@@ -35,6 +37,7 @@ func TestJobSetDefaulting(t *testing.T) {
 									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
 								},
 							},
+							Network: &Network{EnableDNSHostnames: pointer.Bool(true)},
 						},
 					},
 				},
@@ -51,6 +54,7 @@ func TestJobSetDefaulting(t *testing.T) {
 									CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
 								},
 							},
+							Network: &Network{EnableDNSHostnames: pointer.Bool(true)},
 						},
 					},
 				},
@@ -64,6 +68,37 @@ func TestJobSetDefaulting(t *testing.T) {
 									CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
 								},
 							},
+							Network: &Network{EnableDNSHostnames: pointer.Bool(true)},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "enableDNSHostnames is unset",
+			js: &JobSet{
+				Spec: JobSetSpec{
+					ReplicatedJobs: []ReplicatedJob{
+						{
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &JobSet{
+				Spec: JobSetSpec{
+					ReplicatedJobs: []ReplicatedJob{
+						{
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+								},
+							},
+							Network: &Network{EnableDNSHostnames: pointer.Bool(true)},
 						},
 					},
 				},

--- a/api/v1alpha1/jobset_webhook_test.go
+++ b/api/v1alpha1/jobset_webhook_test.go
@@ -112,7 +112,7 @@ func TestJobSetDefaulting(t *testing.T) {
 						{
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
-									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+									CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
 								},
 							},
 							Network: &Network{EnableDNSHostnames: pointer.Bool(false)},
@@ -126,7 +126,7 @@ func TestJobSetDefaulting(t *testing.T) {
 						{
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
-									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+									CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
 								},
 							},
 							Network: &Network{EnableDNSHostnames: pointer.Bool(false)},

--- a/api/v1alpha1/jobset_webhook_test.go
+++ b/api/v1alpha1/jobset_webhook_test.go
@@ -104,6 +104,37 @@ func TestJobSetDefaulting(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "enableDNSHostnames is false",
+			js: &JobSet{
+				Spec: JobSetSpec{
+					ReplicatedJobs: []ReplicatedJob{
+						{
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+								},
+							},
+							Network: &Network{EnableDNSHostnames: pointer.Bool(false)},
+						},
+					},
+				},
+			},
+			want: &JobSet{
+				Spec: JobSetSpec{
+					ReplicatedJobs: []ReplicatedJob{
+						{
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+								},
+							},
+							Network: &Network{EnableDNSHostnames: pointer.Bool(false)},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/test/integration/webhook/jobset_webhook_test.go
+++ b/test/integration/webhook/jobset_webhook_test.go
@@ -106,6 +106,7 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
 				return testing.MakeJobSet("completionmode-nonindexed", ns.Name).
 					ReplicatedJob(testing.MakeReplicatedJob("test-job").
+						EnableDNSHostnames(false).
 						Job(testing.MakeJobTemplate("test-job", ns.Name).
 							CompletionMode(batchv1.NonIndexedCompletion).
 							PodSpec(testing.TestPodSpec).Obj()).

--- a/test/integration/webhook/jobset_webhook_test.go
+++ b/test/integration/webhook/jobset_webhook_test.go
@@ -116,5 +116,18 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 				return completionMode != nil && *completionMode == batchv1.NonIndexedCompletion
 			},
 		}),
+		ginkgo.Entry("enableDNSHostnames defaults to true if unset", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("enablednshostnames-unset", ns.Name).
+					ReplicatedJob(testing.MakeReplicatedJob("test-job").
+						Job(testing.MakeJobTemplate("test-job", ns.Name).
+							CompletionMode(batchv1.IndexedCompletion).
+							PodSpec(testing.TestPodSpec).Obj()).
+						Obj())
+			},
+			defaultsApplied: func(js *jobset.JobSet) bool {
+				return js.Spec.ReplicatedJobs[0].Network != nil && *js.Spec.ReplicatedJobs[0].Network.EnableDNSHostnames
+			},
+		}),
 	) // end of DescribeTable
 }) // end of Describe


### PR DESCRIPTION
Fixes #62 

Enable DNS hostnames by default if unset, if the replicated job template uses indexed completion mode (we cannot enable DNS hostnames for non-indexed completion mode).