### PR TITLE
Automated cherry pick of #562: don't reconcile jobsets with deletion timestamp set

### DIFF
--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -103,6 +103,11 @@ func (r *JobSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	// Don't reconcile JobSets marked for deletion.
+	if jobSetMarkedForDeletion(&js) {
+		return ctrl.Result{}, nil
+	}
+
 	// Track JobSet status updates that should be performed at the end of the reconciliation attempt.
 	updateStatusOpts := statusUpdateOpts{}
 
@@ -814,6 +819,10 @@ func jobSetFinished(js *jobset.JobSet) bool {
 		}
 	}
 	return false
+}
+
+func jobSetMarkedForDeletion(js *jobset.JobSet) bool {
+	return js.DeletionTimestamp != nil
 }
 
 func dnsHostnamesEnabled(js *jobset.JobSet) bool {


### PR DESCRIPTION
Cherry pick of #562 on release-0.5.
#562: don't reconcile jobsets with deletion timestamp set
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
```