### PR TITLE
Don't reconcile JobSets with deletion timestamp set

### DIFF
--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -103,6 +103,11 @@ func (r *JobSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	// Don't reconcile JobSets marked for deletion.
+	if jobSetMarkedForDeletion(&js) {
+		return ctrl.Result{}, nil
+	}
+
 	// Track JobSet status updates that should be performed at the end of the reconciliation attempt.
 	updateStatusOpts := statusUpdateOpts{}
 
@@ -827,6 +832,10 @@ func jobSetFinished(js *jobset.JobSet) bool {
 		}
 	}
 	return false
+}
+
+func jobSetMarkedForDeletion(js *jobset.JobSet) bool {
+	return js.DeletionTimestamp != nil
 }
 
 func dnsHostnamesEnabled(js *jobset.JobSet) bool {


### PR DESCRIPTION
Fixes #561 

Confirmed the fix works via manual testing.

Without the changes in this PR, I deployed a JobSet with 100 Jobs and attempted to delete with foreground cascading deletion policy via  `k delete jobset paralleljobs --cascade=foreground`, and observed the behavior described in #561 where the child jobs and services are continually being recreated after being deleted.

With the changes in this PR, I deployed the same JobSet of 100 Jobs and deleted it with foreground cascading deletion policy, and confirmed the foreground deletion worked as expected.