### PR TITLE
fixed resetting start time bug

### DIFF
--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -258,6 +258,9 @@ func (r *JobSetReconciler) resumeJobSetIfNecessary(ctx context.Context, js *jobs
 			if err := r.Update(ctx, job); err != nil {
 				return err
 			}
+			if job.Status.StartTime == nil {
+				continue
+			}
 			job.Status.StartTime = nil
 			if err := r.Status().Update(ctx, job); err != nil {
 				return err

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -255,8 +255,11 @@ func (r *JobSetReconciler) resumeJobSetIfNecessary(ctx context.Context, js *jobs
 				log.Error(nil, "job missing ReplicatedJobName label")
 			}
 			job.Spec.Suspend = pointer.Bool(false)
-			job.Status.StartTime = nil
 			if err := r.Update(ctx, job); err != nil {
+				return err
+			}
+			job.Status.StartTime = nil
+			if err := r.Status().Update(ctx, job); err != nil {
 				return err
 			}
 		}

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -258,12 +258,11 @@ func (r *JobSetReconciler) resumeJobSetIfNecessary(ctx context.Context, js *jobs
 			if err := r.Update(ctx, job); err != nil {
 				return err
 			}
-			if job.Status.StartTime == nil {
-				continue
-			}
-			job.Status.StartTime = nil
-			if err := r.Status().Update(ctx, job); err != nil {
-				return err
+			if job.Status.StartTime != nil {
+				job.Status.StartTime = nil
+				if err := r.Status().Update(ctx, job); err != nil {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### What would you like to be added:
Update status using client.Status().Update(..)

### Why is this needed:
we reset StartTime to allow updating the nodeSelectors on the job. However StartTime is in status, which we can update via a status update call only

### Issue Number:
#157

/kind bug