### PR TITLE
Validate follower pod owned by same Job as leader pod

### DIFF
--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -146,9 +146,11 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	// If not, then delete all the job's follower pods so they can be recreated and rescheduled correctly.
 	valid, err := r.validatePodPlacements(ctx, &leaderPod, podList)
 	if err != nil {
+		log.Error(err, "validating pod placements")
 		return ctrl.Result{}, err
 	}
 	if !valid {
+		log.V(2).Info("deleting follower pods for leader pod: %s", leaderPod.Name)
 		return ctrl.Result{}, r.deleteFollowerPods(ctx, podList.Items)
 	}
 	return ctrl.Result{}, nil

--- a/pkg/webhooks/pod_admission_webhook.go
+++ b/pkg/webhooks/pod_admission_webhook.go
@@ -83,7 +83,7 @@ func (p *podWebhook) leaderPodScheduled(ctx context.Context, pod *corev1.Pod) (b
 	}
 	scheduled := leaderPod.Spec.NodeName != ""
 	if !scheduled {
-		log.V(0).Info("leader pod %s is not yet scheduled", leaderPod.Name)
+		log.V(2).Info("leader pod %s is not yet scheduled", leaderPod.Name)
 	}
 	return scheduled, nil
 }

--- a/pkg/webhooks/pod_admission_webhook.go
+++ b/pkg/webhooks/pod_admission_webhook.go
@@ -143,7 +143,7 @@ func genLeaderPodName(pod *corev1.Pod) (string, error) {
 	return leaderPodName, nil
 }
 
