### PR TITLE
Add PyTorch MNIST example

### DIFF
--- a/examples/pytorch/mnist.yaml
+++ b/examples/pytorch/mnist.yaml
@@ -1,0 +1,36 @@
+apiVersion: jobset.x-k8s.io/v1alpha1
+kind: JobSet
+metadata:
+  name: pytorch
+spec:
+  replicatedJobs:
+  - name: workers
+    template:
+      spec:
+        parallelism: 4
+        completions: 4
+        backoffLimit: 0
+        template:
+          spec:
+            containers:
+            - name: pytorch
+              image: gcr.io/k8s-staging-jobset/pytorch-mnist:latest
+              ports:
+              - containerPort: 3389
+              env:
+              - name: MASTER_ADDR
+                value: "pytorch-workers-0-0.pytorch-workers"
+              - name: MASTER_PORT
+                value: "3389"
+              - name: RANK
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.annotations['batch.kubernetes.io/job-completion-index']
+              # Force python to not buffer output and write directly to stdout, so we can view training logs via `kubectl logs`.
+              - name: PYTHONUNBUFFERED
+                value: "0"
+              command:
+              - bash
+              - -xc
+              - |
+                torchrun --rdzv_id=123 --nnodes=4 --nproc_per_node=1 --master_addr=$MASTER_ADDR --master_port=$MASTER_PORT --node_rank=$RANK mnist.py --epochs=1 --log-interval=1  


### PR DESCRIPTION
This example runs much more quickly and is more suitable for live demos.

This example took 6.5min to run (excluding image pull time) on a standard GKE cluster. 

However, throughout this period it produces training logs like those below every 1/2 second or so:


```
Train Epoch: 1 [4672/60000 (31%)]       Loss: 0.126806
Train Epoch: 1 [4736/60000 (31%)]       Loss: 0.105196
Train Epoch: 1 [4800/60000 (32%)]       Loss: 0.315103
Train Epoch: 1 [4864/60000 (32%)]       Loss: 0.141531
```
Then upon completion of the first (and only) epoch:

```
Test set: Average loss: 0.0831, Accuracy: 9727/10000 (97%)
```