### PR TITLE
update go to 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19 as builder
+FROM golang:1.20 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/jobset
 
-go 1.19
+go 1.20
 
 require (
 	github.com/google/go-cmp v0.5.9


### PR DESCRIPTION
We are already running go 1.20 in our e2e tests and k8 is working on 1.20 now.  

