### PR TITLE
Bump timeouts to reduce flakiness

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -97,7 +97,7 @@ func pingTestJobSet(ns *corev1.Namespace) *testing.JobSetWrapper {
 	}
 
 	// This bash script loops infinitely until it successfully pings all pods by hostname.
-	// Once successful, it sleeps for 5 seconds to reduce flakiness, since occasionally
+	// Once successful, it sleeps for a short period to reduce flakiness, since occasionally
 	// all pods but one will successfully ping eachother and complete before the last one
 	// successfully pings them all, resulting in a failed test run.
 	cmd := fmt.Sprintf(`for pod in {"%s","%s","%s","%s"}
@@ -115,7 +115,7 @@ do
 	done                                                         
 	echo "Successfully pinged pod: $pod"
 done
-sleep 5`, podHostnames[0], podHostnames[1], podHostnames[2], podHostnames[3])
+sleep 30`, podHostnames[0], podHostnames[1], podHostnames[2], podHostnames[3])
 
 	return testing.MakeJobSet(jsName, ns.Name).
 		ReplicatedJob(testing.MakeReplicatedJob(rjobName).

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	timeout  = 2 * time.Minute
+	timeout  = 5 * time.Minute
 	interval = time.Millisecond * 250
 )
 


### PR DESCRIPTION
Fixes #135 

Bump e2e test timeout from 2min to 5 min.

Bump `sleep 5` to `sleep 30` in bash script since occasionally all pods but one will successfully ping each other and complete before the last one successfully pings them all, resulting in a failed test run, so increasing this sleep will provide a larger buffer.