### PR TITLE
Set node affinity during unsuspend

### DIFF
--- a/api/v1alpha1/jobset_types.go
+++ b/api/v1alpha1/jobset_types.go
@@ -44,7 +44,6 @@ type JobSetSpec struct {
 	// ReplicatedJobs is the group of jobs that will form the set.
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	ReplicatedJobs []ReplicatedJob `json:"replicatedJobs,omitempty"`
 
 	// SuccessPolicy configures when to declare the JobSet as

--- a/api/v1alpha1/jobset_webhook.go
+++ b/api/v1alpha1/jobset_webhook.go
@@ -16,6 +16,7 @@ package v1alpha1
 import (
 	"errors"
 	"fmt"
+	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
@@ -81,7 +82,15 @@ func (js *JobSet) ValidateCreate() error {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (js *JobSet) ValidateUpdate(old runtime.Object) error {
-	return nil
+	oldObj := old.(*JobSet)
+	var allErr []error
+	for index := range js.Spec.ReplicatedJobs {
+		oldObj.Spec.ReplicatedJobs[index].Template.Spec.Template.Spec.NodeSelector = r.Spec.ReplicatedJobs[index].Template.Spec.Template.Spec.NodeSelector
+		if !reflect.DeepEqual(oldObj.Spec.ReplicatedJobs, js.Spec.ReplicatedJobs) {
+			allErr = append(allErr, fmt.Errorf("the spec.ReplicatedJobs value is imutable excepting Spec.ReplicatedJobs[index].Template.Spec.Template.Spec.NodeSelector"))
+		}
+	}
+	return errors.Join(allErr...)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type

--- a/api/v1alpha1/jobset_webhook.go
+++ b/api/v1alpha1/jobset_webhook.go
@@ -96,8 +96,8 @@ func (js *JobSet) ValidateUpdate(old runtime.Object) error {
 		}
 	}
 
-	if !apiequality.Semantic.DeepEqual(oldSpec, mungedSpec) {
-		specDiff := cmp.Diff(oldSpec, mungedSpec)
+	if !apiequality.Semantic.DeepEqual(oldSpec, *mungedSpec) {
+		specDiff := cmp.Diff(oldSpec, *mungedSpec)
 		return field.Forbidden(field.NewPath("spec"), fmt.Sprintf("jobset updates may not change fields other than %s\n%v", strings.Join(updatableFields, ","), specDiff))
 	}
 	return nil

--- a/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
+++ b/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
@@ -9442,9 +9442,6 @@ spec:
                 x-kubernetes-list-map-keys:
                 - name
                 x-kubernetes-list-type: map
-                x-kubernetes-validations:
-                - message: Value is immutable
-                  rule: self == oldSelf
               successPolicy:
                 description: SuccessPolicy configures when to declare the JobSet as
                   succeeded. The JobSet is always declared succeeded if all jobs in

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 	"sync"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -239,18 +238,24 @@ func (r *JobSetReconciler) suspendJobSet(ctx context.Context, js *jobset.JobSet,
 }
 
 func (r *JobSetReconciler) resumeJobSetIfNecessary(ctx context.Context, js *jobset.JobSet, ownedJobs *childJobs) error {
+	log := ctrl.LoggerFrom(ctx)
+
 	nodeAffinities := map[string]map[string]string{}
 	for _, replicatedJob := range js.Spec.ReplicatedJobs {
-		nodeAffinities[fmt.Sprintf("%s-%s", js.Name, replicatedJob.Name)] = replicatedJob.Template.Spec.Template.Spec.NodeSelector
+		nodeAffinities[replicatedJob.Name] = replicatedJob.Template.Spec.Template.Spec.NodeSelector
 	}
 
 	// If JobSpec is unsuspended, ensure all active child Jobs are also
 	// unsuspended and update the suspend condition to true.
 	for _, job := range ownedJobs.active {
 		if pointer.BoolDeref(job.Spec.Suspend, false) != false {
-			i := strings.LastIndex(job.Name, "-")
-			job.Spec.Template.Spec.NodeSelector = nodeAffinities[job.Name[:i]]
+			if job.Labels != nil && job.Labels[jobset.ReplicatedJobNameKey] != "" {
+				job.Spec.Template.Spec.NodeSelector = nodeAffinities[job.Labels[jobset.ReplicatedJobNameKey]]
+			} else {
+				log.Error(nil, "job missing ReplicatedJobName label")
+			}
 			job.Spec.Suspend = pointer.Bool(false)
+			job.Status.StartTime = nil
 			if err := r.Update(ctx, job); err != nil {
 				return err
 			}

--- a/test/integration/webhook/jobset_webhook_test.go
+++ b/test/integration/webhook/jobset_webhook_test.go
@@ -209,6 +209,7 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 			verbType: "update",
 			updateJobSet: func(js *jobset.JobSet) {
 				js.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Hostname = "test"
+				js.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Subdomain = "test"
 			},
 			updateShouldFails: true,
 		}),


### PR DESCRIPTION
### What would you like to be added:
Node selectors should be updated on each of jobs based on ReplicatedJob template during unsuspend.
### Why is this needed:
On suspend and unsuspend process the Node Selectors can be replaced by Kueue Operator.

### Issue Number:
#134 