### PR TITLE
Fix typo in API comments

### DIFF
--- a/api/jobset/v1alpha2/jobset_types.go
+++ b/api/jobset/v1alpha2/jobset_types.go
@@ -69,7 +69,7 @@ type JobSetSpec struct {
 
 	// FailurePolicy, if set, configures when to declare the JobSet as
 	// failed.
-	// The JobSet is always declared failed if all jobs in the set
+	// The JobSet is always declared failed if any job in the set
 	// finished with status failed.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	FailurePolicy *FailurePolicy `json:"failurePolicy,omitempty"`

--- a/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
+++ b/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
@@ -48,7 +48,7 @@ spec:
             properties:
               failurePolicy:
                 description: FailurePolicy, if set, configures when to declare the
-                  JobSet as failed. The JobSet is always declared failed if all jobs
+                  JobSet as failed. The JobSet is always declared failed if any job
                   in the set finished with status failed.
                 properties:
                   maxRestarts:


### PR DESCRIPTION
By default a JobSet is considered failed if **any** (not all) child jobs fail.