### PR TITLE
Fix openapi spec generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ code-generator:
 
 .PHONY: openapi-gen
 openapi-gen:
-	GO111MODULE=on $(GO_CMD) install k8s.io/code-generator/cmd/openapi-gen@latest
+	@GOBIN=$(PROJECT_DIR)/bin GO111MODULE=on $(GO_CMD) install k8s.io/code-generator/cmd/openapi-gen@latest
 	openapi-gen --go-header-file hack/boilerplate.go.txt -i sigs.k8s.io/jobset/api/jobset/v1alpha2 -p sigs.k8s.io/jobset/api/jobset/v1alpha2 --alsologtostderr
 
 .PHONY: envtest

--- a/Makefile
+++ b/Makefile
@@ -222,12 +222,7 @@ code-generator:
 
 .PHONY: openapi-gen
 openapi-gen:
-	$(shell mkdir -p $(PROJECT_DIR)/bin)
 	@GOBIN=$(PROJECT_DIR)/bin GO111MODULE=on $(GO_CMD) install k8s.io/code-generator/cmd/openapi-gen@latest
-	echo "$(GOPATH)"
-	ls "$(GOPATH)"
-	echo $(PROJECT_DIR)
-	ls "$(PROJECT_DIR)/bin"
 	$(PROJECT_DIR)/bin/openapi-gen --go-header-file hack/boilerplate.go.txt -i sigs.k8s.io/jobset/api/jobset/v1alpha2 -p sigs.k8s.io/jobset/api/jobset/v1alpha2 --alsologtostderr
 
 .PHONY: envtest

--- a/Makefile
+++ b/Makefile
@@ -222,8 +222,13 @@ code-generator:
 
 .PHONY: openapi-gen
 openapi-gen:
+	$(shell mkdir -p $(PROJECT_DIR)/bin)
 	@GOBIN=$(PROJECT_DIR)/bin GO111MODULE=on $(GO_CMD) install k8s.io/code-generator/cmd/openapi-gen@latest
-	openapi-gen --go-header-file hack/boilerplate.go.txt -i sigs.k8s.io/jobset/api/jobset/v1alpha2 -p sigs.k8s.io/jobset/api/jobset/v1alpha2 --alsologtostderr
+	echo "$(GOPATH)"
+	ls "$(GOPATH)"
+	echo $(PROJECT_DIR)
+	ls "$(PROJECT_DIR)/bin"
+	$(PROJECT_DIR)/bin/openapi-gen --go-header-file hack/boilerplate.go.txt -i sigs.k8s.io/jobset/api/jobset/v1alpha2 -p sigs.k8s.io/jobset/api/jobset/v1alpha2 --alsologtostderr
 
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.

--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,8 @@ code-generator:
 
 .PHONY: openapi-gen
 openapi-gen:
-	@GOBIN=$(PROJECT_DIR)/bin GO111MODULE=on $(GO_CMD) install k8s.io/code-generator/cmd/openapi-gen@$(CODEGEN_VERSION)
+	GO111MODULE=on $(GO_CMD) install k8s.io/code-generator/cmd/openapi-gen@latest
+	openapi-gen --go-header-file hack/boilerplate.go.txt -i sigs.k8s.io/jobset/api/jobset/v1alpha2 -p sigs.k8s.io/jobset/api/jobset/v1alpha2 --alsologtostderr
 
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.

--- a/api/jobset/v1alpha2/openapi_generated.go
+++ b/api/jobset/v1alpha2/openapi_generated.go
@@ -182,6 +182,12 @@ func schema_jobset_api_jobset_v1alpha2_JobSetSpec(ref common.ReferenceCallback) 
 							},
 						},
 					},
