### PR TITLE
Code cleanup and refactoring

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -53,4 +53,9 @@ const (
 	// the same topology domain as the leader pod for that Job).
 	ExclusivePlacementViolationReason  = "ExclusivePlacementViolation"
 	ExclusivePlacementViolationMessage = "Pod violated JobSet exclusive placement policy"
+
+	// Event reason and messages related to startup policy.
+	InOrderStartupPolicyReason           = "StartupPolicyInOrder"
+	InOrderStartupPolicyExecutingMessage = "in order startup policy is executing"
+	InOrderStartupPolicyCompletedMessage = "in order startup policy has completed"
 )

--- a/pkg/controllers/startup_policy_test.go
+++ b/pkg/controllers/startup_policy_test.go
@@ -17,7 +17,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 )
@@ -109,45 +108,8 @@ func TestReplicatedJobStarted(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := replicatedJobsStarted(tc.replicas, tc.replicatedJobStatus)
+			actual := allReplicasStarted(tc.replicas, tc.replicatedJobStatus)
 			if diff := cmp.Diff(tc.expected, actual); diff != "" {
-				t.Errorf("unexpected finished value (+got/-want): %s", diff)
-			}
-		})
-	}
-}
-
-func TestGenerateStartupPolicyCondition(t *testing.T) {
-	tests := []struct {
-		name              string
-		policyComplete    metav1.ConditionStatus
-		expectedCondition metav1.Condition
-	}{
-		{
-			name:           "in progress startup condition on a",
-			policyComplete: metav1.ConditionFalse,
-			expectedCondition: metav1.Condition{
-				Type:    string(jobset.JobSetStartupPolicyCompleted),
-				Status:  metav1.ConditionFalse,
-				Reason:  "StartupPolicyInOrder",
-				Message: "startup policy in order starting",
-			},
-		},
-		{
-			name:           "startup policy complete",
-			policyComplete: metav1.ConditionTrue,
-			expectedCondition: metav1.Condition{
-				Type:    string(jobset.JobSetStartupPolicyCompleted),
-				Status:  metav1.ConditionTrue,
-				Reason:  "StartupPolicyInOrder",
-				Message: "all replicated jobs have started",
-			},
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			actual := generateStartupPolicyCondition(tc.policyComplete)
-			if diff := cmp.Diff(tc.expectedCondition, actual); diff != "" {
 				t.Errorf("unexpected finished value (+got/-want): %s", diff)
 			}
 		})


### PR DESCRIPTION
Code cleanup and refactoring
- Move more event reasons and messages into constants package
- Refactor `suspendJobSet` to `suspendJobs` to follow same pattern as createJobs and deleteJobs, as well as improve readability (since before the logic read "if jobset is suspended, suspend jobset"
- Refactor `resumeJobsIfNecessary` similarly to above
- Split "`generateStartupPolicyCondition(metav1.True or metav1.False)`" into two functions for readability, which better indicate the possible conditions and their semantic meaning:
  - inOrderStartupPolicyExecutingCondition()
  - inOrderStartupPolicyCompletedCondition
- Add some comments throughout the code base where I think things could some explanation
- Rename `rjobStarted` to `allReplicasStarted` to better indicate what exactly is required for a replicatedJob to be considered started.