### PR TITLE
Automated cherry pick of #393: add backoff for creation

### DIFF
--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
-	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -29,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
@@ -385,7 +383,18 @@ func (r *JobSetReconciler) createJobs(ctx context.Context, js *jobset.JobSet, ow
 		}
 		workqueue.ParallelizeUntil(ctx, maxParallelism, len(jobs), func(i int) {
 			job := jobs[i]
-			if err := r.createJobWithBackOff(ctx, js, job); err != nil {
+
+			// Set jobset controller as owner of the job for garbage collection and reconcilation.
+			if err := ctrl.SetControllerReference(js, job, r.Scheme); err != nil {
+				lock.Lock()
+				defer lock.Unlock()
+				finalErrs = append(finalErrs, err)
+				return
+			}
+
+			// Create the job.
+			// TODO(#18): Deal with the case where the job exists but is not owned by the jobset.
+			if err := r.Create(ctx, job); err != nil {
 				lock.Lock()
 				defer lock.Unlock()
 				finalErrs = append(finalErrs, err)
@@ -395,28 +404,6 @@ func (r *JobSetReconciler) createJobs(ctx context.Context, js *jobset.JobSet, ow
 		})
 	}
 	return errors.Join(finalErrs...)
-}
-
-func (r *JobSetReconciler) createJobWithBackOff(ctx context.Context, js *jobset.JobSet, job *batchv1.Job) error {
-	// 1, 2, 4, 8, 16, 32 seconds.
-	backoff := wait.Backoff{
-		Steps:    6,
-		Duration: 1 * time.Second,
-		Factor:   2.0,
-		Jitter:   0.2,
-	}
-	// Set jobset controller as owner of the job for garbage collection and reconcilation.
-	if err := ctrl.SetControllerReference(js, job, r.Scheme); err != nil {
-		return err
-	}
-
-	// Create the job with an exponential back off policy if it already exists.
-	return wait.ExponentialBackoff(backoff, func() (bool, error) {
-		if err := r.Create(ctx, job); err != nil {
-			return false, err
-		}
-		return true, nil
-	})
 }
 
 // TODO: look into adopting service and updating the selector

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -28,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
@@ -383,18 +385,7 @@ func (r *JobSetReconciler) createJobs(ctx context.Context, js *jobset.JobSet, ow
 		}
 		workqueue.ParallelizeUntil(ctx, maxParallelism, len(jobs), func(i int) {
 			job := jobs[i]
-
-			// Set jobset controller as owner of the job for garbage collection and reconcilation.
-			if err := ctrl.SetControllerReference(js, job, r.Scheme); err != nil {
-				lock.Lock()
-				defer lock.Unlock()
-				finalErrs = append(finalErrs, err)
-				return
-			}
-
-			// Create the job.
-			// TODO(#18): Deal with the case where the job exists but is not owned by the jobset.
-			if err := r.Create(ctx, job); err != nil {
+			if err := r.createJobWithBackOff(ctx, js, job); err != nil {
 				lock.Lock()
 				defer lock.Unlock()
 				finalErrs = append(finalErrs, err)
@@ -404,6 +395,28 @@ func (r *JobSetReconciler) createJobs(ctx context.Context, js *jobset.JobSet, ow
 		})
 	}
 	return errors.Join(finalErrs...)
+}
+
+func (r *JobSetReconciler) createJobWithBackOff(ctx context.Context, js *jobset.JobSet, job *batchv1.Job) error {
+	// 1, 2, 4, 8, 16, 32 seconds.
+	backoff := wait.Backoff{
+		Steps:    6,
+		Duration: 1 * time.Second,
+		Factor:   2.0,
+		Jitter:   0.2,
+	}
+	// Set jobset controller as owner of the job for garbage collection and reconcilation.
+	if err := ctrl.SetControllerReference(js, job, r.Scheme); err != nil {
+		return err
+	}
+
+	// Create the job with an exponential back off policy if it already exists.
+	return wait.ExponentialBackoff(backoff, func() (bool, error) {
+		if err := r.Create(ctx, job); err != nil {
+			return false, err
+		}
+		return true, nil
+	})
 }
 
 // TODO: look into adopting service and updating the selector

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -520,12 +520,17 @@ func (r *JobSetReconciler) deleteJobs(ctx context.Context, jobsForDeletion []*ba
 	var finalErrs []error
 	workqueue.ParallelizeUntil(ctx, maxParallelism, len(jobsForDeletion), func(i int) {
 		targetJob := jobsForDeletion[i]
+		// Skip deleting jobs with deletion timestamp already set.
+		if targetJob.DeletionTimestamp != nil {
+			return
+		}
 		// Delete job. This deletion event will trigger another reconciliation,
 		// where the jobs are recreated.
-		backgroundPolicy := metav1.DeletePropagationBackground
-		if err := r.Delete(ctx, targetJob, &client.DeleteOptions{PropagationPolicy: &backgroundPolicy}); client.IgnoreNotFound(err) != nil {
+		foregroundPolicy := metav1.DeletePropagationForeground
+		if err := r.Delete(ctx, targetJob, &client.DeleteOptions{PropagationPolicy: &foregroundPolicy}); client.IgnoreNotFound(err) != nil {
 			lock.Lock()
 			defer lock.Unlock()
+			log.Error(err, fmt.Sprintf("failed to delete job: %q", targetJob.Name))
 			finalErrs = append(finalErrs, err)
 			return
 		}

--- a/pkg/util/collections/collections.go
+++ b/pkg/util/collections/collections.go
@@ -38,3 +38,12 @@ func Contains[T comparable](slice []T, element T) bool {
 	}
 	return false
 }
+
+func IndexOf[T comparable](slice []T, item T) int {
+	for i, v := range slice {
+		if v == item {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
Cherry pick of #393 on release-0.3.
#393: add backoff for creation
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
```