+					"network": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Network defines the networking options for the jobset.",
+							Ref:         ref("sigs.k8s.io/jobset/api/jobset/v1alpha2.Network"),
+						},
+					},
 					"successPolicy": {
 						SchemaProps: spec.SchemaProps{
 							Description: "SuccessPolicy configures when to declare the JobSet as succeeded. The JobSet is always declared succeeded if all jobs in the set finished with status complete.",
@@ -205,7 +211,7 @@ func schema_jobset_api_jobset_v1alpha2_JobSetSpec(ref common.ReferenceCallback) 
 			},
 		},
 		Dependencies: []string{
-			"sigs.k8s.io/jobset/api/jobset/v1alpha2.FailurePolicy", "sigs.k8s.io/jobset/api/jobset/v1alpha2.ReplicatedJob", "sigs.k8s.io/jobset/api/jobset/v1alpha2.SuccessPolicy"},
+			"sigs.k8s.io/jobset/api/jobset/v1alpha2.FailurePolicy", "sigs.k8s.io/jobset/api/jobset/v1alpha2.Network", "sigs.k8s.io/jobset/api/jobset/v1alpha2.ReplicatedJob", "sigs.k8s.io/jobset/api/jobset/v1alpha2.SuccessPolicy"},
 	}
 }
 
@@ -282,8 +288,15 @@ func schema_jobset_api_jobset_v1alpha2_Network(ref common.ReferenceCallback) com
 				Properties: map[string]spec.Schema{
 					"enableDNSHostnames": {
 						SchemaProps: spec.SchemaProps{
-							Description: "EnableDNSHostnames allows pods to be reached via their hostnames. Pods will be reachable using the fully qualified pod hostname, which is in the format: <jobSet.name>-<spec.replicatedJob.name>-<job-index>-<pod-index>.<jobSet.name>-<spec.replicatedJob.name>",
+							Description: "EnableDNSHostnames allows pods to be reached via their hostnames. Pods will be reachable using the fully qualified pod hostname: <jobSet.name>-<spec.replicatedJob.name>-<job-index>-<pod-index>.<subdomain>",
 							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"subdomain": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Subdomain is an explicit choice for a network subdomain name When set, any replicated job in the set is added to this network. Defaults to <jobSet.name> if not set.",
+							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
@@ -314,12 +327,6 @@ func schema_jobset_api_jobset_v1alpha2_ReplicatedJob(ref common.ReferenceCallbac
 							Ref:         ref("k8s.io/api/batch/v1.JobTemplateSpec"),
 						},
 					},
-					"network": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Network defines the networking options for the job.",
-							Ref:         ref("sigs.k8s.io/jobset/api/jobset/v1alpha2.Network"),
-						},
-					},
 					"replicas": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Replicas is the number of jobs that will be created from this ReplicatedJob's template. Jobs names will be in the format: <jobSet.name>-<spec.replicatedJob.name>-<job-index>",
@@ -332,7 +339,7 @@ func schema_jobset_api_jobset_v1alpha2_ReplicatedJob(ref common.ReferenceCallbac
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/batch/v1.JobTemplateSpec", "sigs.k8s.io/jobset/api/jobset/v1alpha2.Network"},
+			"k8s.io/api/batch/v1.JobTemplateSpec"},
 	}
 }
 
@@ -371,8 +378,15 @@ func schema_jobset_api_jobset_v1alpha2_ReplicatedJobStatus(ref common.ReferenceC
 							Format:  "int32",
 						},
 					},
+					"active": {
+						SchemaProps: spec.SchemaProps{
+							Default: 0,
+							Type:    []string{"integer"},
+							Format:  "int32",
+						},
+					},
 				},
-				Required: []string{"name", "ready", "succeeded", "failed"},
+				Required: []string{"name", "ready", "succeeded", "failed", "active"},
 			},
 		},
 	}

--- a/hack/python-sdk/swagger.json
+++ b/hack/python-sdk/swagger.json
@@ -79,6 +79,10 @@
           "description": "FailurePolicy, if set, configures when to declare the JobSet as failed. The JobSet is always declared failed if all jobs in the set finished with status failed.",
           "$ref": "#/definitions/jobset.v1alpha2.FailurePolicy"
         },
