### PR TITLE
Migrate from background to foreground cascading deletion policy

### DIFF
--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
-	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -29,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
@@ -390,7 +388,18 @@ func (r *JobSetReconciler) createJobs(ctx context.Context, js *jobset.JobSet, ow
 		}
 		workqueue.ParallelizeUntil(ctx, maxParallelism, len(jobs), func(i int) {
 			job := jobs[i]
-			if err := r.createJobWithBackOff(ctx, js, job); err != nil {
+
+			// Set jobset controller as owner of the job for garbage collection and reconcilation.
+			if err := ctrl.SetControllerReference(js, job, r.Scheme); err != nil {
+				lock.Lock()
+				defer lock.Unlock()
+				finalErrs = append(finalErrs, err)
+				return
+			}
+
+			// Create the job.
+			// TODO(#18): Deal with the case where the job exists but is not owned by the jobset.
+			if err := r.Create(ctx, job); err != nil {
 				lock.Lock()
 				defer lock.Unlock()
 				finalErrs = append(finalErrs, err)
@@ -400,28 +409,6 @@ func (r *JobSetReconciler) createJobs(ctx context.Context, js *jobset.JobSet, ow
 		})
 	}
 	return errors.Join(finalErrs...)
-}
-
-func (r *JobSetReconciler) createJobWithBackOff(ctx context.Context, js *jobset.JobSet, job *batchv1.Job) error {
-	// 1, 2, 4, 8, 16, 32 seconds.
-	backoff := wait.Backoff{
-		Steps:    6,
-		Duration: 1 * time.Second,
-		Factor:   2.0,
-		Jitter:   0.2,
-	}
-	// Set jobset controller as owner of the job for garbage collection and reconcilation.
-	if err := ctrl.SetControllerReference(js, job, r.Scheme); err != nil {
-		return err
-	}
-
-	// Create the job with an exponential back off policy if it already exists.
-	return wait.ExponentialBackoff(backoff, func() (bool, error) {
-		if err := r.Create(ctx, job); err != nil {
-			return false, err
-		}
-		return true, nil
-	})
 }
 
 // TODO: look into adopting service and updating the selector

--- a/pkg/util/collections/collections.go
+++ b/pkg/util/collections/collections.go
@@ -38,3 +38,12 @@ func Contains[T comparable](slice []T, element T) bool {
 	}
 	return false
 }
+
+func IndexOf[T comparable](slice []T, item T) int {
+	for i, v := range slice {
+		if v == item {
+			return i
+		}
+	}
+	return -1
+}

--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"strconv"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -34,6 +33,7 @@ import (
 
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 	"sigs.k8s.io/jobset/pkg/controllers"
+	"sigs.k8s.io/jobset/pkg/util/collections"
 	"sigs.k8s.io/jobset/pkg/util/testing"
 	testutil "sigs.k8s.io/jobset/test/util"
 )
@@ -168,9 +168,16 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 					up.jobSetUpdateFn(&jobSet)
 				} else if up.jobUpdateFn != nil {
 					// Fetch updated job objects so we always have the latest resource versions to perform mutations on.
+					// Ensure we have all expected jobs in our jobList before continuing.
 					var jobList batchv1.JobList
-					gomega.Expect(k8sClient.List(ctx, &jobList, client.InNamespace(js.Namespace))).Should(gomega.Succeed())
-					gomega.Expect(len(jobList.Items)).To(gomega.Equal(testutil.NumExpectedJobs(js)))
+					gomega.Eventually(func() (bool, error) {
+						if err := k8sClient.List(ctx, &jobList, client.InNamespace(js.Namespace)); err != nil {
+							return false, err
+						}
+						return len(jobList.Items) == testutil.NumExpectedJobs(js), nil
+					}, timeout, interval).Should(gomega.BeTrue())
+
+					// Perform update on jobs.
 					up.jobUpdateFn(&jobList)
 				}
 
@@ -410,9 +417,13 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 					jobUpdateFn: func(jobList *batchv1.JobList) {
 						failJob(&jobList.Items[0])
 					},
-					checkJobSetState: func(js *jobset.JobSet) {
-						ginkgo.By("checking all jobs are recreated")
-						gomega.Eventually(checkJobsRecreated, timeout, interval).WithArguments(js, 1).Should(gomega.Equal(true))
+					checkJobSetCondition: testutil.JobSetActive,
+				},
+				{
+					jobSetUpdateFn: func(js *jobset.JobSet) {
+						// For a restart, all jobs will be deleted and recreated, so we expect a
+						// foreground deletion finalizer for every job.
+						removeForegroundDeletionFinalizers(js, testutil.NumExpectedJobs(js))
 					},
 				},
 				{
@@ -436,9 +447,12 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 						completeJob(&jobList.Items[0])
 						failJob(&jobList.Items[1])
 					},
