### PR TITLE
Remove generate target from build, run and test targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ vet: ## Run go vet against code.
 	$(GO_CMD) vet ./...
 
 .PHONY: test
-test: manifests generate fmt vet envtest gotestsum test-python-sdk
+test: manifests fmt vet envtest gotestsum test-python-sdk
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GOTESTSUM) --junitfile $(ARTIFACTS)/junit.xml -- ./pkg/... ./api/... -coverprofile  $(ARTIFACTS)/cover.out
 
 .PHONY: test-python-sdk
@@ -125,11 +125,11 @@ verify: vet fmt-verify manifests generate
 ##@ Build
 
 .PHONY: build
-build: manifests generate fmt vet ## Build manager binary.
+build: manifests fmt vet ## Build manager binary.
 	$(GO_CMD) build -o bin/manager main.go
 
 .PHONY: run
-run: manifests generate fmt vet ## Run a controller from your host.
+run: manifests fmt vet ## Run a controller from your host.
 	$(GO_CMD) run ./main.go
 
 # Build the container image
@@ -246,12 +246,12 @@ kind-image-build: IMAGE_BUILD_EXTRA_OPTS=--load
 kind-image-build: kind image-build
 
 .PHONY: test-integration
-test-integration: manifests generate fmt vet envtest ginkgo ## Run tests.
+test-integration: manifests fmt vet envtest ginkgo ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" \
 	$(GINKGO) --junit-report=junit.xml --output-dir=$(ARTIFACTS) -v $(INTEGRATION_TARGET)
 
 .PHONY: test-e2e-kind
-test-e2e-kind: manifests generate kustomize fmt vet envtest ginkgo kind-image-build
+test-e2e-kind: manifests kustomize fmt vet envtest ginkgo kind-image-build
 	E2E_KIND_VERSION=$(E2E_KIND_VERSION) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) ARTIFACTS=$(ARTIFACTS) IMAGE_TAG=$(IMAGE_TAG) ./hack/e2e-test.sh
 
 .PHONY: prometheus


### PR DESCRIPTION
Addresses https://github.com/kubernetes-sigs/jobset/issues/222

This patch removes `generate` target from `build`, `run` and `test` targets.