### PR TITLE
Fix 404 error when clicking on driver-worker-success-policy.yaml

### DIFF
--- a/site/content/en/docs/tasks/_index.md
+++ b/site/content/en/docs/tasks/_index.md
@@ -19,7 +19,7 @@ no_list: true
 
 Here we have some simple examples demonstrating core JobSet features.
 
-- [Success Policy](https://github.com/kubernetes-sigs/jobset/blob/release-0.4/examples/simple/driver-worker-success-policy.yaml) demonstrates an example of utilizing `successPolicy`.
+- [Success Policy](https://github.com/kubernetes-sigs/jobset/blob/release-0.4/examples/simple/success-policy.yaml) demonstrates an example of utilizing `successPolicy`.
 Success Policy allows one to specify when to mark a JobSet as success.  
 This example showcases an example of using the success policy to mark the JobSet as successful if the worker replicated job completes.
 


### PR DESCRIPTION
driver-worker-success-policy.yaml -> success-policy.yaml

Before was giving a 404 error when clicking on it. success-policy is what it is named.