### PR TITLE
Update pod reconciler to handle race conditions in exclusive placement

### DIFF
--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -67,8 +67,7 @@ func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			// Only reconcile leader pods which have been scheduled which are part of
 			// JobSets using exclusive placement.
 			pod, ok := object.(*corev1.Pod)
-			return ok && usingExclusivePlacement(pod)
-			// return ok && placement.IsLeaderPod(pod) && podScheduled(pod) && usingExclusivePlacement(pod) && !podDeleted(pod)
+			return ok && placement.IsLeaderPod(pod) && podScheduled(pod) && usingExclusivePlacement(pod) && !podDeleted(pod)
 		})).
 		Complete(r)
 }

--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -66,8 +66,9 @@ func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			// Only reconcile leader pods which have been scheduled which are part of
 			// JobSets using exclusive placement.
-			pod, ok := object.(*corev1.Pod)
-			return ok && placement.IsLeaderPod(pod) && podScheduled(pod) && usingExclusivePlacement(pod) && !podDeleted(pod)
+			_, ok := object.(*corev1.Pod)
+			return ok
+			// return ok && placement.IsLeaderPod(pod) && podScheduled(pod) && usingExclusivePlacement(pod) && !podDeleted(pod)
 		})).
 		Complete(r)
 }
@@ -130,7 +131,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	log := ctrl.LoggerFrom(ctx).WithValues("pod", klog.KObj(&leaderPod))
 	ctx = ctrl.LoggerInto(ctx, log)
 	log.V(2).Info("Reconciling Pod")
-	log.V(2).Info("TEST")
+	log.V(2).Info("TEST2")
 
 	// Get all the pods owned by the same job as this pod.
 	jobKey, exists := leaderPod.Labels[jobset.JobKey]

--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -130,6 +130,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	log := ctrl.LoggerFrom(ctx).WithValues("pod", klog.KObj(&leaderPod))
 	ctx = ctrl.LoggerInto(ctx, log)
 	log.V(2).Info("Reconciling Pod")
+	log.V(2).Info("TEST")
 
 	// Get all the pods owned by the same job as this pod.
 	jobKey, exists := leaderPod.Labels[jobset.JobKey]

--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -130,7 +130,6 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	log := ctrl.LoggerFrom(ctx).WithValues("pod", klog.KObj(&leaderPod))
 	ctx = ctrl.LoggerInto(ctx, log)
 	log.V(2).Info("Reconciling Pod")
-	log.V(2).Info("TEST2")
 
 	// Get all the pods owned by the same job as this pod.
 	jobKey, exists := leaderPod.Labels[jobset.JobKey]

--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -67,7 +67,7 @@ func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			pod, ok := object.(*corev1.Pod)
 			// Only reconcile leader pods which have been scheduled which are part of
 			// JobSets using exclusive placement.
-			return ok && placement.IsLeaderPod(pod) && podScheduled(pod) && usingExclusivePlacement(pod)
+			return ok && placement.IsLeaderPod(pod) && podScheduled(pod) && usingExclusivePlacement(pod) && !podDeleted(pod)
 		})).
 		Complete(r)
 }
@@ -284,6 +284,11 @@ func usingExclusivePlacement(pod *corev1.Pod) bool {
 // podScheduled returns true if the pod has been scheduled, otherwise it returns false.
 func podScheduled(pod *corev1.Pod) bool {
 	return pod.Spec.NodeName != ""
+}
+
+// podDeleted returns true if hte pod has been marked for deletion, otherwise it returns false.
+func podDeleted(pod *corev1.Pod) bool {
+	return pod.DeletionTimestamp != nil
 }
 
 // removePodNameSuffix removes the random suffix appended to pod names.

--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -64,10 +64,10 @@ func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Pod{}).
 		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
-			pod, ok := object.(*corev1.Pod)
 			// Only reconcile leader pods which have been scheduled which are part of
 			// JobSets using exclusive placement.
