### PR TITLE
fix: add IsNotFoundErr when get headlessSvc

### DIFF
--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -27,6 +27,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -552,6 +553,9 @@ func (r *JobSetReconciler) createHeadlessSvcIfNecessary(ctx context.Context, js 
 	var headlessSvc corev1.Service
 	subdomain := GetSubdomain(js)
 	if err := r.Get(ctx, types.NamespacedName{Name: subdomain, Namespace: js.Namespace}, &headlessSvc); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return err
+		}
 		headlessSvc := corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      subdomain,


### PR DESCRIPTION
get client error, there are two types of errors: "NotFound" error and others. If it is a "NotFound" error, it should be created. If it is not, the original error should be returned.