-					checkJobSetState: func(js *jobset.JobSet) {
-						ginkgo.By("checking all jobs are recreated")
-						gomega.Eventually(checkJobsRecreated, timeout, interval).WithArguments(js, 1).Should(gomega.Equal(true))
+				},
+				{
+					jobSetUpdateFn: func(js *jobset.JobSet) {
+						// For a restart, all jobs will be deleted and recreated, so we expect a
+						// foreground deletion finalizer for every job.
+						removeForegroundDeletionFinalizers(js, testutil.NumExpectedJobs(js))
 					},
 				},
 				{
@@ -640,6 +654,15 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 					},
 					checkJobSetCondition: testutil.JobSetCompleted,
 				},
+				// Remove foreground deletion finalizers.
+				{
+					jobSetUpdateFn: func(js *jobset.JobSet) {
+						// Completed jobs are not marked for deletion if the JobSet is completed,
+						// so we expect the number of foreground deletion finalizers to equal
+						// total jobs - 1.
+						removeForegroundDeletionFinalizers(js, testutil.NumExpectedJobs(js)-1)
+					},
+				},
 				// Ensure remaining active jobs are deleted.
 				{
 					checkJobSetState: func(js *jobset.JobSet) {
@@ -657,6 +680,14 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 						failJob(&jobList.Items[0])
 					},
 					checkJobSetCondition: testutil.JobSetFailed,
+				},
+				// Remove foreground deletion finalizers.
+				{
+					jobSetUpdateFn: func(js *jobset.JobSet) {
+						// For a restart, all jobs will be deleted and recreated, so we expect a
+						// foreground deletion finalizer for every job.
+						removeForegroundDeletionFinalizers(js, testutil.NumExpectedJobs(js)-1)
+					},
 				},
 				// Ensure remaining active jobs are deleted.
 				{
@@ -745,6 +776,29 @@ func completeJob(job *batchv1.Job) {
 			Status: corev1.ConditionTrue,
 		}),
 	})
+}
+
+// removeForegroundDeletionFinalizers will continually fetch the child jobs for a
+// given JobSet until it has deleted all of the expected foreground deletion
+// finalizers from the jobs.
+func removeForegroundDeletionFinalizers(js *jobset.JobSet, expectedFinalizers int) {
+	gomega.Eventually(func() (bool, error) {
+		// Get fresh job list.
+		var jobList batchv1.JobList
+		gomega.Eventually(k8sClient.List(ctx, &jobList, client.InNamespace(js.Namespace))).Should(gomega.Succeed())
+
+		for _, job := range jobList.Items {
+			idx := collections.IndexOf(job.Finalizers, metav1.FinalizerDeleteDependents)
+			if idx != -1 {
+				job.Finalizers = append(job.Finalizers[:idx], job.Finalizers[idx+1:]...)
+				if err := k8sClient.Update(ctx, &job); err != nil {
+					return false, err
+				}
+				expectedFinalizers -= 1
+			}
+		}
+		return expectedFinalizers == 0, nil
+	}, timeout, interval).Should(gomega.Equal(true))
 }
 
 func ReadyJob(job *batchv1.Job) {
@@ -844,24 +898,6 @@ func matchJobsNodeSelectors(js *jobset.JobSet, nodeSelectors map[string]map[stri
 	return wantJobsUpdated == jobsUpdated, nil
 }
 
-func checkJobsRecreated(js *jobset.JobSet, expectedRestarts int) (bool, error) {
-	var jobList batchv1.JobList
-	if err := k8sClient.List(ctx, &jobList, client.InNamespace(js.Namespace)); err != nil {
-		return false, err
-	}
-	// Check we have the right number of jobs.
-	if len(jobList.Items) != testutil.NumExpectedJobs(js) {
-		return false, nil
-	}
-	// Check all the jobs restart counter has been incremented.
-	for _, job := range jobList.Items {
-		if job.Labels[controllers.RestartsKey] != strconv.Itoa(expectedRestarts) {
-			return false, nil
-		}
-	}
-	return true, nil
-}
-
 // Check one headless service per job was created successfully.
 func checkExpectedServices(js *jobset.JobSet) {
 	gomega.Eventually(func() (int, error) {
@@ -892,6 +928,11 @@ func checkNoActiveJobs(js *jobset.JobSet, numFinishedJobs int) {
 }
 
 func jobActive(job *batchv1.Job) bool {
+	// Jobs marked for deletion using foreground cascading deletion will have deletion timestamp set,
+	// but will still exist until dependent objects with ownerReference.blockOwnerDeletion=true set are deleted.
+	if job.DeletionTimestamp != nil {
+		return false
+	}
 	if len(job.Status.Conditions) == 0 {
 		return true
 	}
@@ -899,6 +940,7 @@ func jobActive(job *batchv1.Job) bool {
 	for _, c := range job.Status.Conditions {
 		if (c.Type == batchv1.JobComplete || c.Type == batchv1.JobFailed) && c.Status == corev1.ConditionTrue {
 			active = false
+			break
 		}
 	}
 	return active


### PR DESCRIPTION
Fixes #392 

This change involves:
- Using foreground deletion policy for deleting jobs
- Skipping deletion attempts for jobs with deletion timestamp already set
- Retrying job creations (with exponential backoff) which fail
- Refactoring jobset controller integration tests to remove foreground deletion finalizers for any tests which involve jobs being deleted