-// validatePodsOnSameRestartAttempt returns an error if the leader pod and
+// podsOwnedBySameJob returns an error if the leader pod and
 // follower pod are not owned by the same Job UID. Otherwise, it returns nil.
 func podsOwnedBySameJob(leaderPod, followerPod *corev1.Pod) error {
 	followerOwnerRef := metav1.GetControllerOf(followerPod)
@@ -152,7 +152,7 @@ func podsOwnedBySameJob(leaderPod, followerPod *corev1.Pod) error {
 	}
 	leaderOwnerRef := metav1.GetControllerOf(leaderPod)
 	if leaderOwnerRef == nil {
-		return fmt.Errorf("leader pod %s has no owner reference", leaderPod.Name)
+		return fmt.Errorf("leader pod %q has no owner reference", leaderPod.Name)
 	}
 	if followerOwnerRef.UID != leaderOwnerRef.UID {
 		return fmt.Errorf("follower pod owner UID (%s) != leader pod owner UID (%s)", string(followerOwnerRef.UID), string(leaderOwnerRef.UID))

--- a/pkg/webhooks/pod_admission_webhook_test.go
+++ b/pkg/webhooks/pod_admission_webhook_test.go
@@ -77,26 +77,26 @@ func TestPodsOwnedBySameJob(t *testing.T) {
 	}{
 		{
 			name:        "pods owned by the same job",
-			leaderPod:   createPodWithOwner("job-uid-1", "leader-pod"),
-			followerPod: createPodWithOwner("job-uid-1", "follower-pod"),
+			leaderPod:   createPodWithOwner("leader-pod", "job-uid-1"),
+			followerPod: createPodWithOwner("follower-pod", "job-uid-1"),
 			wantResult:  nil,
 		},
 		{
 			name:        "pods owned by different jobs",
-			leaderPod:   createPodWithOwner("job-uid-1", "leader-pod"),
-			followerPod: createPodWithOwner("job-uid-2", "follower-pod"),
+			leaderPod:   createPodWithOwner("leader-pod", "job-uid-1"),
+			followerPod: createPodWithOwner("follower-pod", "job-uid-2"),
 			wantResult:  fmt.Errorf("follower pod owner UID (%s) != leader pod owner UID (%s)", "job-uid-2", "job-uid-1"),
 		},
 		{
 			name:        "follower pod with no owner",
-			leaderPod:   createPodWithOwner("job-uid-1", "leader-pod"),
-			followerPod: createPodWithOwner("", "follower-pod"),
+			leaderPod:   createPodWithOwner("leader-pod", "job-uid-1"),
+			followerPod: createPodWithOwner("follower-pod", ""),
 			wantResult:  fmt.Errorf("follower pod has no owner reference"),
 		},
 		{
 			name:        "leader pod with no owner",
-			leaderPod:   createPodWithOwner("", "leader-pod"),
-			followerPod: createPodWithOwner("job-uid-2", "follower-pod"),
+			leaderPod:   createPodWithOwner("leader-pod", ""),
+			followerPod: createPodWithOwner("follower-pod", "job-uid-2"),
 			wantResult:  fmt.Errorf("leader pod \"leader-pod\" has no owner reference"),
 		},
 	}
@@ -121,15 +121,15 @@ func TestPodsOwnedBySameJob(t *testing.T) {
 	}
 }
 
-func createPodWithOwner(uid string, name string) *corev1.Pod {
+func createPodWithOwner(name string, ownerUID string) *corev1.Pod {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 	}
-	if uid != "" {
+	if ownerUID != "" {
 		pod.OwnerReferences = []metav1.OwnerReference{
-			{UID: types.UID(uid), Kind: "Job", Controller: ptr.To(true)},
+			{UID: types.UID(ownerUID), Kind: "Job", Controller: ptr.To(true)},
 		}
 	}
 	return pod

--- a/pkg/webhooks/pod_admission_webhook_test.go
+++ b/pkg/webhooks/pod_admission_webhook_test.go
@@ -1,11 +1,14 @@
 package webhooks
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 )
@@ -63,4 +66,71 @@ func TestLeaderPodName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPodsOwnedBySameJob(t *testing.T) {
+	testCases := []struct {
+		name        string
+		leaderPod   *corev1.Pod
+		followerPod *corev1.Pod
+		wantResult  error
+	}{
+		{
+			name:        "pods owned by the same job",
+			leaderPod:   createPodWithOwner("job-uid-1", "leader-pod"),
+			followerPod: createPodWithOwner("job-uid-1", "follower-pod"),
+			wantResult:  nil,
+		},
+		{
+			name:        "pods owned by different jobs",
+			leaderPod:   createPodWithOwner("job-uid-1", "leader-pod"),
+			followerPod: createPodWithOwner("job-uid-2", "follower-pod"),
+			wantResult:  fmt.Errorf("follower pod owner UID (%s) != leader pod owner UID (%s)", "job-uid-2", "job-uid-1"),
+		},
+		{
+			name:        "follower pod with no owner",
+			leaderPod:   createPodWithOwner("job-uid-1", "leader-pod"),
+			followerPod: createPodWithOwner("", "follower-pod"),
+			wantResult:  fmt.Errorf("follower pod has no owner reference"),
+		},
+		{
+			name:        "leader pod with no owner",
+			leaderPod:   createPodWithOwner("", "leader-pod"),
+			followerPod: createPodWithOwner("job-uid-2", "follower-pod"),
+			wantResult:  fmt.Errorf("leader pod \"leader-pod\" has no owner reference"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := podsOwnedBySameJob(tc.leaderPod, tc.followerPod)
+
+			// Want no error, but we got an error.
+			if tc.wantResult == nil && result != nil {
+				t.Errorf("Unexpected error: %v", result)
+
+				// Want an error, but we got no error.
+			} else if tc.wantResult != nil && result == nil {
+				t.Error("Expected error, but got nil")
+
+				// Want an error but the error we got is not the expected error.
+			} else if tc.wantResult != nil && result != nil && tc.wantResult.Error() != result.Error() {
+				t.Errorf("Expected error: %v, got: %v", tc.wantResult, result)
+			}
+		})
+	}
+}
+
+func createPodWithOwner(uid string, name string) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	if uid != "" {
+		pod.OwnerReferences = []metav1.OwnerReference{
+			{UID: types.UID(uid), Kind: "Job", Controller: ptr.To(true)},
+		}
+	}
+	return pod
 }

--- a/pkg/webhooks/pod_mutating_webhook.go
+++ b/pkg/webhooks/pod_mutating_webhook.go
@@ -165,6 +165,7 @@ func (p *podWebhook) setNodeSelector(ctx context.Context, pod *corev1.Pod) error
 	if pod.Spec.NodeSelector == nil {
 		pod.Spec.NodeSelector = make(map[string]string)
 	}
+	log.V(2).Info(fmt.Sprintf("setting nodeSelector %s: %s to follow leader pod %s", topologyKey, topologyValue, leaderPod.Name))
 	pod.Spec.NodeSelector[topologyKey] = topologyValue
 	return nil
 }


### PR DESCRIPTION
This change validates the leader pod has same owner UID as the follower, to ensure they are part of the same Job.
This is necessary to handle a potential race condition between index updates and pod rescheduling during JobSet restarts.

1. A job failure occurs and the JobSet is restarted (deleting and recreating all jobs)
2. Leader pods may land on different node pools than they were originally scheduled on.
3. When the follower pods are recreated, and we look up the leader pod using the index which maps
[pod name without random suffix] -> corev1.Pod object, if this occurs before the index updates for the leader pod have been pushed to the controller, we may get a stale index entry and inject the the wrong nodeSelector, using the topology the leader pod was originally scheduled on before the
restart.