### PR TITLE
Add validation enforcing that network subdomain adheres to RFC 1035

### DIFF
--- a/api/jobset/v1alpha2/jobset_webhook.go
+++ b/api/jobset/v1alpha2/jobset_webhook.go
@@ -91,6 +91,11 @@ func (js *JobSet) ValidateCreate() (admission.Warnings, error) {
 		for _, errMessage := range validation.IsDNS1123Subdomain(js.Spec.Network.Subdomain) {
 			allErrs = append(allErrs, fmt.Errorf(errMessage))
 		}
+
+		// Since subdomain name is also used as service name, it must adhere to RFC 1035 as well.
+		for _, errMessage := range validation.IsDNS1035Label(js.Spec.Network.Subdomain) {
+			allErrs = append(allErrs, fmt.Errorf(errMessage))
+		}
 	}
 
 	for _, rjob := range js.Spec.ReplicatedJobs {

--- a/api/jobset/v1alpha2/jobset_webhook_test.go
+++ b/api/jobset/v1alpha2/jobset_webhook_test.go
@@ -483,7 +483,7 @@ func TestValidateCreate(t *testing.T) {
 				Spec: JobSetSpec{
 					Network: &Network{
 						EnableDNSHostnames: ptr.To(true),
-						Subdomain:          strings.Repeat("a", 257),
+						Subdomain:          strings.Repeat("a", 64),
 					},
 					ReplicatedJobs: []ReplicatedJob{
 						{
@@ -498,7 +498,7 @@ func TestValidateCreate(t *testing.T) {
 				},
 			},
 			want: errors.Join(
-				fmt.Errorf("must be no more than 253 characters"),
+				fmt.Errorf("must be no more than 63 characters"),
 			),
 		},
 	}


### PR DESCRIPTION
Fixes #277 

cc @kannon92 what do you think of this? It seems a bit odd that we are validating against 2 different RFC standards for the subdomain name, since it's used as both as the service name and subdomain name, but this may be simpler than finding a new way to derive a service name and validating that?