### PR TITLE
Automated cherry pick of #409: validate longest pod name for jobset will not exceed 63 chars

### DIFF
--- a/api/jobset/v1alpha2/jobset_webhook_test.go
+++ b/api/jobset/v1alpha2/jobset_webhook_test.go
@@ -510,6 +510,33 @@ func TestValidateCreate(t *testing.T) {
 				fmt.Errorf("must be no more than 63 characters"),
 			),
 		},
+		{
+			name: "jobset name will result in a pod name being too long",
+			js: &JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: strings.Repeat("a", 56),
+				},
+				Spec: JobSetSpec{
+					ReplicatedJobs: []ReplicatedJob{
+						{
+							Name:     "rj",
+							Replicas: 1,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
+									Completions:    ptr.To(int32(1)),
+									Parallelism:    ptr.To(int32(1)),
+								},
+							},
+						},
+					},
+					SuccessPolicy: &SuccessPolicy{},
+				},
+			},
+			want: errors.Join(
+				fmt.Errorf("must be no more than 63 characters"),
+			),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/util/placement/placement.go
+++ b/pkg/util/placement/placement.go
@@ -15,10 +15,10 @@ func GenJobName(jsName, rjobName string, jobIndex int) string {
 	return fmt.Sprintf("%s-%s-%d", jsName, rjobName, jobIndex)
 }
 
-// GenLeaderPodName returns the name of the leader pod (pod with completion index 0)
-// for a given job in a jobset.
-func GenLeaderPodName(jobSet, replicatedJob, jobIndex string) string {
-	return fmt.Sprintf("%s-%s-%s-0", jobSet, replicatedJob, jobIndex)
+// GenPodName returns the pod name for the given JobSet name, ReplicatedJob name,
+// Job index, and Pod index.
+func GenPodName(jobSet, replicatedJob, jobIndex, podIndex string) string {
+	return fmt.Sprintf("%s-%s-%s-%s", jobSet, replicatedJob, jobIndex, podIndex)
 }
 
 // IsLeaderPod returns true if the given pod is a leader pod (job completion index of 0),

--- a/pkg/webhooks/pod_admission_webhook.go
+++ b/pkg/webhooks/pod_admission_webhook.go
@@ -107,7 +107,7 @@ func (p *podWebhook) leaderPodForFollower(ctx context.Context, pod *corev1.Pod) 
 	return leaderPod, nil
 }
 
-// GenLeaderPodName accepts the name of a pod that is part of a jobset as input, and
+// genLeaderPodName accepts the name of a pod that is part of a jobset as input, and
 // returns the name of the pod with completion index 0 in the same child job.
 func genLeaderPodName(pod *corev1.Pod) (string, error) {
 	// Pod name format: <jobset>-<replicatedJob>-<jobIndex>-<podIndex>-<randomSuffix>
@@ -123,5 +123,6 @@ func genLeaderPodName(pod *corev1.Pod) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("pod missing label: %s", jobset.JobIndexKey)
 	}
-	return placement.GenLeaderPodName(jobSet, replicatedJob, jobIndex), nil
+	leaderPodName := placement.GenPodName(jobSet, replicatedJob, jobIndex, "0")
+	return leaderPodName, nil
 }

--- a/pkg/webhooks/pod_admission_webhook_test.go
+++ b/pkg/webhooks/pod_admission_webhook_test.go
@@ -10,7 +10,7 @@ import (
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 )
 
-func TestGenLeaderPodName(t *testing.T) {
+func TestLeaderPodName(t *testing.T) {
 	cases := []struct {
 		desc    string
 		pod     *corev1.Pod


### PR DESCRIPTION
Cherry pick of #409 on release-0.3.
#409: validate longest pod name for jobset will not exceed 63 chars
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
```