### PR TITLE
Fix bug with setting node selectors when resuming suspended jobset

### DIFF
--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -250,6 +250,8 @@ func (r *JobSetReconciler) resumeJobSetIfNecessary(ctx context.Context, js *jobs
 	for _, job := range ownedJobs.active {
 		if pointer.BoolDeref(job.Spec.Suspend, false) != false {
 			if job.Labels != nil && job.Labels[jobset.ReplicatedJobNameKey] != "" {
+				// When resuming a job, its nodeSelectors should match that of the replicatedJob template
+				// that it was created from, which may have been updated while it was suspended.
 				job.Spec.Template.Spec.NodeSelector = nodeAffinities[job.Labels[jobset.ReplicatedJobNameKey]]
 			} else {
 				log.Error(nil, "job missing ReplicatedJobName label")


### PR DESCRIPTION
Fixes #166 

The issue was the nodeSelector map key was using the replicatedJob name as the key, when it should be in the format `<jobSetName>-<replicatedJobName>`, so the key didn't exist.