### PR TITLE
Add info to landing page

### DIFF
--- a/site/content/en/_index.html
+++ b/site/content/en/_index.html
@@ -25,7 +25,7 @@ description = "JobSet is a unified API for deploying HPC and AI/ML training work
 
 {{% blocks/lead color="secondary" %}}
 <h1 class="text-center">Use JobSet to orchestrate large scale, distributed ML training and HPC workloads with out of the box
-	support for fault tolerance, fast failure recovery, configurable sucesss/failure policies, and more.
+	support for fault tolerance, fast failure recovery, configurable success/failure policies, and more.
 </h1>
 {{% /blocks/lead %}}
 

--- a/site/content/en/_index.html
+++ b/site/content/en/_index.html
@@ -20,16 +20,20 @@ description = "JobSet is a unified API for deploying HPC and AI/ML training work
 <div id="description" ></div>
 
 {{% blocks/lead color="primary"%}}
-<h1  class="text-center">TBD</h1>
+<h1  class="text-center">JobSet is a K8s-native API for distributed ML training and HPC workloads.</h1>
 {{% /blocks/lead %}}
 
 {{% blocks/lead color="secondary" %}}
-<h1 class="text-center">TBD
+<h1 class="text-center">Use JobSet to orchestrate large scale, distributed ML training and HPC workloads with out of the box
+	support for fault tolerance, fast failure recovery, configurable sucesss/failure policies, and more.
 </h1>
 {{% /blocks/lead %}}
 
 {{% blocks/lead color="dark" %}}
-<h1 class="text-center">TBD</h1>
+<h1 class="text-center">JobSet manages a group of Kubernetes Jobs as a unit, providing a simple way to orchestrate
+	multiple types of Jobs as a single workload. For example, a parameter server and a group of workers can be 
+	managed as a single workload.
+	</h1>
 {{% /blocks/lead %}}
 
 {{< blocks/section color="light" >}}


### PR DESCRIPTION
Fixes #434 

These are intended to be high level snippets of information that describe what JobSet is and its potential use cases.

They are on the docsite landing page (https://jobset.sigs.k8s.io) so it is very important they be simple, digestible, and tell the JobSet story succinctly. 

Let me know if you have any feedback on what we should include here.