-			return ok && placement.IsLeaderPod(pod) && podScheduled(pod) && usingExclusivePlacement(pod) && !podDeleted(pod)
+			_, ok := object.(*corev1.Pod)
+			return ok // && placement.IsLeaderPod(pod) && podScheduled(pod) && usingExclusivePlacement(pod) && !podDeleted(pod)
 		})).
 		Complete(r)
 }
@@ -131,6 +131,11 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	ctx = ctrl.LoggerInto(ctx, log)
 	log.V(2).Info("Reconciling Pod")
 
+	shouldReconcile := placement.IsLeaderPod(&leaderPod) && podScheduled(&leaderPod) && usingExclusivePlacement(&leaderPod) && !podDeleted(&leaderPod)
+	if !shouldReconcile {
+		log.V(2).Info(fmt.Sprintf("Skipping reconcile on pod: %s", leaderPod.Name))
+		return ctrl.Result{}, nil
+	}
 	// Get all the pods owned by the same job as this pod.
 	jobKey, exists := leaderPod.Labels[jobset.JobKey]
 	if !exists {

--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -66,8 +66,8 @@ func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			// Only reconcile leader pods which have been scheduled which are part of
 			// JobSets using exclusive placement.
-			_, ok := object.(*corev1.Pod)
-			return ok
+			pod, ok := object.(*corev1.Pod)
+			return ok && usingExclusivePlacement(pod)
 			// return ok && placement.IsLeaderPod(pod) && podScheduled(pod) && usingExclusivePlacement(pod) && !podDeleted(pod)
 		})).
 		Complete(r)

--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -15,15 +15,23 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"sigs.k8s.io/jobset/pkg/util/placement"
 
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 )
@@ -37,6 +45,9 @@ const (
 	// the namespaced job name of the job that owns this pod, and value is
 	// the pod itself.
 	podJobKey string = "podJobKey"
+
+	// parallelDeletions defines the maximum number of pod deletions that can be done concurrently.
+	parallelDeletions int = 50
 )
 
 // PodReconciler reconciles a Pod owned by a JobSet using exclusive placement.
