### PR TITLE
Pass a context from controller to the IndexerFunc

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,7 +96,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := controllers.SetupIndexes(mgr.GetFieldIndexer()); err != nil {
+	ctx := ctrl.SetupSignalHandler()
+	if err := controllers.SetupIndexes(ctx, mgr.GetFieldIndexer()); err != nil {
 		setupLog.Error(err, "unable to setup indexes")
 	}
 
@@ -108,7 +109,7 @@ func main() {
 	setupHealthzAndReadyzCheck(mgr)
 
 	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -158,8 +158,8 @@ func (r *JobSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func SetupIndexes(indexer client.FieldIndexer) error {
-	return indexer.IndexField(context.Background(), &batchv1.Job{}, jobOwnerKey, func(obj client.Object) []string {
+func SetupIndexes(ctx context.Context, indexer client.FieldIndexer) error {
+	return indexer.IndexField(ctx, &batchv1.Job{}, jobOwnerKey, func(obj client.Object) []string {
 		o := obj.(*batchv1.Job)
 		owner := metav1.GetControllerOf(o)
 		if owner == nil {

--- a/test/integration/controller/suite_test.go
+++ b/test/integration/controller/suite_test.go
@@ -57,6 +57,8 @@ func TestAPIs(t *testing.T) {
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
+	ctx, cancel = context.WithCancel(context.Background())
+
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "components", "crd", "bases")},
@@ -84,13 +86,11 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	jobSetController := controllers.NewJobSetReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), k8sManager.GetEventRecorderFor("jobset"))
 
-	err = controllers.SetupIndexes(k8sManager.GetFieldIndexer())
+	err = controllers.SetupIndexes(ctx, k8sManager.GetFieldIndexer())
 	Expect(err).ToNot(HaveOccurred())
 
 	err = jobSetController.SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
-
-	ctx, cancel = context.WithCancel(context.Background())
 
 	go func() {
 		defer GinkgoRecover()

--- a/test/integration/webhook/suite_test.go
+++ b/test/integration/webhook/suite_test.go
@@ -100,7 +100,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	err = controllers.SetupIndexes(mgr.GetFieldIndexer())
+	err = controllers.SetupIndexes(ctx, mgr.GetFieldIndexer())
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&jobset.JobSet{}).SetupWebhookWithManager(mgr)


### PR DESCRIPTION
I modified the func `SetupIndexes` to pass a context from the controller to the IndexerFunc.
