### PR TITLE
add dependabot groups for k8s packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
       interval: "weekly"
     labels:
       - "ok-to-test"
+    groups:
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
     ignore:
       # Ignore major and minor versions for dependencies updates
       # Allow patches and security updates.


### PR DESCRIPTION
See https://github.com/kubernetes-sigs/kueue/pull/1675.

Dependabot allows you to group certain packages so they are updating together.