### PR TITLE
Refactor create jobs

### DIFF
--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -515,9 +515,6 @@ func (r *JobSetReconciler) createJobs(ctx context.Context, js *jobset.JobSet, jo
 		// Create the job.
 		// TODO(#18): Deal with the case where the job exists but is not owned by the jobset.
 		if err := r.Create(ctx, job); err != nil {
-			// Emit event to propagate the Job creation failures up to be more visible to the user.
-			// TODO(#422): Investigate ways to validate Job templates at JobSet validation time.
-			r.Record.Eventf(job, corev1.EventTypeWarning, constants.JobCreationFailedReason, err.Error())
 			lock.Lock()
 			defer lock.Unlock()
 			finalErrs = append(finalErrs, fmt.Errorf("job %q creation failed with error: %v", job.Name, err))


### PR DESCRIPTION
Fixes #495 

Change summary:
- `reconcileReplicatedJobs()` now encapsulates the logic which operates at the replicatedJob level (enforcing in-order startup of replicatedJobs), only calling into `createJobs()` when the replicatedJob is ready to be created (based on the startup policy, any order vs in order)
- `createJobs()` now only creates jobs.
- Removed the event emission we were doing when Job creations failed, since instead we are now emitting an event with the **first** failed job which led to the JobSet being marked failed (see #466)

**Note**: I branched off the feature branch for https://github.com/kubernetes-sigs/jobset/pull/494 to create this, so that must be merged first.

I set https://github.com/kubernetes-sigs/jobset/pull/494 as the base for this PR though so we can start review now.