### PR TITLE
Automated cherry pick of #248: add patch rbac for events

### DIFF
--- a/config/components/rbac/role.yaml
+++ b/config/components/rbac/role.yaml
@@ -10,6 +10,7 @@ rules:
   - events
   verbs:
   - create
+  - patch
   - update
   - watch
 - apiGroups:

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -71,7 +71,7 @@ func NewJobSetReconciler(client client.Client, scheme *runtime.Scheme, record re
 	return &JobSetReconciler{Client: client, Scheme: scheme, Record: record}
 }
 
-//+kubebuilder:rbac:groups="",resources=events,verbs=create;watch;update
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;watch;update;patch
 //+kubebuilder:rbac:groups=jobset.x-k8s.io,resources=jobsets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=jobset.x-k8s.io,resources=jobsets/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=jobset.x-k8s.io,resources=jobsets/finalizers,verbs=update


### PR DESCRIPTION
Cherry pick of #248 on release-0.2.
#248: add patch rbac for events
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
```