### PR TITLE
Automated cherry pick of #265: fail fast if we cannot build indexes

### DIFF
--- a/main.go
+++ b/main.go
@@ -99,6 +99,7 @@ func main() {
 	ctx := ctrl.SetupSignalHandler()
 	if err := controllers.SetupIndexes(ctx, mgr.GetFieldIndexer()); err != nil {
 		setupLog.Error(err, "unable to setup indexes")
+		os.Exit(1)
 	}
 
 	// Cert won't be ready until manager starts, so start a goroutine here which


### PR DESCRIPTION
Cherry pick of #265 on release-0.2.
#265: fail fast if we cannot build indexes
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
```