### PR TITLE
Automated cherry pick of #395: default service name in controller

### DIFF
--- a/api/jobset/v1alpha2/jobset_webhook.go
+++ b/api/jobset/v1alpha2/jobset_webhook.go
@@ -63,10 +63,6 @@ func (js *JobSet) Default() {
 		if js.Spec.Network.EnableDNSHostnames == nil {
 			js.Spec.Network.EnableDNSHostnames = ptr.To(true)
 		}
-		// Subdomain defaults to the JobSet name
-		if js.Spec.Network.Subdomain == "" {
-			js.Spec.Network.Subdomain = js.Name
-		}
 
 		// Default pod restart policy to OnFailure.
 		if js.Spec.ReplicatedJobs[i].Template.Spec.Template.Spec.RestartPolicy == "" {

--- a/api/jobset/v1alpha2/jobset_webhook_test.go
+++ b/api/jobset/v1alpha2/jobset_webhook_test.go
@@ -139,49 +139,6 @@ func TestJobSetDefaulting(t *testing.T) {
 			},
 		},
 		{
-			name: "subdomain defaults to jobset name",
-			js: &JobSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "custom-jobset",
-				},
-				Spec: JobSetSpec{
-					SuccessPolicy: defaultSuccessPolicy,
-					ReplicatedJobs: []ReplicatedJob{
-						{
-							Template: batchv1.JobTemplateSpec{
-								Spec: batchv1.JobSpec{
-									Template:       TestPodTemplate,
-									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
-								},
-							},
-						},
-					},
-				},
-			},
-			want: &JobSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "custom-jobset",
-				},
-				Spec: JobSetSpec{
-					SuccessPolicy: defaultSuccessPolicy,
-					Network: &Network{
-						EnableDNSHostnames: ptr.To(true),
-						Subdomain:          "custom-jobset",
-					},
-					ReplicatedJobs: []ReplicatedJob{
-						{
-							Template: batchv1.JobTemplateSpec{
-								Spec: batchv1.JobSpec{
-									Template:       TestPodTemplate,
-									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
 			name: "enableDNSHostnames is false",
 			js: &JobSet{
 				Spec: JobSetSpec{

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -363,11 +363,6 @@ func (r *JobSetReconciler) createJobs(ctx context.Context, js *jobset.JobSet, ow
 
 	// If pod DNS hostnames are enabled, create a headless service for the JobSet
 	if dnsHostnamesEnabled(js) {
-
-		// Don't try to create a headless service without a subdomain
-		if js.Spec.Network.Subdomain == "" {
-			return fmt.Errorf("a subdomain should be set if dns hostnames are enabled")
-		}
 		if err := r.createHeadlessSvcIfNotExist(ctx, js); err != nil {
 			return err
 		}
@@ -411,14 +406,23 @@ func (r *JobSetReconciler) createJobs(ctx context.Context, js *jobset.JobSet, ow
 func (r *JobSetReconciler) createHeadlessSvcIfNotExist(ctx context.Context, js *jobset.JobSet) error {
 	log := ctrl.LoggerFrom(ctx)
 
+	// If enableDNSHostnames is set, and subdomain is unset, default the subdomain to be the JobSet name.
+	// This must be done in the controller rather than in the request-time defaulting, since if a JobSet
+	// uses generateName rather than setting the name explicitly, the JobSet name will still be an empty
+	// string at that time.
+	subdomain := js.Spec.Network.Subdomain
+	if subdomain == "" {
+		subdomain = js.Name
+	}
+
 	// Check if service already exists. The service name should match the subdomain specified in
 	// Spec.Network.Subdomain, with default of <jobSetName> set by the webhook.
 	// If the service doesn't exist in the same namespace, create it.
 	var headlessSvc corev1.Service
-	if err := r.Get(ctx, types.NamespacedName{Name: js.Spec.Network.Subdomain, Namespace: js.Namespace}, &headlessSvc); err != nil {
+	if err := r.Get(ctx, types.NamespacedName{Name: subdomain, Namespace: js.Namespace}, &headlessSvc); err != nil {
 		headlessSvc := corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      js.Spec.Network.Subdomain,
+				Name:      subdomain,
 				Namespace: js.Namespace,
 			},
 			Spec: corev1.ServiceSpec{

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -72,6 +72,14 @@ func (j *JobSetWrapper) SetAnnotations(annotations map[string]string) *JobSetWra
 	return j
 }
 
+// GenerateName sets the JobSet name.
+func (j *JobSetWrapper) SetGenerateName(namePrefix string) *JobSetWrapper {
+	// Name and GenerateName are mutually exclusive, so we must unset the Name field.
+	j.Name = ""
+	j.GenerateName = namePrefix
+	return j
+}
+
 // Obj returns the inner JobSet.
 func (j *JobSetWrapper) Obj() *jobset.JobSet {
 	return &j.JobSet

--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -597,7 +597,7 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 				},
 			},
 		}),
-		ginkgo.Entry("jobset using generateName with enableDNSHostnames should have network subdomain set to the jobset name", &testCase{
+		ginkgo.Entry("jobset using generateName with enableDNSHostnames should have headless service name set to the jobset name", &testCase{
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
 				return testJobSet(ns).SetGenerateName("name-prefix").EnableDNSHostnames(true)
 			},

--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -597,6 +597,20 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 				},
 			},
 		}),
+		ginkgo.Entry("jobset using generateName with enableDNSHostnames should have network subdomain set to the jobset name", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testJobSet(ns).SetGenerateName("name-prefix").EnableDNSHostnames(true)
+			},
+			updates: []*update{
+				{
+					checkJobSetState: func(js *jobset.JobSet) {
+						gomega.Eventually(func() error {
+							return k8sClient.Get(ctx, types.NamespacedName{Name: js.Name, Namespace: js.Namespace}, &corev1.Service{})
+						}, timeout, interval).Should(gomega.Succeed())
+					},
+				},
+			},
+		}),
 	) // end of DescribeTable
 }) // end of Describe
 
@@ -837,7 +851,6 @@ func testJobSet(ns *corev1.Namespace) *testing.JobSetWrapper {
 	return testing.MakeJobSet(jobSetName, ns.Name).
 		SuccessPolicy(&jobset.SuccessPolicy{Operator: jobset.OperatorAll, TargetReplicatedJobs: []string{}}).
 		EnableDNSHostnames(true).
-		NetworkSubdomain(jobSetName).
 		ReplicatedJob(testing.MakeReplicatedJob("replicated-job-a").
 			Job(testing.MakeJobTemplate("test-job-A", ns.Name).PodSpec(testing.TestPodSpec).Obj()).
 			Replicas(1).


### PR DESCRIPTION
Cherry pick of #395 on release-0.3.
#395: default service name in controller
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
```