### PR TITLE
Recalculate and update ReplicatedJobsStatuses on last reconciler iteration when all jobs are succeeded

### DIFF
--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -217,7 +217,7 @@ func (r *JobSetReconciler) getChildJobs(ctx context.Context, js *jobset.JobSet) 
 
 		// Jobs with jobset.sigs.k8s.io/restart-attempt == jobset.status.restarts are part of
 		// the current JobSet run, and marked either active, successful, or failed.
-		_, finishedType := jobFinished(&job)
+		_, finishedType := JobFinished(&job)
 		switch finishedType {
 		case "": // active
 			ownedJobs.active = append(ownedJobs.active, &childJobList.Items[i])
@@ -680,7 +680,7 @@ func labelAndAnnotateObject(obj metav1.Object, js *jobset.JobSet, rjob *jobset.R
 	obj.SetAnnotations(annotations)
 }
 
-func jobFinished(job *batchv1.Job) (bool, batchv1.JobConditionType) {
+func JobFinished(job *batchv1.Job) (bool, batchv1.JobConditionType) {
 	for _, c := range job.Status.Conditions {
 		if (c.Type == batchv1.JobComplete || c.Type == batchv1.JobFailed) && c.Status == corev1.ConditionTrue {
 			return true, c.Type

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -98,6 +98,12 @@ func (r *JobSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, err
 	}
 
+	// Calculate JobsReady and update statuses for each ReplicatedJob
+	if err := r.calculateAndUpdateReplicatedJobsStatuses(ctx, &js, ownedJobs); err != nil {
+		log.Error(err, "updating replicated jobs statuses")
+		return ctrl.Result{}, err
+	}
+
 	// If JobSet is already completed or failed, clean up active child jobs.
 	if jobSetFinished(&js) {
 		if err := r.deleteJobs(ctx, ownedJobs.active); err != nil {
@@ -153,12 +159,6 @@ func (r *JobSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			log.Error(err, "resuming jobset")
 			return ctrl.Result{}, err
 		}
-	}
-
-	// Calculate JobsReady and update statuses for each ReplicatedJob
-	if err := r.calculateAndUpdateReplicatedJobsStatuses(ctx, &js, ownedJobs); err != nil {
-		log.Error(err, "updating replicated jobs statuses")
-		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -96,7 +96,7 @@ func TestIsJobFinished(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			finished, conditionType := jobFinished(&batchv1.Job{
+			finished, conditionType := JobFinished(&batchv1.Job{
 				Status: batchv1.JobStatus{
 					Conditions: tc.conditions,
 				},

--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -672,19 +672,12 @@ func numExpectedServices(js *jobset.JobSet) int {
 func completeAllJobs(jobList *batchv1.JobList) {
 	ginkgo.By("completing all jobs")
 	for _, job := range jobList.Items {
-		updateJobStatusConditions(&job, batchv1.JobStatus{
-			Succeeded: int32(len(jobList.Items)),
-			Conditions: append(job.Status.Conditions, batchv1.JobCondition{
-				Type:   batchv1.JobComplete,
-				Status: corev1.ConditionTrue,
-			}),
-		})
+		completeJob(&job)
 	}
 }
 
 func completeJob(job *batchv1.Job) {
 	updateJobStatusConditions(job, batchv1.JobStatus{
-		Succeeded: 1,
 		Conditions: append(job.Status.Conditions, batchv1.JobCondition{
 			Type:   batchv1.JobComplete,
 			Status: corev1.ConditionTrue,
@@ -705,7 +698,6 @@ func updateJobStatusConditions(job *batchv1.Job, status batchv1.JobStatus) {
 
 func failJob(job *batchv1.Job) {
 	updateJobStatusConditions(job, batchv1.JobStatus{
-		Failed: 1,
 		Conditions: append(job.Status.Conditions, batchv1.JobCondition{
 			Type:   batchv1.JobFailed,
 			Status: corev1.ConditionTrue,

--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -521,6 +521,23 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 				},
 			},
 		}),
+		ginkgo.Entry("update replicatedJobsStatuses after all jobs succeed", &testCase{
+			makeJobSet: testJobSet,
+			updates: []*update{
+				{
+					jobUpdateFn:          completeAllJobs,
+					checkJobSetCondition: testutil.JobSetCompleted,
+				},
+				{
+					checkJobSetState: func(js *jobset.JobSet) {
+						gomega.Eventually(func() bool {
+							gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: js.Name, Namespace: js.Namespace}, js)).To(gomega.Succeed())
+							return checkJobSetReplicatedJobsStatus(js)
+						}, timeout, interval).Should(gomega.Equal(true))
+					},
+				},
+			},
+		}),
 		ginkgo.Entry("jobset replicatedJobsStatuses should create and update", &testCase{
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
 				return testJobSet(ns).Suspend(false)
@@ -600,7 +617,14 @@ func makeAllJobsReady(jl *batchv1.JobList) {
 func checkJobSetReplicatedJobsStatus(js *jobset.JobSet) bool {
 	var jobList batchv1.JobList
 	gomega.Eventually(k8sClient.List(ctx, &jobList, client.InNamespace(js.Namespace))).Should(gomega.Succeed())
-	readyJobs := map[string]int32{}
+	jobsStatuses := map[string]map[string]int32{}
+	for _, job := range jobList.Items {
+		jobsStatuses[job.Labels[jobset.ReplicatedJobNameKey]] = map[string]int32{
+			"ready":     0,
+			"succeeded": 0,
+			"failed":    0,
+		}
+	}
 	for _, job := range jobList.Items {
 		ready := pointer.Int32Deref(job.Status.Ready, 0)
 		// parallelism is always set as it is otherwise defaulted by k8s to 1
@@ -608,17 +632,32 @@ func checkJobSetReplicatedJobsStatus(js *jobset.JobSet) bool {
 		if job.Spec.Completions != nil && *job.Spec.Completions < podsCount {
 			podsCount = *job.Spec.Completions
 		}
+
+		if isFinished, conditionType := controllers.JobFinished(&job); isFinished && conditionType == batchv1.JobComplete {
+			jobsStatuses[job.Labels[jobset.ReplicatedJobNameKey]]["succeeded"]++
+			continue
+		}
+
+		if isFinished, conditionType := controllers.JobFinished(&job); isFinished && conditionType == batchv1.JobFailed {
+			jobsStatuses[job.Labels[jobset.ReplicatedJobNameKey]]["failed"]++
+			continue
+		}
+
 		if job.Status.Succeeded+ready >= podsCount {
 			if job.Labels != nil && job.Labels[jobset.ReplicatedJobNameKey] != "" {
-				readyJobs[job.Labels[jobset.ReplicatedJobNameKey]]++
+				jobsStatuses[job.Labels[jobset.ReplicatedJobNameKey]]["ready"]++
 			}
 		}
 	}
-	readyJobsStatus := map[string]int32{}
+	replicatedJobsStatuses := map[string]map[string]int32{}
 	for _, replicatedJobStatus := range js.Status.ReplicatedJobsStatus {
-		readyJobsStatus[replicatedJobStatus.Name] = replicatedJobStatus.Ready
+		replicatedJobsStatuses[replicatedJobStatus.Name] = map[string]int32{
+			"ready":     replicatedJobStatus.Ready,
+			"succeeded": replicatedJobStatus.Succeeded,
+			"failed":    replicatedJobStatus.Failed,
+		}
 	}
-	return apiequality.Semantic.DeepEqual(readyJobs, readyJobsStatus)
+	return apiequality.Semantic.DeepEqual(jobsStatuses, replicatedJobsStatuses)
 }
 
 func numExpectedServices(js *jobset.JobSet) int {
@@ -633,39 +672,45 @@ func numExpectedServices(js *jobset.JobSet) int {
 func completeAllJobs(jobList *batchv1.JobList) {
 	ginkgo.By("completing all jobs")
 	for _, job := range jobList.Items {
-		completeJob(&job)
+		updateJobStatusConditions(&job, batchv1.JobStatus{
+			Succeeded: int32(len(jobList.Items)),
+			Conditions: append(job.Status.Conditions, batchv1.JobCondition{
+				Type:   batchv1.JobComplete,
+				Status: corev1.ConditionTrue,
+			}),
+		})
 	}
 }
 
 func completeJob(job *batchv1.Job) {
-	ginkgo.By(fmt.Sprintf("completing job: %s", job.Name))
+	updateJobStatusConditions(job, batchv1.JobStatus{
+		Succeeded: 1,
+		Conditions: append(job.Status.Conditions, batchv1.JobCondition{
+			Type:   batchv1.JobComplete,
+			Status: corev1.ConditionTrue,
+		}),
+	})
+}
+
+func updateJobStatusConditions(job *batchv1.Job, status batchv1.JobStatus) {
 	gomega.Eventually(func() error {
 		var jobGet batchv1.Job
 		if err := k8sClient.Get(ctx, types.NamespacedName{Name: job.Name, Namespace: job.Namespace}, &jobGet); err != nil {
 			return err
 		}
-		jobGet.Status.Conditions = append(jobGet.Status.Conditions, batchv1.JobCondition{
-			Type:   batchv1.JobComplete,
-			Status: corev1.ConditionTrue,
-		})
+		jobGet.Status = status
 		return k8sClient.Status().Update(ctx, &jobGet)
 	}, timeout, interval).Should(gomega.Succeed())
-
 }
 
 func failJob(job *batchv1.Job) {
-	ginkgo.By(fmt.Sprintf("failing job: %s", job.Name))
-	gomega.Eventually(func() error {
-		var jobGet batchv1.Job
-		if err := k8sClient.Get(ctx, types.NamespacedName{Name: job.Name, Namespace: job.Namespace}, &jobGet); err != nil {
-			return err
-		}
-		jobGet.Status.Conditions = append(jobGet.Status.Conditions, batchv1.JobCondition{
+	updateJobStatusConditions(job, batchv1.JobStatus{
+		Failed: 1,
+		Conditions: append(job.Status.Conditions, batchv1.JobCondition{
 			Type:   batchv1.JobFailed,
 			Status: corev1.ConditionTrue,
-		})
-		return k8sClient.Status().Update(ctx, &jobGet)
-	}, timeout, interval).Should(gomega.Succeed())
+		}),
+	})
 }
 
 func suspendJobSet(js *jobset.JobSet, suspend bool) {


### PR DESCRIPTION
What would you like to be added:
ReplicatedJobsStatuses on last reconciler iteration when all jobs are succeeded

Why is this needed:
On last reconciler iteration when all jobs are succeeded, the ReplicatedJobsStatuses is not recalculated.

fix #180 