### PR TITLE
add suspend to replicated job status

### DIFF
--- a/api/jobset/v1alpha2/jobset_types.go
+++ b/api/jobset/v1alpha2/jobset_types.go
@@ -95,6 +95,7 @@ type ReplicatedJobStatus struct {
 	Succeeded int32  `json:"succeeded"`
 	Failed    int32  `json:"failed"`
 	Active    int32  `json:"active"`
+	Suspended int32  `json:"suspended"`
 }
 
 // +genclient

--- a/api/jobset/v1alpha2/openapi_generated.go
+++ b/api/jobset/v1alpha2/openapi_generated.go
@@ -385,8 +385,15 @@ func schema_jobset_api_jobset_v1alpha2_ReplicatedJobStatus(ref common.ReferenceC
 							Format:  "int32",
 						},
 					},
+					"suspended": {
+						SchemaProps: spec.SchemaProps{
+							Default: 0,
+							Type:    []string{"integer"},
+							Format:  "int32",
+						},
+					},
 				},
-				Required: []string{"name", "ready", "succeeded", "failed", "active"},
+				Required: []string{"name", "ready", "succeeded", "failed", "active", "suspended"},
 			},
 		},
 	}

--- a/client-go/applyconfiguration/jobset/v1alpha2/replicatedjobstatus.go
+++ b/client-go/applyconfiguration/jobset/v1alpha2/replicatedjobstatus.go
@@ -22,6 +22,7 @@ type ReplicatedJobStatusApplyConfiguration struct {
 	Succeeded *int32  `json:"succeeded,omitempty"`
 	Failed    *int32  `json:"failed,omitempty"`
 	Active    *int32  `json:"active,omitempty"`
+	Suspended *int32  `json:"suspended,omitempty"`
 }
 
 // ReplicatedJobStatusApplyConfiguration constructs an declarative configuration of the ReplicatedJobStatus type for use with
@@ -67,5 +68,13 @@ func (b *ReplicatedJobStatusApplyConfiguration) WithFailed(value int32) *Replica
 // If called multiple times, the Active field is set to the value of the last call.
 func (b *ReplicatedJobStatusApplyConfiguration) WithActive(value int32) *ReplicatedJobStatusApplyConfiguration {
 	b.Active = &value
+	return b
+}
+
+// WithSuspended sets the Suspended field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Suspended field is set to the value of the last call.
+func (b *ReplicatedJobStatusApplyConfiguration) WithSuspended(value int32) *ReplicatedJobStatusApplyConfiguration {
+	b.Suspended = &value
 	return b
 }

--- a/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
+++ b/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
@@ -9723,12 +9723,16 @@ spec:
                     succeeded:
                       format: int32
                       type: integer
+                    suspended:
+                      format: int32
+                      type: integer
                   required:
                   - active
                   - failed
                   - name
                   - ready
                   - succeeded
+                  - suspended
                   type: object
                 type: array
                 x-kubernetes-list-map-keys:

--- a/hack/python-sdk/swagger.json
+++ b/hack/python-sdk/swagger.json
@@ -184,7 +184,8 @@
         "ready",
         "succeeded",
         "failed",
-        "active"
+        "active",
+        "suspended"
       ],
       "properties": {
         "active": {
@@ -207,6 +208,11 @@
           "default": 0
         },
         "succeeded": {
+          "type": "integer",
+          "format": "int32",
+          "default": 0
+        },
+        "suspended": {
           "type": "integer",
           "format": "int32",
           "default": 0

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -252,6 +252,7 @@ func (r *JobSetReconciler) calculateReplicatedJobStatuses(ctx context.Context, j
 			"succeeded": 0,
 			"failed":    0,
 			"active":    0,
+			"suspended": 0,
 		}
 	}
 
@@ -273,6 +274,9 @@ func (r *JobSetReconciler) calculateReplicatedJobStatuses(ctx context.Context, j
 		if job.Status.Active > 0 {
 			replicatedJobsReady[job.Labels[jobset.ReplicatedJobNameKey]]["active"]++
 		}
+		if job.Spec.Suspend != nil && *job.Spec.Suspend {
+			replicatedJobsReady[job.Labels[jobset.ReplicatedJobNameKey]]["suspended"]++
+		}
 	}
 
 	// Calculate succeededJobs
@@ -293,6 +297,7 @@ func (r *JobSetReconciler) calculateReplicatedJobStatuses(ctx context.Context, j
 			Succeeded: status["succeeded"],
 			Failed:    status["failed"],
 			Active:    status["active"],
+			Suspended: status["suspended"],
 		})
 	}
 	return rjStatus

