### PR TITLE
delete duplicate setting suspend is allowed test case

### DIFF
--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -133,18 +133,6 @@ var _ = ginkgo.Describe("JobSet validation", func() {
 				},
 			},
 		}),
-		ginkgo.Entry("setting suspend is allowed", &testCase{
-			makeJobSet:                  testJobSet,
-			jobSetCreationShouldSucceed: true,
-			updates: []*jobSetUpdate{
-				{
-					shouldSucceed: true,
-					fn: func(js *jobset.JobSet) {
-						js.Spec.Suspend = pointer.Bool(true)
-					},
-				},
-			},
-		}),
 	) // end of DescribeTable
 }) // end of Describe
 


### PR DESCRIPTION
I found that we have a duplicate test case in our integration tests:

```
		ginkgo.Entry("setting suspend is allowed", &testCase{
			makeJobSet:                  testJobSet,
			jobSetCreationShouldSucceed: true,
			updates: []*jobSetUpdate{
				{
					shouldSucceed: true,
					fn: func(js *jobset.JobSet) {
						js.Spec.Suspend = pointer.Bool(true)
					},
				},
			},
		}),
		ginkgo.Entry("setting suspend is allowed", &testCase{
			makeJobSet:                  testJobSet,
			jobSetCreationShouldSucceed: true,
			updates: []*jobSetUpdate{
				{
					shouldSucceed: true,
					fn: func(js *jobset.JobSet) {
						js.Spec.Suspend = pointer.Bool(true)
					},
				},
			},
		}),
```

This PR removes the duplicate test.

