### PR TITLE
Add node selector strategy for exclusive job placement per topology

### DIFF
--- a/api/jobset/v1alpha2/jobset_types.go
+++ b/api/jobset/v1alpha2/jobset_types.go
@@ -27,6 +27,11 @@ const (
 	JobKey                string = "jobset.sigs.k8s.io/job-key"
 	JobNameKey            string = "job-name" // TODO(#26): Migrate to the fully qualified label name.
 	ExclusiveKey          string = "alpha.jobset.sigs.k8s.io/exclusive-topology"
+	// NodeSelectorStrategyKey is an annotation that acts as a flag, the value does not matter.
+	// If set, the JobSet controller will automatically inject nodeSelectors for the JobSetNameKey label to
+	// ensure exclusive job placement per topology, instead of injecting pod affinity/anti-affinites for this.
+	// The user must add the JobSet name node label to the desired topologies separately.
+	NodeSelectorStrategyKey string = "alpha.jobset.sigs.k8s.io/node-selector"
 )
 
 type JobSetConditionType string

--- a/api/jobset/v1alpha2/jobset_types.go
+++ b/api/jobset/v1alpha2/jobset_types.go
@@ -33,6 +33,7 @@ const (
 	// The user must add the JobSet name node label to the desired topologies separately.
 	NodeSelectorStrategyKey string = "alpha.jobset.sigs.k8s.io/node-selector"
 	NamespacedJobKey        string = "alpha.jobset.sigs.k8s.io/namespaced-job"
+	NoScheduleTaintKey      string = "alpha.jobset.sigs.k8s.io/no-schedule"
 )
 
 type JobSetConditionType string

--- a/api/jobset/v1alpha2/jobset_types.go
+++ b/api/jobset/v1alpha2/jobset_types.go
@@ -32,6 +32,7 @@ const (
 	// ensure exclusive job placement per topology, instead of injecting pod affinity/anti-affinites for this.
 	// The user must add the JobSet name node label to the desired topologies separately.
 	NodeSelectorStrategyKey string = "alpha.jobset.sigs.k8s.io/node-selector"
+	NamespacedJobKey        string = "alpha.jobset.sigs.k8s.io/namespaced-job"
 )
 
 type JobSetConditionType string

--- a/hack/label_nodes/label_nodes.py
+++ b/hack/label_nodes/label_nodes.py
@@ -1,4 +1,28 @@
 #!/usr/bin/python3
+'''
+This script can be used to add certain labels and taints
+to a given list of GKE node pool, in order to dramatically
+speed up scheduling of pods for very large JobSets which are
+using an exclusive placement strategy of one job per node pool.
+
+usage: label_nodes.py [-h] jobset nodepools
+
+positional arguments:
+  jobset      jobset yaml config
+  nodepools   comma separated list of nodepool names
+
+
+The way it works is by generating the list of namespaced job names
+that will be created by the JobSet, and creating a 1:1 mapping of
+job to node pool. For every given node pool, it looks up the job
+mapped to that node pool, and applies a namespaced job name node label
+to every node in that node pool, allowing the job nodeSelectors injected
+by the JobSet controller to select those nodes to schedule the job pods on.
+It also adds a NoSchedule taint to the nodes (tolerated by the job pods), 
+preventing any external workloads from running on the nodes. Together,
+these allow for exclusive placement of 1 job per GKE node pool.
+'''
+
 import sys
 import yaml
 import argparse

--- a/hack/label_nodes/label_nodes.py
+++ b/hack/label_nodes/label_nodes.py
@@ -1,19 +1,25 @@
 #!/usr/bin/python3
 import sys
+import yaml
 import argparse
 import kubernetes.client
 import kubernetes.config
 
-JOBSET_NAME_KEY = "jobset.sigs.k8s.io/jobset-name"
+NAMESPACED_JOB_KEY = "alpha.jobset.sigs.k8s.io/namespaced-job"
 NODE_POOL_KEY = "cloud.google.com/gke-nodepool"
 
-def main(node_pools: str, jobset: str) -> None:
-    target_node_pools = set(node_pools.split(','))
-    print(f"Adding node label {JOBSET_NAME_KEY}={jobset} to the following node pools:")
-    for np in target_node_pools:
-        print(np)
+def main(node_pools: str, jobset_yaml: str) -> None:
+    namespaced_jobs = generate_namespaced_jobs(jobset_yaml)
 
-    input('Once confirmed, hit any key to continue, or ctrl+C to exit.')
+    # Get target set of node pools to label from user input.
+    target_node_pools = parse_node_pools(node_pools)
+
+    # Validate we have 1 job per node pool.
+    if len(namespaced_jobs) != len(target_node_pools):
+        raise ValueError(f"number of node pools ({len(target_node_pools)}) does not match number of child jobs ({len(namespaced_jobs)})")
+
+    # Map each job to a node pool.
+    job_mapping = generate_job_mapping(namespaced_jobs, target_node_pools)
 
     # Load the Kubernetes configuration from the default location.
     kubernetes.config.load_kube_config()
@@ -24,25 +30,64 @@ def main(node_pools: str, jobset: str) -> None:
     # Get a list of all the nodes in the cluster.
     nodes = client.list_node().items
 
-    body = {
-        "metadata": {
-            "labels": {
-                JOBSET_NAME_KEY: jobset,
-            }
-        }
-    }
-
     # Add the label to each node that is part of a target node pool.
     for node in nodes:
-        if node.metadata.labels[NODE_POOL_KEY] not in target_node_pools:
+        node_pool = node.metadata.labels[NODE_POOL_KEY]
+        if node_pool not in target_node_pools:
             continue
