### PR TITLE
Refactor suspend/resume logic in Reconcile()

### DIFF
--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -133,29 +133,12 @@ func (r *JobSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// If JobSet is suspended, ensure the suspend condition is set and suspend all active child jobs.
 	jobsetSuspended := js.Spec.Suspend != nil && *js.Spec.Suspend
 	if jobsetSuspended {
-		for _, job := range ownedJobs.active {
-			if !pointer.BoolDeref(job.Spec.Suspend, false) {
-				job.Spec.Suspend = pointer.Bool(true)
-				if r.Update(ctx, job); err != nil {
-					log.Error(err, "suspending job", "job", klog.KObj(job))
-					return ctrl.Result{}, nil
-				}
-			}
-		}
-		if err := r.ensureCondition(ctx, &js, corev1.EventTypeNormal, metav1.Condition{
-			Type:               string(jobset.JobSetSuspended),
-			Status:             metav1.ConditionStatus(corev1.ConditionTrue),
-			LastTransitionTime: metav1.Now(),
-			Reason:             "SuspendedJobs",
-			Message:            "jobset is suspended",
-		}); err != nil {
-			log.Error(err, "updating jobset status")
+		if err := r.suspendJobSet(ctx, &js, ownedJobs); err != nil {
 			return ctrl.Result{}, nil
 		}
-
+	} else {
 		// If JobSpec is unsuspended, ensure all active child Jobs are also
 		// unsuspended and update the suspend condition to true.
-	} else {
 		for _, job := range ownedJobs.active {
 			if pointer.BoolDeref(job.Spec.Suspend, false) != false {
 				job.Spec.Suspend = pointer.Bool(false)
@@ -243,6 +226,30 @@ func (r *JobSetReconciler) getChildJobs(ctx context.Context, js *jobset.JobSet) 
 		}
 	}
 	return &ownedJobs, nil
+}
+
+func (r *JobSetReconciler) suspendJobSet(ctx context.Context, js *jobset.JobSet, ownedJobs *childJobs) error {
+	log := ctrl.LoggerFrom(ctx)
+	for _, job := range ownedJobs.active {
+		if !pointer.BoolDeref(job.Spec.Suspend, false) {
+			job.Spec.Suspend = pointer.Bool(true)
+			if err := r.Update(ctx, job); err != nil {
+				log.Error(err, "suspending job", "job", klog.KObj(job))
+				return err
+			}
+		}
+	}
+	if err := r.ensureCondition(ctx, js, corev1.EventTypeNormal, metav1.Condition{
+		Type:               string(jobset.JobSetSuspended),
+		Status:             metav1.ConditionStatus(corev1.ConditionTrue),
+		LastTransitionTime: metav1.Now(),
+		Reason:             "SuspendedJobs",
+		Message:            "jobset is suspended",
+	}); err != nil {
+		log.Error(err, "updating jobset status")
+		return err
+	}
+	return nil
 }
 
 func (r *JobSetReconciler) createJobs(ctx context.Context, js *jobset.JobSet, ownedJobs *childJobs) error {

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -130,7 +130,7 @@ func (r *JobSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, nil
 	}
 
-	// If JobSet is suspended, ensure the suspend condition is set and suspend all active child jobs.
+	// Handle suspending a jobset or resuming a suspended jobset.
 	jobsetSuspended := js.Spec.Suspend != nil && *js.Spec.Suspend
 	if jobsetSuspended {
 		if err := r.suspendJobSet(ctx, &js, ownedJobs); err != nil {


### PR DESCRIPTION
I'd like to keep the top level entry point to the jobset reconciler (i.e. the `Reconcile()` method) as simple and readable as possible, abstracting away the implementation details of how certain logical steps are performed into lower levels of the code.

This is just a suggestion/preference, we don't necessarily need to merge this. @ahg-g @kannon92 any thoughts?