+        "network": {
+          "description": "Network defines the networking options for the jobset.",
+          "$ref": "#/definitions/jobset.v1alpha2.Network"
+        },
         "replicatedJobs": {
           "description": "ReplicatedJobs is the group of jobs that will form the set.",
           "type": "array",
@@ -139,8 +143,12 @@
       "type": "object",
       "properties": {
         "enableDNSHostnames": {
-          "description": "EnableDNSHostnames allows pods to be reached via their hostnames. Pods will be reachable using the fully qualified pod hostname, which is in the format: \u003cjobSet.name\u003e-\u003cspec.replicatedJob.name\u003e-\u003cjob-index\u003e-\u003cpod-index\u003e.\u003cjobSet.name\u003e-\u003cspec.replicatedJob.name\u003e",
+          "description": "EnableDNSHostnames allows pods to be reached via their hostnames. Pods will be reachable using the fully qualified pod hostname: \u003cjobSet.name\u003e-\u003cspec.replicatedJob.name\u003e-\u003cjob-index\u003e-\u003cpod-index\u003e.\u003csubdomain\u003e",
           "type": "boolean"
+        },
+        "subdomain": {
+          "description": "Subdomain is an explicit choice for a network subdomain name When set, any replicated job in the set is added to this network. Defaults to \u003cjobSet.name\u003e if not set.",
+          "type": "string"
         }
       }
     },
@@ -155,10 +163,6 @@
           "description": "Name is the name of the entry and will be used as a suffix for the Job name.",
           "type": "string",
           "default": ""
