### PR TITLE
Move headless service creation outside of createJobs

### DIFF
--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -145,6 +145,7 @@ func (r *JobSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	// If pod DNS hostnames are enabled, create a headless service for the JobSet
 	if err := r.createHeadlessSvcIfNecessary(ctx, &js); err != nil {
+		log.Error(err, "creating headless service")
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
The fact that headless service creation is inside the createJobs function is a relic of the first JobSet release where we created 1 headless service per replicatedJob.

When we changed this to 1 headless service per JobSet, we should have moved this outside of the createJobs function, to better follow the single responsibility principle. The headless service creation now has no dependency on jobs or replicated jobs so we should move it out to the main reconcile loops before job creation begins.