### PR TITLE
Delete active jobs for finished JobSets

### DIFF
--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -782,7 +782,8 @@ func checkExpectedServices(js *jobset.JobSet) {
 	}).Should(gomega.Equal(numExpectedServices(js)))
 }
 
-// Check one headless service per job was created successfully.
+// Check that there are no active jobs owned by jobset, and the
+// only remaining jobs are the finished ones.
 func checkNoActiveJobs(js *jobset.JobSet, numFinishedJobs int) {
 	ginkgo.By("checking there are no active jobs")
 	gomega.Eventually(func() (bool, error) {


### PR DESCRIPTION
Fixes #162 

Also fixes a bug in the `success policy 'all' with empty replicated jobs list` test case parameters (success policy target should be empty) which had somehow slipped our test logic until I added these changes to the controller.