-        node.metadata.labels[JOBSET_NAME_KEY] = jobset
+
+        # Look up the job this node pool is assigned and add it as a label.
+        body = {
+            "metadata": {
+                "labels": {
+                    NAMESPACED_JOB_KEY: job_mapping[node_pool],
+                }
+            }
+        }
+
         client.patch_node(node.metadata.name, body)
-        print(f"Successfully added label {JOBSET_NAME_KEY}={jobset} to node {node.metadata.name}")
+        print(f"Successfully added label {NAMESPACED_JOB_KEY}={job_mapping[node_pool]} to node {node.metadata.name}")
+
+
+def parse_node_pools(node_pools: str) -> set:
+    '''Parse comma separated list of node pools into a set, and confirm with user before continuing.'''
+    node_pools_set = set(node_pools.split(','))
+    
+    print("Adding namespaced job name labels to the following node pools:")
+    for np in node_pools_set:
+        print(np)    
+
+    input('Once confirmed, hit any key to continue, or ctrl+C to exit.')
+    return node_pools_set
+
+
+def generate_namespaced_jobs(jobset_yaml: str) -> list:
+    '''Generate list of namespaced jobs from the jobset config.'''
+    with open(jobset_yaml, 'r') as f:
+        jobset = yaml.safe_load(f.read())
+
+    jobset_name = jobset['metadata']['name']
+    namespace = jobset['metadata'].get('namespace', 'default') # default namespace if unspecified
+
+    jobs = []
+    for replicated_job in jobset['spec']['replicatedJobs']:
+        replicas = int(replicated_job.get('replicas', '1')) # replicas defaults to 1 if unspecified
+        for job_idx in range(replicas):
+            jobs.append(f"{namespace}_{jobset_name}-{replicated_job['name']}-{job_idx}")
+    return jobs
+
+
+def generate_job_mapping(namespaced_jobs: list[str], node_pools: set) -> dict:
+    '''Map each job to a node pool, and return this mapping in a dictionary.'''
+    mapping = {}
+    for np in node_pools:
+        mapping[np] = namespaced_jobs.pop()
+    return mapping
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("jobset", help="name of the jobset that should run on the given nodepools")
+    parser.add_argument("jobset", help="jobset yaml config")
     parser.add_argument("nodepools", help="comma separated list of nodepool names")
     args = parser.parse_args()
     main(args.nodepools, args.jobset)

--- a/hack/label_nodes/label_nodes.py
+++ b/hack/label_nodes/label_nodes.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python3
+import sys
+import argparse
+import kubernetes.client
+import kubernetes.config
+
+JOBSET_NAME_KEY = "jobset.sigs.k8s.io/jobset-name"
+NODE_POOL_KEY = "cloud.google.com/gke-nodepool"
+
+def main(node_pools: str, jobset: str) -> None:
+    target_node_pools = set(node_pools.split(','))
+    print(f"Adding node label {JOBSET_NAME_KEY}={jobset} to the following node pools:")
+    for np in target_node_pools:
+        print(np)
+
+    input('Once confirmed, hit any key to continue, or ctrl+C to exit.')
+
+    # Load the Kubernetes configuration from the default location.
+    kubernetes.config.load_kube_config()
+
+    # Create a new Kubernetes client.
+    client = kubernetes.client.CoreV1Api()
+
+    # Get a list of all the nodes in the cluster.
+    nodes = client.list_node().items
+
+    body = {
+        "metadata": {
+            "labels": {
+                JOBSET_NAME_KEY: jobset,
+            }
+        }
+    }
+
+    # Add the label to each node that is part of a target node pool.
+    for node in nodes:
+        if node.metadata.labels[NODE_POOL_KEY] not in target_node_pools:
+            continue
+        node.metadata.labels[JOBSET_NAME_KEY] = jobset
+        client.patch_node(node.metadata.name, body)
+        print(f"Successfully added label {JOBSET_NAME_KEY}={jobset} to node {node.metadata.name}")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("jobset", help="name of the jobset that should run on the given nodepools")
+    parser.add_argument("nodepools", help="comma separated list of nodepool names")
+    args = parser.parse_args()
+    main(args.nodepools, args.jobset)

--- a/hack/label_nodes/requirements.txt
+++ b/hack/label_nodes/requirements.txt
@@ -1,0 +1,1 @@
+kubernetes

--- a/hack/label_nodes/requirements.txt
+++ b/hack/label_nodes/requirements.txt
@@ -1,1 +1,2 @@
 kubernetes
+pyyaml

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -674,6 +674,7 @@ func addTaintToleration(job *batchv1.Job) {
 		corev1.Toleration{
 			Key:      jobset.NoScheduleTaintKey,
 			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
 		},
 	)
 }

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -278,6 +278,18 @@ func (j *JobWrapper) Ready(ready int32) *JobWrapper {
 	return j
 }
 
+// Tolerations set the tolerations.
+func (j *JobWrapper) Tolerations(t []corev1.Toleration) *JobWrapper {
+	j.Spec.Template.Spec.Tolerations = t
+	return j
+}
+
+// NodeSelector sets the node selector.
+func (j *JobWrapper) NodeSelector(nodeSelector map[string]string) *JobWrapper {
+	j.Spec.Template.Spec.NodeSelector = nodeSelector
+	return j
+}
+
 // Obj returns the wrapped Job.
 func (j *JobWrapper) Obj() *batchv1.Job {
 	return &j.Job


### PR DESCRIPTION
Fixes #312

Add node selector strategy for exclusive job placement per topology.

NodeSelectorStrategyKey is an annotation that acts as a flag, the value does not matter. If set, the JobSet controller will automatically inject nodeSelectors for the JobSetNameKey label to ensure exclusive job placement per topology, instead of injecting pod affinity/anti-affinites for this. The user must add the JobSet name node label to the desired topologies separately. 

I manually verified the python script works on a test cluster.