### PR TITLE
[Release-0.5] Do not default the managedBy field

### DIFF
--- a/pkg/webhooks/jobset_webhook.go
+++ b/pkg/webhooks/jobset_webhook.go
@@ -118,9 +118,6 @@ func (j *jobSetWebhook) Default(ctx context.Context, obj runtime.Object) error {
 		}
 	}
 
-	if js.Spec.ManagedBy == nil {
-		js.Spec.ManagedBy = ptr.To(jobset.JobSetControllerName)
-	}
 	return nil
 }
 

--- a/pkg/webhooks/jobset_webhook_test.go
+++ b/pkg/webhooks/jobset_webhook_test.go
@@ -410,6 +410,7 @@ func TestJobSetDefaulting(t *testing.T) {
 							},
 						},
 					},
+					ManagedBy: ptr.To(jobset.JobSetControllerName),
 				},
 			},
 			want: &jobset.JobSet{
@@ -440,7 +441,7 @@ func TestJobSetDefaulting(t *testing.T) {
 			},
 		},
 		{
-			name: "managed-by label is unset",
+			name: "managedBy field is left nil",
 			js: &jobset.JobSet{
 				Spec: jobset.JobSetSpec{
 					SuccessPolicy: defaultSuccessPolicy,
@@ -472,12 +473,11 @@ func TestJobSetDefaulting(t *testing.T) {
 							},
 						},
 					},
-					ManagedBy: ptr.To(jobset.JobSetControllerName),
 				},
 			},
 		},
 		{
-			name: "when provided, managed-by label is preserved",
+			name: "when provided, managedBy field is preserved",
 			js: &jobset.JobSet{
 				Spec: jobset.JobSetSpec{
 					SuccessPolicy: defaultSuccessPolicy,

--- a/test/integration/webhook/jobset_webhook_test.go
+++ b/test/integration/webhook/jobset_webhook_test.go
@@ -335,7 +335,7 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 			},
 			updateShouldFail: true,
 		}),
-		ginkgo.Entry("validate jobSet immutable for managed-by label", &testCase{
+		ginkgo.Entry("validate jobSet immutable for managedBy field", &testCase{
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
 				return testing.MakeJobSet("js-hostnames-non-indexed", ns.Name).
 					Suspend(true).
@@ -347,7 +347,7 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 						Obj())
 			},
 			defaultsApplied: func(js *jobset.JobSet) bool {
-				return ptr.Deref(js.Spec.ManagedBy, "") == jobset.JobSetControllerName
+				return true
 			},
 			updateJobSet: func(js *jobset.JobSet) {
 				js.Spec.ManagedBy = ptr.To("new-manager")


### PR DESCRIPTION
Cherry pick this into release-0.5.

This is to keep the same behavior as upstream Job and to support Kueue use case. This was a major point of release 0.5 so I think a cherry-pick is useful.

We also need #527 in the patch so we should not release a patch until that PR is also in the release.