### PR TITLE
Add failure policy with max restarts example

### DIFF
--- a/examples/simple/max-restarts.yaml
+++ b/examples/simple/max-restarts.yaml
@@ -13,14 +13,13 @@ spec:
       spec:
         # Set backoff limit to 0 so job will immediately fail if any pod fails.
         backoffLimit: 0 
-        completionMode: Indexed
         completions: 2
         parallelism: 2
         template:
           spec:
             restartPolicy: Never
             containers:
-            - name: worker
+            - name: leader
               image: bash:latest
               # Default failure policy is to recreate all jobs if any jobs fails. 
               # The bash script provides a simple demonstration of it by failing
@@ -49,7 +48,6 @@ spec:
     template:
       spec:
         backoffLimit: 0 
-        completionMode: Indexed
         completions: 2
         parallelism: 2
         template:

--- a/examples/simple/max-restarts.yaml
+++ b/examples/simple/max-restarts.yaml
@@ -7,7 +7,7 @@ spec:
   failurePolicy:
     maxRestarts: 3
   replicatedJobs:
-  - name: worker1
+  - name: leader
     replicas: 1
     template:
       spec:
@@ -44,7 +44,7 @@ spec:
                   echo "$i"
                   sleep 1
                 done
-  - name: worker2
+  - name: workers
     replicas: 1
     template:
       spec:

--- a/examples/simple/max-restarts.yaml
+++ b/examples/simple/max-restarts.yaml
@@ -1,0 +1,64 @@
+apiVersion: jobset.x-k8s.io/v1alpha1
+kind: JobSet
+metadata:
+  name: failurepolicy
+spec:
+  # On failure, restart all jobs up to 3 times.
+  failurePolicy:
+    maxRestarts: 3
+  replicatedJobs:
+  - name: worker1
+    replicas: 1
+    template:
+      spec:
+        # Set backoff limit to 0 so job will immediately fail if any pod fails.
+        backoffLimit: 0 
+        completionMode: Indexed
+        completions: 2
+        parallelism: 2
+        template:
+          spec:
+            restartPolicy: Never
+            containers:
+            - name: worker
+              image: bash:latest
+              # Default failure policy is to recreate all jobs if any jobs fails. 
+              # The bash script provides a simple demonstration of it by failing
+              # the pod with completion index 0, which will trigger job failure
+              # and the jobset controller wil recreate all jobs. 
+              command:
+              - bash
+              - -xc
+              - |
+                echo "JOB_COMPLETION_INDEX=$JOB_COMPLETION_INDEX"
+                if [[ "$JOB_COMPLETION_INDEX" == "0" ]]; then
+                  for i in $(seq 10 -1 1)
+                  do
+                    echo "Sleeping in $i"
+                    sleep 1
+                  done
+                  exit 1
+                fi
+                for i in $(seq 1 1000)
+                do
+                  echo "$i"
+                  sleep 1
+                done
+  - name: worker2
+    replicas: 1
+    template:
+      spec:
+        backoffLimit: 0 
+        completionMode: Indexed
+        completions: 2
+        parallelism: 2
+        template:
+          spec:
+            containers:
+            - name: worker
+              image: bash:latest
+              command:
+              - bash
+              - -xc
+              - |
+                sleep 1000

--- a/examples/simple/max-restarts.yaml
+++ b/examples/simple/max-restarts.yaml
@@ -17,7 +17,6 @@ spec:
         parallelism: 2
         template:
           spec:
-            restartPolicy: Never
             containers:
             - name: leader
               image: bash:latest


### PR DESCRIPTION
This example runs a JobSet with a failurePolicy with maxRestarts=3. It has 2 replicated jobs (`worker1` and `worker2`), with 1 replica each.

worker1 has a bash script which will fail pod index 0 after 10 seconds, causing the job worker1 to fail. This will trigger the jobset controller to restart all the jobs. This will process will repeat until maxRestarts (3) is hit.

I thought this would be a helpful example for quickly demonstrating how the failure policy with max restarts works.