### PR TITLE
add flags for qps and burst instead of hardcoding them

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,11 +56,15 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+	var qps float64
+	var burst int
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.Float64Var(&qps, "kube-api-qps", 500, "Maximum QPS to use while talking with Kubernetes API")
+	flag.IntVar(&burst, "kube-api-burst", 500, "Maximum burst for throttle while talking with Kubernetes API")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -70,9 +74,8 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	kubeConfig := ctrl.GetConfigOrDie()
-	// TODO(#338): set QPS and Burst via config flags
-	kubeConfig.QPS = 500
-	kubeConfig.Burst = 500
+	kubeConfig.QPS = float32(qps)
+	kubeConfig.Burst = burst
 
 	mgr, err := ctrl.NewManager(kubeConfig, ctrl.Options{
 		Scheme: scheme,


### PR DESCRIPTION
**Changelog**

Add flags for qps (`-kube-api-qps`) and burst (`-kube-api-burst`) for configuring them instead of having them hardcoded.

This PR closes Issue https://github.com/kubernetes-sigs/jobset/issues/338