### PR TITLE
adding a simple parallel sleep and fix validation with pytorch

### DIFF
--- a/examples/pytorch/resnet.yaml
+++ b/examples/pytorch/resnet.yaml
@@ -5,8 +5,6 @@ metadata:
 spec:
   replicatedJobs:
   - name: workers
-    network:
-      enableDNSHostnames: true
     template:
       spec:
         parallelism: 4

--- a/examples/pytorch/resnet.yaml
+++ b/examples/pytorch/resnet.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   replicatedJobs:
   - name: workers
+    network:
+      enableDNSHostnames: true
     template:
       spec:
         parallelism: 4

--- a/examples/simple/paralleljobs.yaml
+++ b/examples/simple/paralleljobs.yaml
@@ -18,4 +18,19 @@ spec:
               command:
               - sleep
               - 100
+  - name: driver
+    template:
+      spec:
+        parallelism: 1
+        completions: 1
+        backoffLimit: 0
+        template:
+          spec:
+            containers:
+            - name: sleep
+              image: busybox
+              command:
+              - sleep
+              - 100
+
                 

--- a/examples/simple/paralleljobs.yaml
+++ b/examples/simple/paralleljobs.yaml
@@ -5,8 +5,6 @@ metadata:
 spec:
   replicatedJobs:
   - name: workers
-    network:
-      enableDNSHostnames: false
     template:
       spec:
         parallelism: 4

--- a/examples/simple/paralleljobs.yaml
+++ b/examples/simple/paralleljobs.yaml
@@ -1,0 +1,23 @@
+apiVersion: jobset.x-k8s.io/v1alpha1
+kind: JobSet
+metadata:
+  name: sleep
+spec:
+  replicatedJobs:
+  - name: workers
+    network:
+      enableDNSHostnames: false
+    template:
+      spec:
+        parallelism: 4
+        completions: 4
+        backoffLimit: 0
+        template:
+          spec:
+            containers:
+            - name: sleep
+              image: busybox
+              command:
+              - sleep
+              - 100
+                


### PR DESCRIPTION
I was trying to run the resnet example and I notice that we were missing the network field.  

This may not be necessary with other work in place but figured I'd open something up.

I also added a lightweight example just for testing purposes.   