### PR TITLE
Correct typo in configurable failure policy KEP.

### DIFF
--- a/keps/262-ConfigurableFailurePolicy/README.md
+++ b/keps/262-ConfigurableFailurePolicy/README.md
@@ -371,7 +371,7 @@ in the batchv1 Job API. At the time of writing this KEP, these include:
   - `MaxFailedIndexesExceeded`
   - `FailedIndexes`
 
-### Implmentation
+### Implementation
 
 The core part of the implementation will be defining what specific mechanisms the JobSet controller uses to implement
 the behavior defined for each FailurePolicyAction type:


### PR DESCRIPTION
This pull request resolves #538.