### PR TITLE
Update e2e make rule with step to download kustomize binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,5 +208,5 @@ test-integration: manifests generate fmt vet envtest ginkgo ## Run tests.
 	$(GINKGO) -v $(INTEGRATION_TARGET)
 
 .PHONY: test-e2e-kind
-test-e2e-kind: manifests generate fmt vet envtest ginkgo kind-image-build
+test-e2e-kind: manifests generate kustomize fmt vet envtest ginkgo kind-image-build
 	E2E_KIND_VERSION=$(E2E_KIND_VERSION) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) IMAGE_TAG=$(IMAGE_TAG) ./hack/e2e-test.sh


### PR DESCRIPTION
E2E tests are currently failing because there is no kustomize binary to use. See [example](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_jobset/64/pull-jobset-test-e2e-main-1-26/1651042086352326656).