### PR TITLE
Do not default the managedBy field

### DIFF
--- a/pkg/webhooks/jobset_webhook.go
+++ b/pkg/webhooks/jobset_webhook.go
@@ -121,9 +121,6 @@ func (j *jobSetWebhook) Default(ctx context.Context, obj runtime.Object) error {
 		js.Spec.Network.PublishNotReadyAddresses = ptr.To(true)
 	}
 
-	if js.Spec.ManagedBy == nil {
-		js.Spec.ManagedBy = ptr.To(jobset.JobSetControllerName)
-	}
 	return nil
 }
 

--- a/pkg/webhooks/jobset_webhook_test.go
+++ b/pkg/webhooks/jobset_webhook_test.go
@@ -489,6 +489,7 @@ func TestJobSetDefaulting(t *testing.T) {
 							},
 						},
 					},
+					ManagedBy: ptr.To(jobset.JobSetControllerName),
 				},
 			},
 			want: &jobset.JobSet{
@@ -519,7 +520,7 @@ func TestJobSetDefaulting(t *testing.T) {
 			},
 		},
 		{
-			name: "managed-by label is unset",
+			name: "managedBy field is left nil",
 			js: &jobset.JobSet{
 				Spec: jobset.JobSetSpec{
 					SuccessPolicy: defaultSuccessPolicy,
@@ -551,12 +552,11 @@ func TestJobSetDefaulting(t *testing.T) {
 							},
 						},
 					},
-					ManagedBy: ptr.To(jobset.JobSetControllerName),
 				},
 			},
 		},
 		{
-			name: "when provided, managed-by label is preserved",
+			name: "when provided, managedBy field is preserved",
 			js: &jobset.JobSet{
 				Spec: jobset.JobSetSpec{
 					SuccessPolicy: defaultSuccessPolicy,

--- a/test/integration/webhook/jobset_webhook_test.go
+++ b/test/integration/webhook/jobset_webhook_test.go
@@ -353,7 +353,7 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 			},
 			updateShouldFail: true,
 		}),
-		ginkgo.Entry("validate jobSet immutable for managed-by label", &testCase{
+		ginkgo.Entry("validate jobSet immutable for managedBy field", &testCase{
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
 				return testing.MakeJobSet("js-hostnames-non-indexed", ns.Name).
 					Suspend(true).
@@ -365,7 +365,7 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 						Obj())
 			},
 			defaultsApplied: func(js *jobset.JobSet) bool {
-				return ptr.Deref(js.Spec.ManagedBy, "") == jobset.JobSetControllerName
+				return true
 			},
 			updateJobSet: func(js *jobset.JobSet) {
 				js.Spec.ManagedBy = ptr.To("new-manager")


### PR DESCRIPTION
1. To be consistent with the batch Job which does not default
2. To let MultiKueue default the field to `kueue.x-k8s.io/multikueue` on the management cluster. Otherwise we would need to mutate it.

Not defaulting is fine, because both nil and the reserved value are handled by the JobSet controller the same way.