### PR TITLE
Automated cherry pick of #527: Fix path for the error when mutating managedBy

### DIFF
--- a/pkg/webhooks/jobset_webhook.go
+++ b/pkg/webhooks/jobset_webhook.go
@@ -228,7 +228,7 @@ func (j *jobSetWebhook) ValidateUpdate(ctx context.Context, old, newObj runtime.
 	}
 	// Note that SucccessPolicy and failurePolicy are made immutable via CEL.
 	errs := apivalidation.ValidateImmutableField(mungedSpec.ReplicatedJobs, oldJS.Spec.ReplicatedJobs, field.NewPath("spec").Child("replicatedJobs"))
-	errs = append(errs, apivalidation.ValidateImmutableField(mungedSpec.ManagedBy, oldJS.Spec.ManagedBy, field.NewPath("spec").Child("labels").Key("managedBy"))...)
+	errs = append(errs, apivalidation.ValidateImmutableField(mungedSpec.ManagedBy, oldJS.Spec.ManagedBy, field.NewPath("spec").Child("managedBy"))...)
 	return nil, errs.ToAggregate()
 }
 

--- a/pkg/webhooks/jobset_webhook_test.go
+++ b/pkg/webhooks/jobset_webhook_test.go
@@ -977,19 +977,19 @@ func TestValidateUpdate(t *testing.T) {
 			js: &jobset.JobSet{
 				ObjectMeta: validObjectMeta,
 				Spec: jobset.JobSetSpec{
-					ManagedBy:      ptr.To("example.com/one"),
+					ManagedBy:      ptr.To("example.com/new"),
 					ReplicatedJobs: validReplicatedJobs,
 				},
 			},
 			oldJs: &jobset.JobSet{
 				ObjectMeta: validObjectMeta,
 				Spec: jobset.JobSetSpec{
-					ManagedBy:      ptr.To("example.com/two"),
+					ManagedBy:      ptr.To("example.com/old"),
 					ReplicatedJobs: validReplicatedJobs,
 				},
 			},
 			want: field.ErrorList{
-				field.Invalid(field.NewPath("spec").Child("managedBy"), ptr.To("example.com/one"), "field is immutable"),
+				field.Invalid(field.NewPath("spec").Child("managedBy"), ptr.To("example.com/new"), "field is immutable"),
 			}.ToAggregate(),
 		},
 		{

--- a/pkg/webhooks/jobset_webhook_test.go
+++ b/pkg/webhooks/jobset_webhook_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -990,7 +989,7 @@ func TestValidateUpdate(t *testing.T) {
 				},
 			},
 			want: field.ErrorList{
-				field.Invalid(field.NewPath("spec").Child("managedBy"), "", "field is immutable"),
+				field.Invalid(field.NewPath("spec").Child("managedBy"), ptr.To("example.com/one"), "field is immutable"),
 			}.ToAggregate(),
 		},
 		{
@@ -1028,7 +1027,26 @@ func TestValidateUpdate(t *testing.T) {
 				},
 			},
 			want: field.ErrorList{
-				field.Invalid(field.NewPath("spec").Child("replicatedJobs"), "", "field is immutable"),
+				field.Invalid(field.NewPath("spec").Child("replicatedJobs"), []jobset.ReplicatedJob{
+					{
+						Name:     "test-jobset-replicated-job-0",
+						Replicas: 2,
+						Template: batchv1.JobTemplateSpec{
+							Spec: batchv1.JobSpec{
+								Parallelism: ptr.To[int32](2),
+							},
+						},
+					},
+					{
+						Name:     "test-jobset-replicated-job-1",
+						Replicas: 1,
+						Template: batchv1.JobTemplateSpec{
+							Spec: batchv1.JobSpec{
+								Parallelism: ptr.To[int32](1),
+							},
+						},
+					},
+				}, "field is immutable"),
 			}.ToAggregate(),
 		},
 	}
@@ -1041,7 +1059,7 @@ func TestValidateUpdate(t *testing.T) {
 			newObj := tc.js.DeepCopyObject()
 			oldObj := tc.oldJs.DeepCopyObject()
 			_, err = webhook.ValidateUpdate(context.TODO(), oldObj, newObj)
-			if diff := cmp.Diff(tc.want, err, cmpopts.IgnoreFields(field.Error{}, "BadValue")); diff != "" {
+			if diff := cmp.Diff(tc.want, err); diff != "" {
 				t.Errorf("ValidateResources() mismatch (-want +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
Cherry pick of #527 on release-0.5.
#527: Fix path for the error when mutating managedBy
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
```