### PR TITLE
Add ElasticJob support

### DIFF
--- a/api/jobset/v1alpha2/jobset_webhook.go
+++ b/api/jobset/v1alpha2/jobset_webhook.go
@@ -178,8 +178,7 @@ func (js *JobSet) ValidateUpdate(old runtime.Object) (admission.Warnings, error)
 		}
 	}
 	// Note that SucccessPolicy and failurePolicy are made immutable via CEL.
-	errs := apivalidation.ValidateImmutableField(mungedSpec.ReplicatedJobs, oldJS.Spec.ReplicatedJobs, field.NewPath("spec").Child("replicatedJobs"))
-	errs = append(errs, apivalidation.ValidateImmutableField(js.Labels[LabelManagedBy], oldJS.Labels[LabelManagedBy], field.NewPath("metadata").Child("labels").Key(LabelManagedBy))...)
+	errs := apivalidation.ValidateImmutableField(js.Labels[LabelManagedBy], oldJS.Labels[LabelManagedBy], field.NewPath("metadata").Child("labels").Key(LabelManagedBy))
 	return nil, errs.ToAggregate()
 }
 


### PR DESCRIPTION
Fixes #463 

Elastic JobSet provides a way to downscale/upscale replicated jobs. The goal of this PR is to support ElasticJobSet sets.

In order to support this, we need to relax our validation of ReplicatedJobs.


