### PR TITLE
Reset StartTime before updating the jobs NodeSelector

### DIFF
--- a/api/v1alpha1/jobset_types.go
+++ b/api/v1alpha1/jobset_types.go
@@ -156,7 +156,7 @@ type SuccessPolicy struct {
 
 	// TargetReplicatedJobs are the names of the replicated jobs the operator will apply to.
 	// A null or empty list will apply to all replicatedJobs.
-	TargetReplicatedJobs []string `json:"replicatedJobNames,omitempty"`
+	TargetReplicatedJobs []string `json:"targetReplicatedJobs,omitempty"`
 }
 
 func init() {

--- a/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
+++ b/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
@@ -9526,7 +9526,7 @@ spec:
                     - All
                     - Any
                     type: string
-                  replicatedJobNames:
+                  targetReplicatedJobs:
                     description: TargetReplicatedJobs are the names of the replicated
                       jobs the operator will apply to. A null or empty list will apply
                       to all replicatedJobs.

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -313,7 +313,7 @@ func (r *JobSetReconciler) resumeJobSetIfNecessary(ctx context.Context, js *jobs
 	// If JobSpec is unsuspended, ensure all active child Jobs are also
 	// unsuspended and update the suspend condition to true.
 	for _, job := range ownedJobs.active {
-		if pointer.BoolDeref(job.Spec.Suspend, false) != false {
+		if pointer.BoolDeref(job.Spec.Suspend, false) {
 			if job.Status.StartTime != nil {
 				job.Status.StartTime = nil
 				if err := r.Status().Update(ctx, job); err != nil {
@@ -417,7 +417,6 @@ func (r *JobSetReconciler) createHeadlessSvcIfNotExist(ctx context.Context, js *
 // and updates the jobset status to completed if the success policy conditions are met.
 // Returns a boolean value indicating if the jobset was completed or not.
 func (r *JobSetReconciler) executeSuccessPolicy(ctx context.Context, js *jobset.JobSet, ownedJobs *childJobs) (bool, error) {
-	log := ctrl.LoggerFrom(ctx)
 	if numJobsMatchingSuccessPolicy(js, ownedJobs.successful) >= numJobsExpectedToSucceed(js) {
 		if err := r.ensureCondition(ctx, js, corev1.EventTypeNormal, metav1.Condition{
 			Type:    string(jobset.JobSetCompleted),
@@ -425,7 +424,6 @@ func (r *JobSetReconciler) executeSuccessPolicy(ctx context.Context, js *jobset.
 			Reason:  "AllJobsCompleted",
 			Message: "jobset completed successfully",
 		}); err != nil {
-			log.Error(err, "updating jobset status")
 			return false, err
 		}
 		return true, nil
@@ -535,7 +533,7 @@ func updateCondition(js *jobset.JobSet, condition metav1.Condition) bool {
 			return false
 		}
 	}
-	// condition doesn't exist, update only if the status is false
+	// condition doesn't exist, update only if the status is true
 	if condition.Status == metav1.ConditionTrue {
 		js.Status.Conditions = append(js.Status.Conditions, condition)
 		return true

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -314,6 +314,12 @@ func (r *JobSetReconciler) resumeJobSetIfNecessary(ctx context.Context, js *jobs
 	// unsuspended and update the suspend condition to true.
 	for _, job := range ownedJobs.active {
 		if pointer.BoolDeref(job.Spec.Suspend, false) != false {
+			if job.Status.StartTime != nil {
+				job.Status.StartTime = nil
+				if err := r.Status().Update(ctx, job); err != nil {
+					return err
+				}
+			}
 			if job.Labels != nil && job.Labels[jobset.ReplicatedJobNameKey] != "" {
 				// When resuming a job, its nodeSelectors should match that of the replicatedJob template
 				// that it was created from, which may have been updated while it was suspended.
@@ -324,12 +330,6 @@ func (r *JobSetReconciler) resumeJobSetIfNecessary(ctx context.Context, js *jobs
 			job.Spec.Suspend = pointer.Bool(false)
 			if err := r.Update(ctx, job); err != nil {
 				return err
-			}
-			if job.Status.StartTime != nil {
-				job.Status.StartTime = nil
-				if err := r.Status().Update(ctx, job); err != nil {
-					return err
-				}
 			}
 		}
 	}

--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -43,24 +43,6 @@ const (
 )
 
 var _ = ginkgo.Describe("JobSet validation", func() {
-	// Each test runs in a separate namespace.
-	var ns *corev1.Namespace
-
-	ginkgo.BeforeEach(func() {
-		// Create test namespace before each test.
-		ns = &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "test-ns-",
-			},
-		}
-		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
-
-	})
-
-	ginkgo.AfterEach(func() {
-		gomega.Expect(testutil.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
-	})
-
 	// jobSetUpdate contains the mutations to perform on the jobset and the
 	// checks to perform afterwards.
 	type jobSetUpdate struct {
@@ -77,6 +59,18 @@ var _ = ginkgo.Describe("JobSet validation", func() {
 	ginkgo.DescribeTable("JobSet validation during creation and updates",
 		func(tc *testCase) {
 			ctx := context.Background()
+
+			// Create test namespace for each entry.
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "jobset-ns-",
+				},
+			}
+			gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+
+			defer func() {
+				gomega.Expect(testutil.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			}()
 
 			// Create JobSet.
 			ginkgo.By("creating jobset")

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -132,7 +132,7 @@ func DeleteNamespace(ctx context.Context, c client.Client, ns *corev1.Namespace)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
-	if err := c.Delete(ctx, ns); err != nil && !apierrors.IsNotFound(err) {
+	if err := c.Delete(ctx, ns, client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Otherwise api-server will reject the nodeSelector update if the job was previously unsuspended then suspended. This unfortunately can't be tested in an integration test because this bug only manifests if we have a job controller

Also fixed the json tag to one of the parameters.