### PR TITLE
require templates in replicatejobs

### DIFF
--- a/api/v1alpha1/jobset_types.go
+++ b/api/v1alpha1/jobset_types.go
@@ -85,7 +85,7 @@ type ReplicatedJob struct {
 	// for the Job name.
 	Name string `json:"name"`
 	// Template defines the template of the Job that will be created.
-	Template batchv1.JobTemplateSpec `json:"template,omitempty"`
+	Template batchv1.JobTemplateSpec `json:"template"`
 	// Network defines the networking options for the job.
 	// +optional
 	Network *Network `json:"network,omitempty"`

--- a/config/crd/bases/jobset.x-k8s.io_jobsets.yaml
+++ b/config/crd/bases/jobset.x-k8s.io_jobsets.yaml
@@ -9492,13 +9492,8 @@ spec:
                       type: object
                   required:
                   - name
+                  - template
                   type: object
-                  x-kubernetes-validations:
-                  - message: EnableDNSHostnames requires job to be in indexed completion
-                      mode
-                    rule: '!has(self.network) || !has(self.network.enableDNSHostnames)
-                      || !self.network.enableDNSHostnames || (has(self.template.spec.completionMode)
-                      && self.template.spec.completionMode == "Indexed")'
                 type: array
                 x-kubernetes-list-map-keys:
                 - name


### PR DESCRIPTION
Discussing with @ahg-g it doesn't really seem to make sense to not require job templates in a replicatedjob so we will require those fields to be set.