### PR TITLE
Automated cherry pick of #110: update annotations

### DIFF
--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -550,6 +550,8 @@ func labelAndAnnotateObject(obj metav1.Object, js *jobset.JobSet, rjob *jobset.R
 	labels[jobset.JobIndexKey] = strconv.Itoa(jobIdx)
 
 	annotations := cloneMap(obj.GetAnnotations())
+	labels[jobset.JobSetNameKey] = js.Name
+	labels[jobset.ReplicatedJobNameKey] = rjob.Name
 	annotations[jobset.ReplicatedJobReplicas] = strconv.Itoa(rjob.Replicas)
 	annotations[jobset.JobIndexKey] = strconv.Itoa(jobIdx)
 

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -550,8 +550,8 @@ func labelAndAnnotateObject(obj metav1.Object, js *jobset.JobSet, rjob *jobset.R
 	labels[jobset.JobIndexKey] = strconv.Itoa(jobIdx)
 
 	annotations := cloneMap(obj.GetAnnotations())
-	labels[jobset.JobSetNameKey] = js.Name
-	labels[jobset.ReplicatedJobNameKey] = rjob.Name
+	annotations[jobset.JobSetNameKey] = js.Name
+	annotations[jobset.ReplicatedJobNameKey] = rjob.Name
 	annotations[jobset.ReplicatedJobReplicas] = strconv.Itoa(rjob.Replicas)
 	annotations[jobset.JobIndexKey] = strconv.Itoa(jobIdx)
 

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -720,6 +720,8 @@ func makeJob(args *makeJobArgs) *testutils.JobWrapper {
 			RestartsKey:                  strconv.Itoa(args.restarts),
 		}).
 		JobAnnotations(map[string]string{
+			jobset.JobSetNameKey:         args.jobSetName,
+			jobset.ReplicatedJobNameKey:  args.replicatedJobName,
 			jobset.ReplicatedJobReplicas: strconv.Itoa(args.replicas),
 			jobset.JobIndexKey:           strconv.Itoa(args.jobIdx),
 		}).
@@ -731,6 +733,8 @@ func makeJob(args *makeJobArgs) *testutils.JobWrapper {
 			RestartsKey:                  strconv.Itoa(args.restarts),
 		}).
 		PodAnnotations(map[string]string{
+			jobset.JobSetNameKey:         args.jobSetName,
+			jobset.ReplicatedJobNameKey:  args.replicatedJobName,
 			jobset.ReplicatedJobReplicas: strconv.Itoa(args.replicas),
 			jobset.JobIndexKey:           strconv.Itoa(args.jobIdx),
 		})


### PR DESCRIPTION
Cherry pick of #110 on release-0.1.
#110: update annotations
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
```