### PR TITLE
Add `Completed` and `Restarts` printcolumns to JobSet

### DIFF
--- a/api/v1alpha1/jobset_types.go
+++ b/api/v1alpha1/jobset_types.go
@@ -90,6 +90,9 @@ type ReplicatedJobStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Restarts",JSONPath=".status.restarts",type=string,description="Number of restarts"
+// +kubebuilder:printcolumn:name="Completed",type="string",priority=0,JSONPath=".status.conditions[?(@.type==\"Completed\")].status"
+// +kubebuilder:printcolumn:name="Age",JSONPath=".metadata.creationTimestamp",type=date,description="Time this JobSet was created"
 // JobSet is the Schema for the jobsets API
 type JobSet struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
+++ b/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
@@ -14,7 +14,19 @@ spec:
     singular: jobset
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Number of restarts
+      jsonPath: .status.restarts
+      name: Restarts
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Completed")].status
+      name: Completed
+      type: string
+    - description: Time this JobSet was created
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: JobSet is the Schema for the jobsets API


### PR DESCRIPTION
Addresses part of https://github.com/kubernetes-sigs/jobset/issues/161

This PR adds new printcolumns, `Completed` and `Restarts` that will be part of `kubectl get` response table.

example:
```bash
> k get jobset
NAME    RESTARTS   COMPLETED   AGE
sleep              True        3m48s
```
