### PR TITLE
Emit Job creation failed event

### DIFF
--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -475,6 +475,9 @@ func (r *JobSetReconciler) createJobs(ctx context.Context, js *jobset.JobSet, ow
 	}
 	allErrs := errors.Join(finalErrs...)
 	if allErrs != nil {
+		// Emit event to propagate the Job creation failures up to be more visible to the user.
+		// TODO(#422): Investigate ways to validate Job templates at JobSet validation time.
+		r.Record.Eventf(js, corev1.EventTypeWarning, "JobCreationFailed", "Job creation(s) failed with error: %s", allErrs)
 		return allErrs
 	}
 	// Skip emitting a condition for StartupPolicy if JobSet is suspended

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -456,7 +456,7 @@ func (r *JobSetReconciler) createJobs(ctx context.Context, js *jobset.JobSet, ow
 			if err := r.Create(ctx, job); err != nil {
 				lock.Lock()
 				defer lock.Unlock()
-				finalErrs = append(finalErrs, err)
+				finalErrs = append(finalErrs, fmt.Errorf("job %q creation failed with error: %v", job.Name, err))
 				return
 			}
 			log.V(2).Info("successfully created job", "job", klog.KObj(job))
@@ -477,7 +477,7 @@ func (r *JobSetReconciler) createJobs(ctx context.Context, js *jobset.JobSet, ow
 	if allErrs != nil {
 		// Emit event to propagate the Job creation failures up to be more visible to the user.
 		// TODO(#422): Investigate ways to validate Job templates at JobSet validation time.
-		r.Record.Eventf(js, corev1.EventTypeWarning, "JobCreationFailed", "Job creation(s) failed with error: %s", allErrs)
+		r.Record.Eventf(js, corev1.EventTypeWarning, "JobCreationFailed", allErrs.Error())
 		return allErrs
 	}
 	// Skip emitting a condition for StartupPolicy if JobSet is suspended


### PR DESCRIPTION
Fixes #447 

I opted to only emit 1 event if any Job creation fails, rather than emit a separate event for each Job failure (since there could be many).

While unconventional, I included the error message in the event message since the intent is to allow the user to quickly see why Jobs aren't being created without digging through logs.