--- a/sdk/python/docs/JobsetV1alpha2ReplicatedJobStatus.md
+++ b/sdk/python/docs/JobsetV1alpha2ReplicatedJobStatus.md
@@ -9,6 +9,7 @@ Name | Type | Description | Notes
 **name** | **str** |  | [default to '']
 **ready** | **int** |  | [default to 0]
 **succeeded** | **int** |  | [default to 0]
+**suspended** | **int** |  | [default to 0]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/sdk/python/jobset/models/jobset_v1alpha2_replicated_job_status.py
+++ b/sdk/python/jobset/models/jobset_v1alpha2_replicated_job_status.py
@@ -37,7 +37,8 @@ class JobsetV1alpha2ReplicatedJobStatus(object):
         'failed': 'int',
         'name': 'str',
         'ready': 'int',
-        'succeeded': 'int'
+        'succeeded': 'int',
+        'suspended': 'int'
     }
 
     attribute_map = {
@@ -45,10 +46,11 @@ class JobsetV1alpha2ReplicatedJobStatus(object):
         'failed': 'failed',
         'name': 'name',
         'ready': 'ready',
-        'succeeded': 'succeeded'
+        'succeeded': 'succeeded',
+        'suspended': 'suspended'
     }
 
-    def __init__(self, active=0, failed=0, name='', ready=0, succeeded=0, local_vars_configuration=None):  # noqa: E501
+    def __init__(self, active=0, failed=0, name='', ready=0, succeeded=0, suspended=0, local_vars_configuration=None):  # noqa: E501
         """JobsetV1alpha2ReplicatedJobStatus - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()
@@ -59,6 +61,7 @@ class JobsetV1alpha2ReplicatedJobStatus(object):
         self._name = None
         self._ready = None
         self._succeeded = None
+        self._suspended = None
         self.discriminator = None
 
         self.active = active
@@ -66,6 +69,7 @@ class JobsetV1alpha2ReplicatedJobStatus(object):
         self.name = name
         self.ready = ready
         self.succeeded = succeeded
+        self.suspended = suspended
 
     @property
     def active(self):
@@ -181,6 +185,29 @@ class JobsetV1alpha2ReplicatedJobStatus(object):
             raise ValueError("Invalid value for `succeeded`, must not be `None`")  # noqa: E501
 
         self._succeeded = succeeded
+
+    @property
+    def suspended(self):
+        """Gets the suspended of this JobsetV1alpha2ReplicatedJobStatus.  # noqa: E501
+
+
+        :return: The suspended of this JobsetV1alpha2ReplicatedJobStatus.  # noqa: E501
+        :rtype: int
+        """
+        return self._suspended
+
+    @suspended.setter
+    def suspended(self, suspended):
+        """Sets the suspended of this JobsetV1alpha2ReplicatedJobStatus.
+
+
+        :param suspended: The suspended of this JobsetV1alpha2ReplicatedJobStatus.  # noqa: E501
+        :type: int
+        """
+        if self.local_vars_configuration.client_side_validation and suspended is None:  # noqa: E501
+            raise ValueError("Invalid value for `suspended`, must not be `None`")  # noqa: E501
+
+        self._suspended = suspended
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/sdk/python/test/test_jobset_v1alpha2_job_set.py
+++ b/sdk/python/test/test_jobset_v1alpha2_job_set.py
@@ -69,7 +69,8 @@ class TestJobsetV1alpha2JobSet(unittest.TestCase):
                             failed = 56, 
                             name = '0', 
                             ready = 56, 
-                            succeeded = 56, )
+                            succeeded = 56, 
+                            suspended = 56, )
                         ], 
                     restarts = 56, )
             )

--- a/sdk/python/test/test_jobset_v1alpha2_job_set_list.py
+++ b/sdk/python/test/test_jobset_v1alpha2_job_set_list.py
@@ -72,7 +72,8 @@ class TestJobsetV1alpha2JobSetList(unittest.TestCase):
                                     failed = 56, 
                                     name = '0', 
                                     ready = 56, 
-                                    succeeded = 56, )
+                                    succeeded = 56, 
+                                    suspended = 56, )
                                 ], 
                             restarts = 56, ), )
                     ], 
@@ -114,7 +115,8 @@ class TestJobsetV1alpha2JobSetList(unittest.TestCase):
                                     failed = 56, 
                                     name = '0', 
                                     ready = 56, 
-                                    succeeded = 56, )
+                                    succeeded = 56, 
+                                    suspended = 56, )
                                 ], 
                             restarts = 56, ), )
                     ],

--- a/sdk/python/test/test_jobset_v1alpha2_job_set_status.py
+++ b/sdk/python/test/test_jobset_v1alpha2_job_set_status.py
@@ -47,7 +47,8 @@ class TestJobsetV1alpha2JobSetStatus(unittest.TestCase):
                         failed = 56, 
                         name = '0', 
                         ready = 56, 
-                        succeeded = 56, )
+                        succeeded = 56, 
+                        suspended = 56, )
                     ], 
                 restarts = 56
             )

--- a/sdk/python/test/test_jobset_v1alpha2_replicated_job_status.py
+++ b/sdk/python/test/test_jobset_v1alpha2_replicated_job_status.py
@@ -42,7 +42,8 @@ class TestJobsetV1alpha2ReplicatedJobStatus(unittest.TestCase):
                 failed = 56, 
                 name = '0', 
                 ready = 56, 
-                succeeded = 56
+                succeeded = 56, 
+                suspended = 56
             )
         else :
             return JobsetV1alpha2ReplicatedJobStatus(
@@ -51,6 +52,7 @@ class TestJobsetV1alpha2ReplicatedJobStatus(unittest.TestCase):
                 name = '0',
                 ready = 56,
                 succeeded = 56,
+                suspended = 56,
         )
 
     def testJobsetV1alpha2ReplicatedJobStatus(self):

--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -18,6 +18,7 @@ package controllertest
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"time"
 
@@ -191,6 +192,18 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 				{
 					jobUpdateFn:          completeAllJobs,
 					checkJobSetCondition: testutil.JobSetCompleted,
+					checkJobSetState: func(js *jobset.JobSet) {
+						matchJobSetReplicatedStatus(js, []jobset.ReplicatedJobStatus{
+							{
+								Name:      "replicated-job-b",
+								Succeeded: 3,
+							},
+							{
+								Name:      "replicated-job-a",
+								Succeeded: 1,
+							},
+						})
+					},
 				},
 			},
 		}),
@@ -203,8 +216,22 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 						for i := 0; i < len(jobList.Items)-1; i++ {
 							completeJob(&jobList.Items[i])
 						}
+						ReadyJob(&jobList.Items[len(jobList.Items)-1])
 					},
 					checkJobSetCondition: testutil.JobSetActive,
+					checkJobSetState: func(js *jobset.JobSet) {
+						matchJobSetReplicatedStatus(js, []jobset.ReplicatedJobStatus{
+							{
+								Name:      "replicated-job-b",
+								Succeeded: 2,
+								Ready:     1,
+							},
+							{
+								Name:      "replicated-job-a",
+								Succeeded: 1,
+							},
+						})
+					},
 				},
 			},
 		}),
@@ -434,6 +461,21 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 					},
 					checkJobSetCondition: testutil.JobSetSuspended,
 				},
+				{
+					checkJobSetState: func(js *jobset.JobSet) {
+						ginkgo.By("Check ReplicatedJobStatus for suspend")
+						matchJobSetReplicatedStatus(js, []jobset.ReplicatedJobStatus{
+							{
+								Name:      "replicated-job-b",
+								Suspended: 3,
+							},
+							{
+								Name:      "replicated-job-a",
+								Suspended: 1,
+							},
+						})
+					},
+				},
 			},
 		}),
 		ginkgo.Entry("resume a suspended jobset", &testCase{
@@ -452,6 +494,19 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 					jobSetUpdateFn: func(js *jobset.JobSet) {
 						updateJobSetNodeSelectors(js, nodeSelectors)
 					},
+					checkJobSetState: func(js *jobset.JobSet) {
+						ginkgo.By("Check ReplicatedJobStatus for suspend")
+						matchJobSetReplicatedStatus(js, []jobset.ReplicatedJobStatus{
+							{
+								Name:      "replicated-job-b",
+								Suspended: 3,
+							},
+							{
+								Name:      "replicated-job-a",
+								Suspended: 1,
+							},
+						})
+					},
 				},
 				{
 					jobSetUpdateFn: func(js *jobset.JobSet) {
@@ -469,6 +524,20 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 					},
 					jobUpdateFn:          completeAllJobs,
 					checkJobSetCondition: testutil.JobSetCompleted,
+				},
+				{
+					checkJobSetState: func(js *jobset.JobSet) {
+						matchJobSetReplicatedStatus(js, []jobset.ReplicatedJobStatus{
+							{
+								Name:      "replicated-job-b",
+								Succeeded: 3,
+							},
+							{
+								Name:      "replicated-job-a",
+								Succeeded: 1,
+							},
+						})
+					},
 				},
 			},
 		}),
@@ -671,7 +740,7 @@ func completeAllJobs(jobList *batchv1.JobList) {
 }
 
 func completeJob(job *batchv1.Job) {
-	updateJobStatusConditions(job, batchv1.JobStatus{
+	updateJobStatus(job, batchv1.JobStatus{
 		Conditions: append(job.Status.Conditions, batchv1.JobCondition{
 			Type:   batchv1.JobComplete,
 			Status: corev1.ConditionTrue,
@@ -679,7 +748,13 @@ func completeJob(job *batchv1.Job) {
 	})
 }
 
-func updateJobStatusConditions(job *batchv1.Job, status batchv1.JobStatus) {
+func ReadyJob(job *batchv1.Job) {
+	updateJobStatus(job, batchv1.JobStatus{
+		Ready: job.Spec.Parallelism,
+	})
+}
+
+func updateJobStatus(job *batchv1.Job, status batchv1.JobStatus) {
 	gomega.Eventually(func() error {
 		var jobGet batchv1.Job
 		if err := k8sClient.Get(ctx, types.NamespacedName{Name: job.Name, Namespace: job.Namespace}, &jobGet); err != nil {
@@ -691,7 +766,7 @@ func updateJobStatusConditions(job *batchv1.Job, status batchv1.JobStatus) {
 }
 
 func failJob(job *batchv1.Job) {
-	updateJobStatusConditions(job, batchv1.JobStatus{
+	updateJobStatus(job, batchv1.JobStatus{
 		Conditions: append(job.Status.Conditions, batchv1.JobCondition{
 			Type:   batchv1.JobFailed,
 			Status: corev1.ConditionTrue,
@@ -828,6 +903,22 @@ func jobActive(job *batchv1.Job) bool {
 		}
 	}
 	return active
+}
+
+func matchJobSetReplicatedStatus(js *jobset.JobSet, expectedStatus []jobset.ReplicatedJobStatus) {
+	gomega.Eventually(func() ([]jobset.ReplicatedJobStatus, error) {
+		newJs := jobset.JobSet{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: js.Name, Namespace: js.Namespace}, &newJs); err != nil {
+			return nil, err
+		}
+		// ReplicatedStatus is a map and we are not guaranteed to have same order from run to run.
+		// This sort allows us to compare statuses consistently.
+		compareNames := func(i, j int) bool {
+			return newJs.Status.ReplicatedJobsStatus[i].Name > newJs.Status.ReplicatedJobsStatus[j].Name
+		}
+		sort.Slice(newJs.Status.ReplicatedJobsStatus, compareNames)
+		return newJs.Status.ReplicatedJobsStatus, nil
+	}, timeout, interval).Should(gomega.BeComparableTo(expectedStatus))
 }
 
 // 2 replicated jobs:


### PR DESCRIPTION
As part of #244, I think adding a status field for suspend would be helpful if we go this route.  

I added a field for suspend and updated a few of our tests to directly compare against status field.  