-        },
-        "network": {
-          "description": "Network defines the networking options for the job.",
-          "$ref": "#/definitions/jobset.v1alpha2.Network"
         },
         "replicas": {
           "description": "Replicas is the number of jobs that will be created from this ReplicatedJob's template. Jobs names will be in the format: \u003cjobSet.name\u003e-\u003cspec.replicatedJob.name\u003e-\u003cjob-index\u003e",
@@ -179,9 +183,15 @@
         "name",
         "ready",
         "succeeded",
-        "failed"
+        "failed",
+        "active"
       ],
       "properties": {
+        "active": {
+          "type": "integer",
+          "format": "int32",
+          "default": 0
+        },
         "failed": {
           "type": "integer",
           "format": "int32",

--- a/sdk/python/docs/JobsetV1alpha2JobSetSpec.md
+++ b/sdk/python/docs/JobsetV1alpha2JobSetSpec.md
@@ -5,6 +5,7 @@ JobSetSpec defines the desired state of JobSet
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **failure_policy** | [**JobsetV1alpha2FailurePolicy**](JobsetV1alpha2FailurePolicy.md) |  | [optional] 
+**network** | [**JobsetV1alpha2Network**](JobsetV1alpha2Network.md) |  | [optional] 
 **replicated_jobs** | [**list[JobsetV1alpha2ReplicatedJob]**](JobsetV1alpha2ReplicatedJob.md) | ReplicatedJobs is the group of jobs that will form the set. | [optional] 
 **success_policy** | [**JobsetV1alpha2SuccessPolicy**](JobsetV1alpha2SuccessPolicy.md) |  | [optional] 
 **suspend** | **bool** | Suspend suspends all running child Jobs when set to true. | [optional] 

--- a/sdk/python/docs/JobsetV1alpha2Network.md
+++ b/sdk/python/docs/JobsetV1alpha2Network.md
@@ -3,7 +3,8 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**enable_dns_hostnames** | **bool** | EnableDNSHostnames allows pods to be reached via their hostnames. Pods will be reachable using the fully qualified pod hostname, which is in the format: &lt;jobSet.name&gt;-&lt;spec.replicatedJob.name&gt;-&lt;job-index&gt;-&lt;pod-index&gt;.&lt;jobSet.name&gt;-&lt;spec.replicatedJob.name&gt; | [optional] 
+**enable_dns_hostnames** | **bool** | EnableDNSHostnames allows pods to be reached via their hostnames. Pods will be reachable using the fully qualified pod hostname: &lt;jobSet.name&gt;-&lt;spec.replicatedJob.name&gt;-&lt;job-index&gt;-&lt;pod-index&gt;.&lt;subdomain&gt; | [optional] 
+**subdomain** | **str** | Subdomain is an explicit choice for a network subdomain name When set, any replicated job in the set is added to this network. Defaults to &lt;jobSet.name&gt; if not set. | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/sdk/python/docs/JobsetV1alpha2ReplicatedJob.md
+++ b/sdk/python/docs/JobsetV1alpha2ReplicatedJob.md
@@ -4,7 +4,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **str** | Name is the name of the entry and will be used as a suffix for the Job name. | [default to '']
-**network** | [**JobsetV1alpha2Network**](JobsetV1alpha2Network.md) |  | [optional] 
 **replicas** | **int** | Replicas is the number of jobs that will be created from this ReplicatedJob&#39;s template. Jobs names will be in the format: &lt;jobSet.name&gt;-&lt;spec.replicatedJob.name&gt;-&lt;job-index&gt; | [optional] 
 **template** | [**V1JobTemplateSpec**](V1JobTemplateSpec.md) |  | 
 

--- a/sdk/python/docs/JobsetV1alpha2ReplicatedJobStatus.md
+++ b/sdk/python/docs/JobsetV1alpha2ReplicatedJobStatus.md
@@ -4,6 +4,7 @@ ReplicatedJobStatus defines the observed ReplicatedJobs Readiness.
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**active** | **int** |  | [default to 0]
 **failed** | **int** |  | [default to 0]
 **name** | **str** |  | [default to '']
 **ready** | **int** |  | [default to 0]

--- a/sdk/python/jobset/models/jobset_v1alpha2_job_set_spec.py
+++ b/sdk/python/jobset/models/jobset_v1alpha2_job_set_spec.py
@@ -34,6 +34,7 @@ class JobsetV1alpha2JobSetSpec(object):
     """
     openapi_types = {
         'failure_policy': 'JobsetV1alpha2FailurePolicy',
+        'network': 'JobsetV1alpha2Network',
         'replicated_jobs': 'list[JobsetV1alpha2ReplicatedJob]',
         'success_policy': 'JobsetV1alpha2SuccessPolicy',
         'suspend': 'bool'
@@ -41,18 +42,20 @@ class JobsetV1alpha2JobSetSpec(object):
 
     attribute_map = {
         'failure_policy': 'failurePolicy',
+        'network': 'network',
         'replicated_jobs': 'replicatedJobs',
         'success_policy': 'successPolicy',
         'suspend': 'suspend'
     }
 
-    def __init__(self, failure_policy=None, replicated_jobs=None, success_policy=None, suspend=None, local_vars_configuration=None):  # noqa: E501
+    def __init__(self, failure_policy=None, network=None, replicated_jobs=None, success_policy=None, suspend=None, local_vars_configuration=None):  # noqa: E501
         """JobsetV1alpha2JobSetSpec - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()
         self.local_vars_configuration = local_vars_configuration
 
         self._failure_policy = None
+        self._network = None
         self._replicated_jobs = None
         self._success_policy = None
         self._suspend = None
@@ -60,6 +63,8 @@ class JobsetV1alpha2JobSetSpec(object):
 
         if failure_policy is not None:
             self.failure_policy = failure_policy
+        if network is not None:
+            self.network = network
         if replicated_jobs is not None:
             self.replicated_jobs = replicated_jobs
         if success_policy is not None:
@@ -87,6 +92,27 @@ class JobsetV1alpha2JobSetSpec(object):
         """
 
         self._failure_policy = failure_policy
+
+    @property
+    def network(self):
+        """Gets the network of this JobsetV1alpha2JobSetSpec.  # noqa: E501
+
+
+        :return: The network of this JobsetV1alpha2JobSetSpec.  # noqa: E501
+        :rtype: JobsetV1alpha2Network
+        """
+        return self._network
+
+    @network.setter
+    def network(self, network):
+        """Sets the network of this JobsetV1alpha2JobSetSpec.
+
+
+        :param network: The network of this JobsetV1alpha2JobSetSpec.  # noqa: E501
+        :type: JobsetV1alpha2Network
+        """
+
+        self._network = network
 
     @property
     def replicated_jobs(self):

--- a/sdk/python/jobset/models/jobset_v1alpha2_network.py
+++ b/sdk/python/jobset/models/jobset_v1alpha2_network.py
@@ -33,30 +33,35 @@ class JobsetV1alpha2Network(object):
                             and the value is json key in definition.
     """
     openapi_types = {
-        'enable_dns_hostnames': 'bool'
+        'enable_dns_hostnames': 'bool',
+        'subdomain': 'str'
     }
 
     attribute_map = {
-        'enable_dns_hostnames': 'enableDNSHostnames'
+        'enable_dns_hostnames': 'enableDNSHostnames',
+        'subdomain': 'subdomain'
     }
 
-    def __init__(self, enable_dns_hostnames=None, local_vars_configuration=None):  # noqa: E501
+    def __init__(self, enable_dns_hostnames=None, subdomain=None, local_vars_configuration=None):  # noqa: E501
         """JobsetV1alpha2Network - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()
         self.local_vars_configuration = local_vars_configuration
 
         self._enable_dns_hostnames = None
+        self._subdomain = None
         self.discriminator = None
 
         if enable_dns_hostnames is not None:
             self.enable_dns_hostnames = enable_dns_hostnames
+        if subdomain is not None:
+            self.subdomain = subdomain
 
     @property
     def enable_dns_hostnames(self):
         """Gets the enable_dns_hostnames of this JobsetV1alpha2Network.  # noqa: E501
 
-        EnableDNSHostnames allows pods to be reached via their hostnames. Pods will be reachable using the fully qualified pod hostname, which is in the format: <jobSet.name>-<spec.replicatedJob.name>-<job-index>-<pod-index>.<jobSet.name>-<spec.replicatedJob.name>  # noqa: E501
+        EnableDNSHostnames allows pods to be reached via their hostnames. Pods will be reachable using the fully qualified pod hostname: <jobSet.name>-<spec.replicatedJob.name>-<job-index>-<pod-index>.<subdomain>  # noqa: E501
 
         :return: The enable_dns_hostnames of this JobsetV1alpha2Network.  # noqa: E501
         :rtype: bool
@@ -67,13 +72,36 @@ class JobsetV1alpha2Network(object):
     def enable_dns_hostnames(self, enable_dns_hostnames):
         """Sets the enable_dns_hostnames of this JobsetV1alpha2Network.
 
-        EnableDNSHostnames allows pods to be reached via their hostnames. Pods will be reachable using the fully qualified pod hostname, which is in the format: <jobSet.name>-<spec.replicatedJob.name>-<job-index>-<pod-index>.<jobSet.name>-<spec.replicatedJob.name>  # noqa: E501
+        EnableDNSHostnames allows pods to be reached via their hostnames. Pods will be reachable using the fully qualified pod hostname: <jobSet.name>-<spec.replicatedJob.name>-<job-index>-<pod-index>.<subdomain>  # noqa: E501
 
         :param enable_dns_hostnames: The enable_dns_hostnames of this JobsetV1alpha2Network.  # noqa: E501
         :type: bool
         """
 
         self._enable_dns_hostnames = enable_dns_hostnames
+
+    @property
+    def subdomain(self):
+        """Gets the subdomain of this JobsetV1alpha2Network.  # noqa: E501
+
+        Subdomain is an explicit choice for a network subdomain name When set, any replicated job in the set is added to this network. Defaults to <jobSet.name> if not set.  # noqa: E501
+
+        :return: The subdomain of this JobsetV1alpha2Network.  # noqa: E501
+        :rtype: str
+        """
+        return self._subdomain
+
+    @subdomain.setter
+    def subdomain(self, subdomain):
+        """Sets the subdomain of this JobsetV1alpha2Network.
+
+        Subdomain is an explicit choice for a network subdomain name When set, any replicated job in the set is added to this network. Defaults to <jobSet.name> if not set.  # noqa: E501
+
+        :param subdomain: The subdomain of this JobsetV1alpha2Network.  # noqa: E501
+        :type: str
+        """
+
+        self._subdomain = subdomain
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/sdk/python/jobset/models/jobset_v1alpha2_replicated_job.py
+++ b/sdk/python/jobset/models/jobset_v1alpha2_replicated_job.py
@@ -34,33 +34,28 @@ class JobsetV1alpha2ReplicatedJob(object):
     """
     openapi_types = {
         'name': 'str',
-        'network': 'JobsetV1alpha2Network',
         'replicas': 'int',
         'template': 'V1JobTemplateSpec'
     }
 
     attribute_map = {
         'name': 'name',
-        'network': 'network',
         'replicas': 'replicas',
         'template': 'template'
     }
 
-    def __init__(self, name='', network=None, replicas=None, template=None, local_vars_configuration=None):  # noqa: E501
+    def __init__(self, name='', replicas=None, template=None, local_vars_configuration=None):  # noqa: E501
         """JobsetV1alpha2ReplicatedJob - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None
-        self._network = None
         self._replicas = None
         self._template = None
         self.discriminator = None
 
         self.name = name
-        if network is not None:
-            self.network = network
         if replicas is not None:
             self.replicas = replicas
         self.template = template
@@ -89,27 +84,6 @@ class JobsetV1alpha2ReplicatedJob(object):
             raise ValueError("Invalid value for `name`, must not be `None`")  # noqa: E501
 
         self._name = name
-
-    @property
-    def network(self):
-        """Gets the network of this JobsetV1alpha2ReplicatedJob.  # noqa: E501
-
-
-        :return: The network of this JobsetV1alpha2ReplicatedJob.  # noqa: E501
-        :rtype: JobsetV1alpha2Network
-        """
-        return self._network
-
-    @network.setter
-    def network(self, network):
-        """Sets the network of this JobsetV1alpha2ReplicatedJob.
-
-
-        :param network: The network of this JobsetV1alpha2ReplicatedJob.  # noqa: E501
-        :type: JobsetV1alpha2Network
-        """
-
-        self._network = network
 
     @property
     def replicas(self):

--- a/sdk/python/jobset/models/jobset_v1alpha2_replicated_job_status.py
+++ b/sdk/python/jobset/models/jobset_v1alpha2_replicated_job_status.py
@@ -33,6 +33,7 @@ class JobsetV1alpha2ReplicatedJobStatus(object):
                             and the value is json key in definition.
     """
     openapi_types = {
+        'active': 'int',
         'failed': 'int',
         'name': 'str',
         'ready': 'int',
@@ -40,28 +41,54 @@ class JobsetV1alpha2ReplicatedJobStatus(object):
     }
 
     attribute_map = {
+        'active': 'active',
         'failed': 'failed',
         'name': 'name',
         'ready': 'ready',
         'succeeded': 'succeeded'
     }
 
-    def __init__(self, failed=0, name='', ready=0, succeeded=0, local_vars_configuration=None):  # noqa: E501
+    def __init__(self, active=0, failed=0, name='', ready=0, succeeded=0, local_vars_configuration=None):  # noqa: E501
         """JobsetV1alpha2ReplicatedJobStatus - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()
         self.local_vars_configuration = local_vars_configuration
 
+        self._active = None
         self._failed = None
         self._name = None
         self._ready = None
         self._succeeded = None
         self.discriminator = None
 
+        self.active = active
         self.failed = failed
         self.name = name
         self.ready = ready
         self.succeeded = succeeded
+
+    @property
+    def active(self):
+        """Gets the active of this JobsetV1alpha2ReplicatedJobStatus.  # noqa: E501
+
+
+        :return: The active of this JobsetV1alpha2ReplicatedJobStatus.  # noqa: E501
+        :rtype: int
+        """
+        return self._active
+
+    @active.setter
+    def active(self, active):
+        """Sets the active of this JobsetV1alpha2ReplicatedJobStatus.
+
+
+        :param active: The active of this JobsetV1alpha2ReplicatedJobStatus.  # noqa: E501
+        :type: int
+        """
+        if self.local_vars_configuration.client_side_validation and active is None:  # noqa: E501
+            raise ValueError("Invalid value for `active`, must not be `None`")  # noqa: E501
+
+        self._active = active
 
     @property
     def failed(self):

--- a/sdk/python/test/test_jobset_v1alpha2_job_set.py
+++ b/sdk/python/test/test_jobset_v1alpha2_job_set.py
@@ -44,11 +44,12 @@ class TestJobsetV1alpha2JobSet(unittest.TestCase):
                 spec = jobset.models.jobset_v1alpha2_job_set_spec.JobsetV1alpha2JobSetSpec(
                     failure_policy = jobset.models.jobset_v1alpha2_failure_policy.JobsetV1alpha2FailurePolicy(
                         max_restarts = 56, ), 
+                    network = jobset.models.jobset_v1alpha2_network.JobsetV1alpha2Network(
+                        enable_dns_hostnames = True, 
+                        subdomain = '0', ), 
                     replicated_jobs = [
                         jobset.models.jobset_v1alpha2_replicated_job.JobsetV1alpha2ReplicatedJob(
                             name = '0', 
-                            network = jobset.models.jobset_v1alpha2_network.JobsetV1alpha2Network(
-                                enable_dns_hostnames = True, ), 
                             replicas = 56, 
                             template = V1JobTemplateSpec(), )
                         ], 
@@ -61,6 +62,7 @@ class TestJobsetV1alpha2JobSet(unittest.TestCase):
                 status = jobset.models.jobset_v1alpha2_job_set_status.JobsetV1alpha2JobSetStatus(
                     replicated_jobs_status = [
                         jobset.models.jobset_v1alpha2_replicated_job_status.JobsetV1alpha2ReplicatedJobStatus(
+                            active = 56, 
                             failed = 56, 
                             name = '0', 
                             ready = 56, 

--- a/sdk/python/test/test_jobset_v1alpha2_job_set_list.py
+++ b/sdk/python/test/test_jobset_v1alpha2_job_set_list.py
@@ -47,11 +47,12 @@ class TestJobsetV1alpha2JobSetList(unittest.TestCase):
                         spec = jobset.models.jobset_v1alpha2_job_set_spec.JobsetV1alpha2JobSetSpec(
                             failure_policy = jobset.models.jobset_v1alpha2_failure_policy.JobsetV1alpha2FailurePolicy(
                                 max_restarts = 56, ), 
+                            network = jobset.models.jobset_v1alpha2_network.JobsetV1alpha2Network(
+                                enable_dns_hostnames = True, 
+                                subdomain = '0', ), 
                             replicated_jobs = [
                                 jobset.models.jobset_v1alpha2_replicated_job.JobsetV1alpha2ReplicatedJob(
                                     name = '0', 
-                                    network = jobset.models.jobset_v1alpha2_network.JobsetV1alpha2Network(
-                                        enable_dns_hostnames = True, ), 
                                     replicas = 56, 
                                     template = V1JobTemplateSpec(), )
                                 ], 
@@ -64,6 +65,7 @@ class TestJobsetV1alpha2JobSetList(unittest.TestCase):
                         status = jobset.models.jobset_v1alpha2_job_set_status.JobsetV1alpha2JobSetStatus(
                             replicated_jobs_status = [
                                 jobset.models.jobset_v1alpha2_replicated_job_status.JobsetV1alpha2ReplicatedJobStatus(
+                                    active = 56, 
                                     failed = 56, 
                                     name = '0', 
                                     ready = 56, 
@@ -87,11 +89,12 @@ class TestJobsetV1alpha2JobSetList(unittest.TestCase):
                         spec = jobset.models.jobset_v1alpha2_job_set_spec.JobsetV1alpha2JobSetSpec(
                             failure_policy = jobset.models.jobset_v1alpha2_failure_policy.JobsetV1alpha2FailurePolicy(
                                 max_restarts = 56, ), 
+                            network = jobset.models.jobset_v1alpha2_network.JobsetV1alpha2Network(
+                                enable_dns_hostnames = True, 
+                                subdomain = '0', ), 
                             replicated_jobs = [
                                 jobset.models.jobset_v1alpha2_replicated_job.JobsetV1alpha2ReplicatedJob(
                                     name = '0', 
-                                    network = jobset.models.jobset_v1alpha2_network.JobsetV1alpha2Network(
-                                        enable_dns_hostnames = True, ), 
                                     replicas = 56, 
                                     template = V1JobTemplateSpec(), )
                                 ], 
@@ -104,6 +107,7 @@ class TestJobsetV1alpha2JobSetList(unittest.TestCase):
                         status = jobset.models.jobset_v1alpha2_job_set_status.JobsetV1alpha2JobSetStatus(
                             replicated_jobs_status = [
                                 jobset.models.jobset_v1alpha2_replicated_job_status.JobsetV1alpha2ReplicatedJobStatus(
+                                    active = 56, 
                                     failed = 56, 
                                     name = '0', 
                                     ready = 56, 

--- a/sdk/python/test/test_jobset_v1alpha2_job_set_spec.py
+++ b/sdk/python/test/test_jobset_v1alpha2_job_set_spec.py
@@ -40,11 +40,12 @@ class TestJobsetV1alpha2JobSetSpec(unittest.TestCase):
             return JobsetV1alpha2JobSetSpec(
                 failure_policy = jobset.models.jobset_v1alpha2_failure_policy.JobsetV1alpha2FailurePolicy(
                     max_restarts = 56, ), 
+                network = jobset.models.jobset_v1alpha2_network.JobsetV1alpha2Network(
+                    enable_dns_hostnames = True, 
+                    subdomain = '0', ), 
                 replicated_jobs = [
                     jobset.models.jobset_v1alpha2_replicated_job.JobsetV1alpha2ReplicatedJob(
                         name = '0', 
-                        network = jobset.models.jobset_v1alpha2_network.JobsetV1alpha2Network(
-                            enable_dns_hostnames = True, ), 
                         replicas = 56, 
                         template = V1JobTemplateSpec(), )
                     ], 

--- a/sdk/python/test/test_jobset_v1alpha2_job_set_status.py
+++ b/sdk/python/test/test_jobset_v1alpha2_job_set_status.py
@@ -40,6 +40,7 @@ class TestJobsetV1alpha2JobSetStatus(unittest.TestCase):
             return JobsetV1alpha2JobSetStatus(
                 replicated_jobs_status = [
                     jobset.models.jobset_v1alpha2_replicated_job_status.JobsetV1alpha2ReplicatedJobStatus(
+                        active = 56, 
                         failed = 56, 
                         name = '0', 
                         ready = 56, 

--- a/sdk/python/test/test_jobset_v1alpha2_network.py
+++ b/sdk/python/test/test_jobset_v1alpha2_network.py
@@ -38,7 +38,8 @@ class TestJobsetV1alpha2Network(unittest.TestCase):
         # model = jobset.models.jobset_v1alpha2_network.JobsetV1alpha2Network()  # noqa: E501
         if include_optional :
             return JobsetV1alpha2Network(
-                enable_dns_hostnames = True
+                enable_dns_hostnames = True, 
+                subdomain = '0'
             )
         else :
             return JobsetV1alpha2Network(

--- a/sdk/python/test/test_jobset_v1alpha2_replicated_job.py
+++ b/sdk/python/test/test_jobset_v1alpha2_replicated_job.py
@@ -39,8 +39,6 @@ class TestJobsetV1alpha2ReplicatedJob(unittest.TestCase):
         if include_optional :
             return JobsetV1alpha2ReplicatedJob(
                 name = '0', 
-                network = jobset.models.jobset_v1alpha2_network.JobsetV1alpha2Network(
-                    enable_dns_hostnames = True, ), 
                 replicas = 56, 
                 template = V1JobTemplateSpec()
             )

--- a/sdk/python/test/test_jobset_v1alpha2_replicated_job_status.py
+++ b/sdk/python/test/test_jobset_v1alpha2_replicated_job_status.py
@@ -38,6 +38,7 @@ class TestJobsetV1alpha2ReplicatedJobStatus(unittest.TestCase):
         # model = jobset.models.jobset_v1alpha2_replicated_job_status.JobsetV1alpha2ReplicatedJobStatus()  # noqa: E501
         if include_optional :
             return JobsetV1alpha2ReplicatedJobStatus(
+                active = 56, 
                 failed = 56, 
                 name = '0', 
                 ready = 56, 
@@ -45,6 +46,7 @@ class TestJobsetV1alpha2ReplicatedJobStatus(unittest.TestCase):
             )
         else :
             return JobsetV1alpha2ReplicatedJobStatus(
+                active = 56,
                 failed = 56,
                 name = '0',
                 ready = 56,


### PR DESCRIPTION
Fixes #205 

Makefile was installing the `openapi-gen` command line tool but not executing it anywhere to generate the OpenAPI spec (openapi_generated.go file).