### PR TITLE
add an example for success policy

### DIFF
--- a/examples/simple/driver-worker-success-policy.yaml
+++ b/examples/simple/driver-worker-success-policy.yaml
@@ -3,7 +3,7 @@ kind: JobSet
 metadata:
   name: success-policy
 spec:
-# We want to declare our JobSet successful if workers finish
+# We want to declare our JobSet successful if workers finish.
 # If workers finish we should clean up the remaining replicatedJobs.
   successPolicy:
     operator: All

--- a/examples/simple/driver-worker-success-policy.yaml
+++ b/examples/simple/driver-worker-success-policy.yaml
@@ -1,0 +1,47 @@
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: success-policy
+spec:
+# We want to declare our JobSet successful if workers finish
+# If workers finish we should clean up the other jobsets.
+  successPolicy:
+    operator: All
+    targetReplicatedJobs:
+    - workers
+  replicatedJobs:
+  - name: leader
+    replicas: 1
+    template:
+      spec:
+        # Set backoff limit to 0 so job will immediately fail if any pod fails.
+        backoffLimit: 0 
+        completions: 1
+        parallelism: 1
+        template:
+          spec:
+            containers:
+            - name: leader
+              image: bash:latest
+              command:
+              - bash
+              - -xc
+              - |
+                sleep 10000
+  - name: workers
+    replicas: 1
+    template:
+      spec:
+        backoffLimit: 0 
+        completions: 2
+        parallelism: 2
+        template:
+          spec:
+            containers:
+            - name: worker
+              image: bash:latest
+              command:
+              - bash
+              - -xc
+              - |
+                sleep 10

--- a/examples/simple/driver-worker-success-policy.yaml
+++ b/examples/simple/driver-worker-success-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: success-policy
 spec:
 # We want to declare our JobSet successful if workers finish
-# If workers finish we should clean up the other jobsets.
+# If workers finish we should clean up the remaining replicatedJobs.
   successPolicy:
     operator: All
     targetReplicatedJobs:


### PR DESCRIPTION
In a private conversation with @ahg-g and @danielvegamyhre, we wanted to see if it was possible to have a case where workers finish and then JobSet should terminate the driver.  

This is a simple example to demonstrate using `SuccessPolicy` to achieve this.  I think its a useful example to include in the repo.  