### PR TITLE
Automated cherry pick of #268: add update/patch rbac verbs for resource jobs/status

### DIFF
--- a/config/components/rbac/role.yaml
+++ b/config/components/rbac/role.yaml
@@ -58,6 +58,8 @@ rules:
   - jobs/status
   verbs:
   - get
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -76,7 +76,7 @@ func NewJobSetReconciler(client client.Client, scheme *runtime.Scheme, record re
 //+kubebuilder:rbac:groups=jobset.x-k8s.io,resources=jobsets/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=jobset.x-k8s.io,resources=jobsets/finalizers,verbs=update
 //+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=batch,resources=jobs/status,verbs=get
+//+kubebuilder:rbac:groups=batch,resources=jobs/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to


### PR DESCRIPTION
Cherry pick of #268 on release-0.2.
#268: add update/patch rbac verbs for resource jobs/status
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
```