### PR TITLE
Add managed-by label support.

### DIFF
--- a/api/jobset/v1alpha2/jobset_types.go
+++ b/api/jobset/v1alpha2/jobset_types.go
@@ -39,6 +39,13 @@ const (
 	NodeSelectorStrategyKey string = "alpha.jobset.sigs.k8s.io/node-selector"
 	NamespacedJobKey        string = "alpha.jobset.sigs.k8s.io/namespaced-job"
 	NoScheduleTaintKey      string = "alpha.jobset.sigs.k8s.io/no-schedule"
+
+	// LabelManagedBy is used to indicate the controller or entity that manages an JobSet
+	LabelManagedBy = "jobset.sigs.k8s.io/managed-by"
+
+	// JobSetManager is used as the value for LabelManagedBy to identify the jobset controller manager
+	// as the manager of a specific JobSet.
+	JobSetManager = "jobset"
 )
 
 type JobSetConditionType string

--- a/api/jobset/v1alpha2/jobset_types.go
+++ b/api/jobset/v1alpha2/jobset_types.go
@@ -41,7 +41,7 @@ const (
 	NoScheduleTaintKey      string = "alpha.jobset.sigs.k8s.io/no-schedule"
 
 	// LabelManagedBy is used to indicate the controller or entity that manages an JobSet
-	LabelManagedBy = "jobset.sigs.k8s.io/managed-by"
+	LabelManagedBy = "alpha.jobset.sigs.k8s.io/managed-by"
 
 	// JobSetManager is used as the value for LabelManagedBy to identify the jobset controller manager
 	// as the manager of a specific JobSet.

--- a/api/jobset/v1alpha2/jobset_webhook_test.go
+++ b/api/jobset/v1alpha2/jobset_webhook_test.go
@@ -39,6 +39,9 @@ func TestJobSetDefaulting(t *testing.T) {
 		{
 			name: "job completion mode is unset",
 			js: &JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{LabelManagedBy: JobSetManager},
+				},
 				Spec: JobSetSpec{
 					SuccessPolicy: defaultSuccessPolicy,
 					StartupPolicy: defaultStartupPolicy,
@@ -55,6 +58,9 @@ func TestJobSetDefaulting(t *testing.T) {
 				},
 			},
 			want: &JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{LabelManagedBy: JobSetManager},
+				},
 				Spec: JobSetSpec{
 					SuccessPolicy: defaultSuccessPolicy,
 					StartupPolicy: defaultStartupPolicy,
@@ -75,6 +81,9 @@ func TestJobSetDefaulting(t *testing.T) {
 		{
 			name: "job completion mode is set to non-indexed",
 			js: &JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{LabelManagedBy: JobSetManager},
+				},
 				Spec: JobSetSpec{
 					SuccessPolicy: defaultSuccessPolicy,
 					Network:       &Network{EnableDNSHostnames: ptr.To(true)},
@@ -91,6 +100,9 @@ func TestJobSetDefaulting(t *testing.T) {
 				},
 			},
 			want: &JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{LabelManagedBy: JobSetManager},
+				},
 				Spec: JobSetSpec{
 					SuccessPolicy: defaultSuccessPolicy,
 					StartupPolicy: defaultStartupPolicy,
@@ -111,6 +123,9 @@ func TestJobSetDefaulting(t *testing.T) {
 		{
 			name: "enableDNSHostnames is unset",
 			js: &JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{LabelManagedBy: JobSetManager},
+				},
 				Spec: JobSetSpec{
 					SuccessPolicy: defaultSuccessPolicy,
 					StartupPolicy: defaultStartupPolicy,
@@ -127,6 +142,9 @@ func TestJobSetDefaulting(t *testing.T) {
 				},
 			},
 			want: &JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{LabelManagedBy: JobSetManager},
+				},
 				Spec: JobSetSpec{
 					SuccessPolicy: defaultSuccessPolicy,
 					StartupPolicy: defaultStartupPolicy,
@@ -147,6 +165,9 @@ func TestJobSetDefaulting(t *testing.T) {
 		{
 			name: "enableDNSHostnames is false",
 			js: &JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{LabelManagedBy: JobSetManager},
+				},
 				Spec: JobSetSpec{
 					SuccessPolicy: defaultSuccessPolicy,
 					StartupPolicy: defaultStartupPolicy,
@@ -164,6 +185,9 @@ func TestJobSetDefaulting(t *testing.T) {
 				},
 			},
 			want: &JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{LabelManagedBy: JobSetManager},
+				},
 				Spec: JobSetSpec{
 					SuccessPolicy: defaultSuccessPolicy,
 					StartupPolicy: defaultStartupPolicy,
@@ -184,6 +208,9 @@ func TestJobSetDefaulting(t *testing.T) {
 		{
 			name: "pod restart policy unset",
 			js: &JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{LabelManagedBy: JobSetManager},
+				},
 				Spec: JobSetSpec{
 					SuccessPolicy: defaultSuccessPolicy,
 					StartupPolicy: defaultStartupPolicy,
@@ -203,6 +230,9 @@ func TestJobSetDefaulting(t *testing.T) {
 				},
 			},
 			want: &JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{LabelManagedBy: JobSetManager},
+				},
 				Spec: JobSetSpec{
 					SuccessPolicy: defaultSuccessPolicy,
 					StartupPolicy: defaultStartupPolicy,
@@ -227,6 +257,9 @@ func TestJobSetDefaulting(t *testing.T) {
 		{
 			name: "pod restart policy set",
 			js: &JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{LabelManagedBy: JobSetManager},
+				},
 				Spec: JobSetSpec{
 					SuccessPolicy: defaultSuccessPolicy,
 					StartupPolicy: defaultStartupPolicy,
@@ -248,6 +281,9 @@ func TestJobSetDefaulting(t *testing.T) {
 				},
 			},
 			want: &JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{LabelManagedBy: JobSetManager},
+				},
 				Spec: JobSetSpec{
 					SuccessPolicy: defaultSuccessPolicy,
 					StartupPolicy: defaultStartupPolicy,
@@ -272,6 +308,9 @@ func TestJobSetDefaulting(t *testing.T) {
 		{
 			name: "success policy unset",
 			js: &JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{LabelManagedBy: JobSetManager},
+				},
 				Spec: JobSetSpec{
 					StartupPolicy: defaultStartupPolicy,
 					Network:       &Network{EnableDNSHostnames: ptr.To(true)},
@@ -292,6 +331,9 @@ func TestJobSetDefaulting(t *testing.T) {
 				},
 			},
 			want: &JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{LabelManagedBy: JobSetManager},
+				},
 				Spec: JobSetSpec{
 					StartupPolicy: defaultStartupPolicy,
 					SuccessPolicy: defaultSuccessPolicy,
@@ -316,6 +358,9 @@ func TestJobSetDefaulting(t *testing.T) {
 		{
 			name: "success policy operator set, replicatedJobNames unset",
 			js: &JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{LabelManagedBy: JobSetManager},
+				},
 				Spec: JobSetSpec{
 					SuccessPolicy: &SuccessPolicy{
 						Operator: OperatorAny,
@@ -339,6 +384,9 @@ func TestJobSetDefaulting(t *testing.T) {
 				},
 			},
 			want: &JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{LabelManagedBy: JobSetManager},
+				},
 				Spec: JobSetSpec{
 					SuccessPolicy: &SuccessPolicy{
 						Operator: OperatorAny,
@@ -407,6 +455,44 @@ func TestJobSetDefaulting(t *testing.T) {
 											RestartPolicy: corev1.RestartPolicyAlways,
 										},
 									},
+									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "managed-by label is unset",
+			js: &JobSet{
+				Spec: JobSetSpec{
+					SuccessPolicy: defaultSuccessPolicy,
+					Network:       &Network{EnableDNSHostnames: ptr.To(true)},
+					ReplicatedJobs: []ReplicatedJob{
+						{
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Template:       TestPodTemplate,
+									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{LabelManagedBy: JobSetManager},
+				},
+				Spec: JobSetSpec{
+					SuccessPolicy: defaultSuccessPolicy,
+					Network:       &Network{EnableDNSHostnames: ptr.To(true)},
+					ReplicatedJobs: []ReplicatedJob{
+						{
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Template:       TestPodTemplate,
 									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
 								},
 							},

--- a/api/jobset/v1alpha2/jobset_webhook_test.go
+++ b/api/jobset/v1alpha2/jobset_webhook_test.go
@@ -501,6 +501,47 @@ func TestJobSetDefaulting(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "when provided, managed-by label is preserved",
+			js: &JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{LabelManagedBy: "other-controller"},
+				},
+				Spec: JobSetSpec{
+					SuccessPolicy: defaultSuccessPolicy,
+					Network:       &Network{EnableDNSHostnames: ptr.To(true)},
+					ReplicatedJobs: []ReplicatedJob{
+						{
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Template:       TestPodTemplate,
+									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{LabelManagedBy: "other-controller"},
+				},
+				Spec: JobSetSpec{
+					SuccessPolicy: defaultSuccessPolicy,
+					Network:       &Network{EnableDNSHostnames: ptr.To(true)},
+					ReplicatedJobs: []ReplicatedJob{
+						{
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Template:       TestPodTemplate,
+									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/api/jobset/v1alpha2/jobset_webhook_test.go
+++ b/api/jobset/v1alpha2/jobset_webhook_test.go
@@ -438,6 +438,9 @@ func TestJobSetDefaulting(t *testing.T) {
 				},
 			},
 			want: &JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{LabelManagedBy: JobSetManager},
+				},
 				Spec: JobSetSpec{
 					SuccessPolicy: &SuccessPolicy{
 						Operator: OperatorAny,
@@ -487,6 +490,7 @@ func TestJobSetDefaulting(t *testing.T) {
 				},
 				Spec: JobSetSpec{
 					SuccessPolicy: defaultSuccessPolicy,
+					StartupPolicy: defaultStartupPolicy,
 					Network:       &Network{EnableDNSHostnames: ptr.To(true)},
 					ReplicatedJobs: []ReplicatedJob{
 						{
@@ -528,6 +532,7 @@ func TestJobSetDefaulting(t *testing.T) {
 				},
 				Spec: JobSetSpec{
 					SuccessPolicy: defaultSuccessPolicy,
+					StartupPolicy: defaultStartupPolicy,
 					Network:       &Network{EnableDNSHostnames: ptr.To(true)},
 					ReplicatedJobs: []ReplicatedJob{
 						{

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -90,6 +90,11 @@ func (r *JobSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	if manager, found := js.Labels[jobset.LabelManagedBy]; found && manager != jobset.JobSetManager {
+		// the JobSet is not managed by this controller
+		return ctrl.Result{}, nil
+	}
+
 	log := ctrl.LoggerFrom(ctx).WithValues("jobset", klog.KObj(&js))
 	ctx = ctrl.LoggerInto(ctx, log)
 	log.V(2).Info("Reconciling JobSet")

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -90,13 +90,14 @@ func (r *JobSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	log := ctrl.LoggerFrom(ctx).WithValues("jobset", klog.KObj(&js))
+	ctx = ctrl.LoggerInto(ctx, log)
+
 	if manager, found := js.Labels[jobset.LabelManagedBy]; found && manager != jobset.JobSetManager {
-		// the JobSet is not managed by this controller
+		log.V(5).Info("Skipping JobSet managed by a different controller", "managed-by", manager)
 		return ctrl.Result{}, nil
 	}
 
-	log := ctrl.LoggerFrom(ctx).WithValues("jobset", klog.KObj(&js))
-	ctx = ctrl.LoggerInto(ctx, log)
 	log.V(2).Info("Reconciling JobSet")
 
 	// Get Jobs owned by JobSet.

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -78,6 +78,12 @@ func (j *JobSetWrapper) SetAnnotations(annotations map[string]string) *JobSetWra
 	return j
 }
 
+// SetLabels sets the value of the jobSet.metadata.labels.
+func (j *JobSetWrapper) SetLabels(labels map[string]string) *JobSetWrapper {
+	j.Labels = labels
+	return j
+}
+
 // GenerateName sets the JobSet name.
 func (j *JobSetWrapper) SetGenerateName(namePrefix string) *JobSetWrapper {
 	// Name and GenerateName are mutually exclusive, so we must unset the Name field.

--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -1167,7 +1167,7 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 
 		ginkgo.It("Should not create any jobs for it, when unsuspended", func() {
 			var jobList batchv1.JobList
-			ginkgo.By("Unsuspending the jobset", func() {
+			ginkgo.By("Unsuspending the JobSet", func() {
 				updatedJs := &jobset.JobSet{}
 
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -1184,7 +1184,7 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 			}, timeout, interval).Should(gomega.Succeed())
 		})
 
-		ginkgo.It("updates to its status are preserved", func() {
+		ginkgo.It("Updates to its status are preserved", func() {
 			updatedJs := &jobset.JobSet{}
 			wantStatus := jobset.JobSetStatus{
 				Conditions: []metav1.Condition{
@@ -1208,7 +1208,7 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 				},
 			}
 
-			ginkgo.By("Updateing the jobset status", func() {
+			ginkgo.By("Updating the JobSet status", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(js), updatedJs)).To(gomega.Succeed())
 					updatedJs.Status = wantStatus


### PR DESCRIPTION
Add support for a new label `alpha.jobset.sigs.k8s.io/managed-by` which can be used to mark the JobSets that are managed by
another controller then the JobSet one.

The motivation and implementation are similar to the ones described in kubernetes/enhancements#4370 for `batch/Job` and used to implement MultiKueue support for JobSets in Kueue.

Fixes #379