### PR TITLE
update subdomain tests

### DIFF
--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -524,7 +524,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			name: "pod dns hostnames enabled",
 			js: testutils.MakeJobSet(jobSetName, ns).
 				EnableDNSHostnames(true).
-				Subdomain(jobSetName).
+				NetworkSubdomain(jobSetName).
 				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName).
 					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
 					Subdomain(jobSetName).
@@ -549,7 +549,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			js: testutils.MakeJobSet(jobSetName, ns).
 				Suspend(true).
 				EnableDNSHostnames(true).
-				Subdomain(jobSetName).
+				NetworkSubdomain(jobSetName).
 				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName).
 					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
 					Subdomain(jobSetName).
@@ -574,7 +574,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			js: testutils.MakeJobSet(jobSetName, ns).
 				Suspend(false).
 				EnableDNSHostnames(true).
-				Subdomain(jobSetName).
+				NetworkSubdomain(jobSetName).
 				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName).
 					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
 					Subdomain(jobSetName).

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -72,12 +72,6 @@ func (j *JobSetWrapper) SetAnnotations(annotations map[string]string) *JobSetWra
 	return j
 }
 
-// Subdomain sets the JobSet Network subdomain.
-func (j *JobSetWrapper) Subdomain(subdomain string) *JobSetWrapper {
-	j.Spec.Network.Subdomain = subdomain
-	return j
-}
-
 // Obj returns the inner JobSet.
 func (j *JobSetWrapper) Obj() *jobset.JobSet {
 	return &j.JobSet

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -146,9 +146,6 @@ func pingTestJobSet(ns *corev1.Namespace) *testing.JobSetWrapper {
 	cmd := getPingCommand(podHostnames)
 	return testing.MakeJobSet(jsName, ns.Name).
 		EnableDNSHostnames(true).
-		NetworkSubdomain(jsName).
-		// We have to explicitly set it since the webhook does not work
-		Subdomain(jsName).
 		ReplicatedJob(testing.MakeReplicatedJob(rjobName).
 			Job(testing.MakeJobTemplate("job", ns.Name).
 				PodSpec(corev1.PodSpec{
@@ -184,13 +181,10 @@ func pingTestJobSetSubdomain(ns *corev1.Namespace) *testing.JobSetWrapper {
 	return testing.MakeJobSet(jsName, ns.Name).
 		EnableDNSHostnames(true).
 		NetworkSubdomain(subdomain).
-		// We have to explicitly set it since the webhook does not work
-		Subdomain(subdomain).
 		ReplicatedJob(testing.MakeReplicatedJob(rjobName).
 			Job(testing.MakeJobTemplate("job", ns.Name).
 				PodSpec(corev1.PodSpec{
 					RestartPolicy: "Never",
-					Subdomain:     subdomain,
 					Containers: []corev1.Container{
 						{
 							Name:    "ping-test-container",

--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -807,7 +807,7 @@ func testJobSet(ns *corev1.Namespace) *testing.JobSetWrapper {
 	return testing.MakeJobSet(jobSetName, ns.Name).
 		SuccessPolicy(&jobset.SuccessPolicy{Operator: jobset.OperatorAll, TargetReplicatedJobs: []string{}}).
 		EnableDNSHostnames(true).
-		Subdomain(jobSetName).
+		NetworkSubdomain(jobSetName).
 		ReplicatedJob(testing.MakeReplicatedJob("replicated-job-a").
 			Job(testing.MakeJobTemplate("test-job-A", ns.Name).PodSpec(testing.TestPodSpec).Obj()).
 			Replicas(1).


### PR DESCRIPTION
Problem: there are duplicated attributes for subdomain/networksubdomain, and setting the subdomain on the result should be done by the JobSet. 

Solution: remove the duplicate (subdomain) and manual setting.

This should hopefully help with https://github.com/kubernetes-sigs/jobset/pull/181 if the issue is related!