### PR TITLE
add integration test where service/job are created before jobset

### DIFF
--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -184,6 +184,7 @@ var _ = ginkgo.Describe("JobSet validation", func() {
 		}),
 		ginkgo.Entry("existing job conflicts with jobset", &testCase{
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				ginkgo.By("making js-exist-job")
 				return testing.MakeJobSet("js-exist-job", ns.Name).
 					ReplicatedJob(testing.MakeReplicatedJob("test-exist-job").
 						Job(testing.MakeJobTemplate("test-exist-job", ns.Name).
@@ -197,7 +198,7 @@ var _ = ginkgo.Describe("JobSet validation", func() {
 			existingJob: func(ns *corev1.Namespace) *batchv1.Job {
 				return &batchv1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-exist-job",
+						Name:      "test-exist-job-0",
 						Namespace: ns.Name,
 					},
 					Spec: batchv1.JobSpec{

--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -188,15 +188,16 @@ var _ = ginkgo.Describe("JobSet validation", func() {
 					ReplicatedJob(testing.MakeReplicatedJob("test-exist-job").
 						Job(testing.MakeJobTemplate("test-exist-job", ns.Name).
 							PodSpec(testing.TestPodSpec).
-							CompletionMode(batchv1.IndexedCompletion).Obj()).
+							CompletionMode(batchv1.NonIndexedCompletion).Obj()).
 						EnableDNSHostnames(true).
+						Replicas(1).
 						Obj())
 			},
 			jobSetCreationShouldSucceed: true,
 			existingJob: func(ns *corev1.Namespace) *batchv1.Job {
 				return &batchv1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-job",
+						Name:      "test-exist-job",
 						Namespace: ns.Name,
 					},
 					Spec: batchv1.JobSpec{
@@ -213,8 +214,9 @@ var _ = ginkgo.Describe("JobSet validation", func() {
 					ReplicatedJob(testing.MakeReplicatedJob("service-job").
 						Job(testing.MakeJobTemplate("service-job", ns.Name).
 							PodSpec(testing.TestPodSpec).
-							CompletionMode(batchv1.IndexedCompletion).Obj()).
+							CompletionMode(batchv1.NonIndexedCompletion).Obj()).
 						EnableDNSHostnames(true).
+						Replicas(1).
 						Obj())
 			},
 			jobSetCreationShouldSucceed: true,

--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -185,8 +185,8 @@ var _ = ginkgo.Describe("JobSet validation", func() {
 		ginkgo.Entry("existing job conflicts with jobset", &testCase{
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
 				ginkgo.By("making js-exist-job")
-				return testing.MakeJobSet("js-exist-job", ns.Name).
-					ReplicatedJob(testing.MakeReplicatedJob("test-exist-job").
+				return testing.MakeJobSet("js", ns.Name).
+					ReplicatedJob(testing.MakeReplicatedJob("job").
 						Job(testing.MakeJobTemplate("test-exist-job", ns.Name).
 							PodSpec(testing.TestPodSpec).
 							CompletionMode(batchv1.NonIndexedCompletion).Obj()).
@@ -198,7 +198,7 @@ var _ = ginkgo.Describe("JobSet validation", func() {
 			existingJob: func(ns *corev1.Namespace) *batchv1.Job {
 				return &batchv1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-exist-job-0",
+						Name:      "js-job-0",
 						Namespace: ns.Name,
 					},
 					Spec: batchv1.JobSpec{
@@ -211,9 +211,9 @@ var _ = ginkgo.Describe("JobSet validation", func() {
 		}),
 		ginkgo.Entry("existing service conflicts with jobset", &testCase{
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
-				return testing.MakeJobSet("js-exist-service", ns.Name).
-					ReplicatedJob(testing.MakeReplicatedJob("service-job").
-						Job(testing.MakeJobTemplate("service-job", ns.Name).
+				return testing.MakeJobSet("js", ns.Name).
+					ReplicatedJob(testing.MakeReplicatedJob("job").
+						Job(testing.MakeJobTemplate("job", ns.Name).
 							PodSpec(testing.TestPodSpec).
 							CompletionMode(batchv1.NonIndexedCompletion).Obj()).
 						EnableDNSHostnames(true).
@@ -224,7 +224,7 @@ var _ = ginkgo.Describe("JobSet validation", func() {
 			existingService: func(ns *corev1.Namespace) *corev1.Service {
 				return &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "js-exist-service-service-job",
+						Name:      "js-job",
 						Namespace: ns.Name,
 					},
 					Spec: corev1.ServiceSpec{


### PR DESCRIPTION
Fixes #18 

I am adding some integration tests to fix 18 but I am running into some trouble.  

```
 2023-05-01T22:00:32Z  ERROR   creating jobs   {"controller": "jobset", "controllerGroup": "jobset.x-k8s.io", "controllerKind": "JobSet", "JobSet": {"name":"test-js","namespace":"test-ns-fp9mx"}, "namespace": "test-ns-fp9mx", "name": "test-js", "reconcileID": "c0982dd3-313f-45e7-9fda-b4192b6c00c5", "jobset": {"name":"test-js","namespace":"test-ns-fp9mx"}, "error": "jobs.batch \"test-js-replicated-job-b-2\" is forbidden: unable to create new content in namespace test-ns-fp9mx because it is being terminated"}
  sigs.k8s.io/jobset/pkg/controllers.(*JobSetReconciler).Reconcile
        /home/ec2-user/Work/GIT/jobset-kevin/pkg/controllers/jobset_controller.go:129
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
        /home/ec2-user/go/1.20.2/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:122
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
        /home/ec2-user/go/1.20.2/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:323
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
        /home/ec2-user/go/1.20.2/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:274
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
        /home/ec2-user/go/1.20.2/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:235
  2023-05-01T22:00:32Z  ERROR   creating jobs   {"controller": "jobset", "controllerGroup": "jobset.x-k8s.io", "controllerKind": "JobSet", "JobSet": {"name":"test-js","namespace":"test-ns-fp9mx"}, "namespace": "test-ns-fp9mx", "name": "test-js", "reconcileID": "2468a498-600d-4aa6-b240-fa7876de3b0b", "jobset": {"name":"test-js","namespace":"test-ns-fp9mx"}, "error": "jobs.batch \"test-js-replicated-job-b-2\" is forbidden: unable to create new content in namespace test-ns-fp9mx because it is being terminated"}
  sigs.k8s.io/jobset/pkg/controllers.(*JobSetReconciler).Reconcile
 
```

I am getting namespace being terminated when trying to create Jobs/Services before creating the jobservice.