### PR TITLE
fix python sdk generation script for python 310

### DIFF
--- a/hack/python-sdk/post_gen.py
+++ b/hack/python-sdk/post_gen.py
@@ -109,7 +109,7 @@ def add_imports() -> None:
         f.writelines(new_lines)
 
 
-def _apply_regex(replacements: list[tuple[str, str]], input_str: str) -> str:
+def _apply_regex(replacements, input_str: str) -> str:
     for pattern, replacement in replacements:
         input_str = re.sub(pattern, replacement, input_str)
     return input_str


### PR DESCRIPTION
The typing required 3.10 and we realize that it could be relaxed.