### PR TITLE
Update envtest and add back crd generation when updating the api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.26.0
+ENVTEST_K8S_VERSION = 1.29
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ help: ## Display this help.
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) \
 		rbac:roleName=manager-role output:rbac:artifacts:config=config/components/rbac\
+		crd:generateEmbeddedObjectMeta=true output:crd:artifacts:config=config/components/crd/bases\
 		paths="./api/..."
 	$(CONTROLLER_GEN) \
 		rbac:roleName=manager-role output:rbac:artifacts:config=config/components/rbac\


### PR DESCRIPTION
As I was working on https://github.com/kubernetes-sigs/jobset/pull/505#discussion_r1563622468, I found an interesting bug where my CRDs were no longer being updated.

It was a pain in the butt to detect as the code detects the API but e2e/integration report that the field didn't exist.

We need this back so people could generate CRDs if they updated the API.

And I also update envtest to 1.29.0 as 1.26 is out of support.