### PR TITLE
update golang to 1.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
+ARG BUILDER_IMAGE
+ARG BASE_IMAGE
 # Build the manager binary
-FROM golang:1.20 as builder
-ARG TARGETOS
+FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as builder
+
+ARG CGO_ENABLED
 ARG TARGETARCH
 
 WORKDIR /workspace

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/jobset
 
-go 1.21
+go 1.22
 
 require (
 	github.com/google/go-cmp v0.6.0


### PR DESCRIPTION
Seems like a lot of kube dependencies are upgrading to 1.22 with kube 1.30 coming down the pipe.

Let's bump this to 1.22. We just bumped our CI to run with 1.22 image.