@@ -102,9 +113,187 @@ func SetupPodIndexes(ctx context.Context, indexer client.FieldIndexer) error {
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// Get Pod from apiserver.
+	var pod corev1.Pod
+	if err := r.Get(ctx, req.NamespacedName, &pod); err != nil {
+		// we'll ignore not-found errors, since there is nothing we can do here.
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	log := ctrl.LoggerFrom(ctx).WithValues("pod", klog.KObj(&pod))
+	ctx = ctrl.LoggerInto(ctx, log)
+	log.V(2).Info("Reconciling Pod")
+
+	// Check if this is the leader pod. If it is the leader pod and it hasn't been
+	// scheduled, do nothing and return early.
+	leader := placement.IsLeaderPod(&pod)
+	if leader {
+		log.Info(fmt.Sprintf("%q is a leader pod", pod.Name))
+		if pod.Spec.NodeName == "" {
+			log.Info("leader pod not scheduled")
+			return ctrl.Result{}, nil
+		}
+	}
+
+	// We need a reference to the scheduled leader pod of this job, to find the topology domain
+	// it is scheduled in.
+	leaderPod, err := r.leaderPodForFollower(ctx, &pod)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Get all the pods owned by the same job as this pod.
+	jobKey, exists := leaderPod.Labels[jobset.JobKey]
+	if !exists {
+		return ctrl.Result{}, fmt.Errorf("job key label not found on leader pod: %q", leaderPod.Name)
+	}
+	podList, err := r.listPodsForJob(ctx, leaderPod.Namespace, jobKey)
+	if err != nil {
+		log.Error(err, "listing pods for job")
+		return ctrl.Result{}, err
+	}
+
+	// Validate all follower pods in this job are assigned to the same topology as the leader pod.
+	// If not, then delete all the job's pods so they can be recreated and rescheduled correctly.
+	valid, err := r.validatePodPlacements(ctx, leaderPod, podList)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if !valid {
+		return ctrl.Result{}, r.deletePods(ctx, podList.Items)
+	}
 	return ctrl.Result{}, nil
 }
 
+// listPodsForJobKey returns a list of pods owned by a specific job, using the
+// jobKey (SHA1 hash of the namespaced job name) label selector.
+func (r *PodReconciler) listPodsForJob(ctx context.Context, ns, jobKey string) (*corev1.PodList, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	var podList corev1.PodList
+	if err := r.List(ctx, &podList, client.InNamespace(ns), &client.MatchingFields{podJobKey: jobKey}); err != nil {
+		log.Error(err, "listing pods")
+		return nil, err
+	}
+
+	return &podList, nil
+}
+
+// getPodByName returns the Pod object for a given pod name.
+func (r *PodReconciler) getPodByName(ctx context.Context, ns, podName string) (*corev1.Pod, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	var podList corev1.PodList
+	if err := r.List(ctx, &podList, client.InNamespace(ns), &client.MatchingFields{PodNameKey: podName}); err != nil {
+		log.Error(err, "listing pods")
+		return nil, err
+	}
+
+	// Validate only 1 pod with this name exists.
+	if len(podList.Items) != 1 {
+		return nil, fmt.Errorf("expected 1 pod with name %q, got %d", podName, len(podList.Items))
+	}
+
+	return &podList.Items[0], nil
+}
+
+// leaderPodForFollower returns the Pod object for the leader pod (job completion index 0) for
+// a given follower pod.
+func (r *PodReconciler) leaderPodForFollower(ctx context.Context, pod *corev1.Pod) (*corev1.Pod, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	var leaderPod *corev1.Pod
+	if placement.IsLeaderPod(pod) {
+		log.Info(fmt.Sprintf("%q is a leader pod", pod.Name))
+		leaderPod = pod
+	} else {
+		log.Info(fmt.Sprintf("%q is a follower pod", pod.Name))
+		leaderPodName, err := leaderPodNameForFollower(pod)
+		if err != nil {
+			log.Error(err, "generating leader pod name")
+			return nil, err
+		}
+		// Use pod name index to quickly fetch the leader pod object.
+		leaderPod, err = r.getPodByName(ctx, pod.Namespace, leaderPodName)
+		if err != nil {
+			log.Error(err, "getting leader pod by name")
+			return nil, err
+		}
+	}
+	return leaderPod, nil
+}
+
+// validatePodPlacements returns true if the topology value specified in follower pods' nodeSelectors
+// matches that of their leader pod, and the leader pod exists. Otherwise, it returns false.
+func (r *PodReconciler) validatePodPlacements(ctx context.Context, leaderPod *corev1.Pod, podList *corev1.PodList) (bool, error) {
+	// We know exclusive key is set since we have an event filter for this.
+	topologyKey := leaderPod.Annotations[jobset.ExclusiveKey]
+	leaderTopology, err := r.topologyFromPod(ctx, leaderPod, topologyKey)
+	if err != nil {
+		return false, err
+	}
+
+	// Validate all follower pods are assigned to the same topology as the leader pod.
+	for _, pod := range podList.Items {
+		if placement.IsLeaderPod(&pod) {
+			continue
+		}
+		followerTopology, err := r.topologyFromPod(ctx, &pod, topologyKey)
+		if err != nil {
+			return false, err
+		}
+		if followerTopology != leaderTopology {
+			return false, fmt.Errorf("follower topology %q != leader topology %q", followerTopology, leaderTopology)
+		}
+	}
+	return true, nil
+}
+
+// topologyFromPod returns the topology value (e.g., node pool name, zone, etc.)
+// for a given pod and topology key.
+func (r *PodReconciler) topologyFromPod(ctx context.Context, pod *corev1.Pod, topologyKey string) (string, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	nodeName := pod.Spec.NodeName
+	ns := pod.Namespace
+
+	// Get node the leader pod is running on.
+	var node corev1.Node
+	if err := r.Get(ctx, types.NamespacedName{Name: nodeName, Namespace: ns}, &node); err != nil {
+		// We'll ignore not-found errors, since there is nothing we can do here.
+		// A node may not exist temporarily due to a maintenance event or other scenarios.
+		log.Error(err, fmt.Sprintf("getting node %s", nodeName))
+		return "", client.IgnoreNotFound(err)
+	}
+
+	// Get topology (e.g. node pool name) from node labels.
+	topology, exists := node.Labels[topologyKey]
+	if !exists {
+		return "", fmt.Errorf("node does not have topology label: %s", topology)
+	}
+	return topology, nil
+}
+
+// deletePods deletes the given pods, parallelizing up to `parallelDeletions` requests.
+func (r *PodReconciler) deletePods(ctx context.Context, pods []corev1.Pod) error {
+	lock := &sync.Mutex{}
+	var finalErrs []error
+
+	workqueue.ParallelizeUntil(ctx, parallelDeletions, len(pods), func(i int) {
+		pod := pods[i]
+		backgroundPolicy := metav1.DeletePropagationBackground
+		if err := r.Delete(ctx, &pod, &client.DeleteOptions{PropagationPolicy: &backgroundPolicy}); client.IgnoreNotFound(err) != nil {
+			lock.Lock()
+			defer lock.Unlock()
+			finalErrs = append(finalErrs, err)
+			return
+		}
+	})
+	return errors.Join(finalErrs...)
+}
+
+// usingExclusivePlacement returns true if the pod is part of a JobSet using
+// exclusive placement, otherwise it returns false.
 func usingExclusivePlacement(pod *corev1.Pod) bool {
 	_, exists := pod.Annotations[jobset.ExclusiveKey]
 	return exists
@@ -120,4 +309,23 @@ func removePodNameSuffix(podName string) (string, error) {
 		return "", fmt.Errorf("invalid pod name: %s", podName)
 	}
 	return strings.Join(parts[:len(parts)-1], "-"), nil
+}
+
+// leaderPodNameForFollower accepts the name of a pod that is part of a jobset as input, and
+// returns the name of the pod with completion index 0 in the same child job.
+func leaderPodNameForFollower(pod *corev1.Pod) (string, error) {
+	// Pod name format: <jobset>-<replicatedJob>-<jobIndex>-<podIndex>-<randomSuffix>
+	jobSet, ok := pod.Labels[jobset.JobSetNameKey]
+	if !ok {
+		return "", fmt.Errorf("pod missing label: %s", jobset.JobSetNameKey)
+	}
+	replicatedJob, ok := pod.Labels[jobset.ReplicatedJobNameKey]
+	if !ok {
+		return "", fmt.Errorf("pod missing label: %s", jobset.ReplicatedJobNameKey)
+	}
+	jobIndex, ok := pod.Labels[jobset.JobIndexKey]
+	if !ok {
+		return "", fmt.Errorf("pod missing label: %s", jobset.JobIndexKey)
+	}
+	return placement.GenLeaderPodName(jobSet, replicatedJob, jobIndex), nil
 }

--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -110,8 +110,8 @@ func SetupPodIndexes(ctx context.Context, indexer client.FieldIndexer) error {
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch
 
 // Reconcile attempts to enforce that the pods that belong to the same job are
-// scheduled on the same topology domain exclusively (if the parent JobSet is using
-// exclusive placement).
+// scheduled on the same topology domain exclusively if the parent JobSet is using
+// exclusive placement.
 func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	// In the following, we aim to enforce that for JobSets using exclusive placement,
 	// pods that belong to the same job are scheduled on the same topology domain exclusively.
@@ -212,7 +212,7 @@ func (r *PodReconciler) deleteFollowerPods(ctx context.Context, pods []corev1.Po
 			Message: "Pod violated JobSet exclusive placement policy",
 		}
 
-		// If pod status already has this condition, we don't need to send the update RPC again.
+		// If pod status already has this condition, we don't need to send the update again.
 		if updatePodCondition(&pod, condition) {
 			if err := r.Status().Update(ctx, &pod); err != nil {
 				lock.Lock()

--- a/pkg/util/placement/placement.go
+++ b/pkg/util/placement/placement.go
@@ -15,14 +15,14 @@ func GenJobName(jsName, rjobName string, jobIndex int) string {
 	return fmt.Sprintf("%s-%s-%d", jsName, rjobName, jobIndex)
 }
 
-// IsLeaderPod returns true if the given pod is a leader pod (job completion index of 0),
-// otherwise it returns false.
-func IsLeaderPod(pod *corev1.Pod) bool {
-	return pod.Annotations[batchv1.JobCompletionIndexAnnotation] == "0"
-}
-
 // GenLeaderPodName returns the name of the leader pod (pod with completion index 0)
 // for a given job in a jobset.
 func GenLeaderPodName(jobSet, replicatedJob, jobIndex string) string {
 	return fmt.Sprintf("%s-%s-%s-0", jobSet, replicatedJob, jobIndex)
+}
+
+// IsLeaderPod returns true if the given pod is a leader pod (job completion index of 0),
+// otherwise it returns false.
+func IsLeaderPod(pod *corev1.Pod) bool {
+	return pod.Annotations[batchv1.JobCompletionIndexAnnotation] == "0"
 }

--- a/pkg/webhooks/pod_admission_webhook.go
+++ b/pkg/webhooks/pod_admission_webhook.go
@@ -100,7 +100,7 @@ func (p *podWebhook) leaderPodForFollower(ctx context.Context, pod *corev1.Pod) 
 
 	// Validate there is only 1 leader pod for this job.
 	if len(podList.Items) != 1 {
-		return nil, fmt.Errorf("too many leader pods for this job (expected 1, got %d", len(podList.Items))
+		return nil, fmt.Errorf("incorrect number of leader pods for this job (expected 1, got %d)", len(podList.Items))
 	}
 
 	// Check if the leader pod is scheduled.

--- a/pkg/webhooks/pod_admission_webhook.go
+++ b/pkg/webhooks/pod_admission_webhook.go
@@ -85,7 +85,6 @@ func (p *podWebhook) leaderPodScheduled(ctx context.Context, pod *corev1.Pod) (b
 func (p *podWebhook) leaderPodForFollower(ctx context.Context, pod *corev1.Pod) (*corev1.Pod, error) {
 	// Generate the expected leader pod name for this follower pod.
 	log := ctrl.LoggerFrom(ctx)
-	log.Info(fmt.Sprintf("generating leader pod name for follower pod: %s", pod.Name))
 	leaderPodName, err := genLeaderPodName(pod)
 	if err != nil {
 		log.Error(err, "getting leader pod name for follower pod")

--- a/pkg/webhooks/pod_mutating_webhook.go
+++ b/pkg/webhooks/pod_mutating_webhook.go
@@ -83,11 +83,11 @@ func (p *podWebhook) Default(ctx context.Context, obj runtime.Object) error {
 func (p *podWebhook) patchPod(ctx context.Context, pod *corev1.Pod) error {
 	log := ctrl.LoggerFrom(ctx)
 	if pod.Annotations[batchv1.JobCompletionIndexAnnotation] == "0" {
-		log.Info(fmt.Sprintf("pod webhook: setting exclusive affinities for pod: %s", pod.Name))
+		log.V(3).Info(fmt.Sprintf("pod webhook: setting exclusive affinities for pod: %s", pod.Name))
 		setExclusiveAffinities(pod)
 		return nil
 	} else {
-		log.Info(fmt.Sprintf("pod webhook: adding node selector for follower pod: %s", pod.Name))
+		log.V(3).Info(fmt.Sprintf("pod webhook: adding node selector for follower pod: %s", pod.Name))
 		return p.setNodeSelector(ctx, pod)
 	}
 }


### PR DESCRIPTION
Fixes #341 

In the following changes, we aim to enforce that for JobSets using exclusive placement, pods that belong to the same job are scheduled on the same topology domain exclusively. We do this by performing the following steps:

1. Reconcile leader pods which are scheduled and using exclusive placement.
2. For a given leader pod, check all follower pods's nodeSelectors are all configured to select the same topology as the leader pod is currently placed on.
3. If the above condition is false, we delete all the follower pods in this job to allow them to be rescheduled correctly. When deleting pods, we first add a pod condition so that these deletions can be ignored by a podFailurePolicy, to not count against a backoffLimit.

I will add an e2e test forcing the race condition to happen and verifying the reconciler handles it in a follow-up PR.