### PR TITLE
Improve the API generated docs for managedBy

### DIFF
--- a/api/jobset/v1alpha2/jobset_types.go
+++ b/api/jobset/v1alpha2/jobset_types.go
@@ -94,7 +94,18 @@ type JobSetSpec struct {
 	// Suspend suspends all running child Jobs when set to true.
 	Suspend *bool `json:"suspend,omitempty"`
 
-	// ManagedBy is used to indicate the controller or entity that manages a JobSet
+	// ManagedBy is used to indicate the controller or entity that manages a JobSet.
+	// The built-in JobSet controller reconciles JobSets which don't have this
+	// field at all or the field value is the reserved string
+	// `jobset.sigs.k8s.io/jobset-controller`, but skips reconciling JobSets
+	// with a custom value for this field.
+	//
+	// The value must be a valid domain-prefixed path (e.g. acme.io/foo) -
+	// all characters before the first "/" must be a valid subdomain as defined
+	// by RFC 1123. All characters trailing the first "/" must be valid HTTP Path
+	// characters as defined by RFC 3986. The value cannot exceed 63 characters.
+	// The field is immutable.
+	// +optional
 	ManagedBy *string `json:"managedBy,omitempty"`
 
 	// TTLSecondsAfterFinished limits the lifetime of a JobSet that has finished

--- a/api/jobset/v1alpha2/openapi_generated.go
+++ b/api/jobset/v1alpha2/openapi_generated.go
@@ -214,7 +214,7 @@ func schema_jobset_api_jobset_v1alpha2_JobSetSpec(ref common.ReferenceCallback) 
 					},
 					"managedBy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ManagedBy is used to indicate the controller or entity that manages a JobSet",
+							Description: "ManagedBy is used to indicate the controller or entity that manages a JobSet. The built-in JobSet controller reconciles JobSets which don't have this field at all or the field value is the reserved string `jobset.sigs.k8s.io/jobset-controller`, but skips reconciling JobSets with a custom value for this field.\n\nThe value must be a valid domain-prefixed path (e.g. acme.io/foo) - all characters before the first \"/\" must be a valid subdomain as defined by RFC 1123. All characters trailing the first \"/\" must be valid HTTP Path characters as defined by RFC 3986. The value cannot exceed 63 characters. The field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
+++ b/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
@@ -73,8 +73,19 @@ spec:
                 - message: Value is immutable
                   rule: self == oldSelf
               managedBy:
-                description: ManagedBy is used to indicate the controller or entity
-                  that manages a JobSet
+                description: |-
+                  ManagedBy is used to indicate the controller or entity that manages a JobSet.
+                  The built-in JobSet controller reconciles JobSets which don't have this
+                  field at all or the field value is the reserved string
+                  `jobset.sigs.k8s.io/jobset-controller`, but skips reconciling JobSets
+                  with a custom value for this field.
+
+
+                  The value must be a valid domain-prefixed path (e.g. acme.io/foo) -
+                  all characters before the first "/" must be a valid subdomain as defined
+                  by RFC 1123. All characters trailing the first "/" must be valid HTTP Path
+                  characters as defined by RFC 3986. The value cannot exceed 63 characters.
+                  The field is immutable.
                 type: string
               network:
                 description: Network defines the networking options for the jobset.

--- a/hack/python-sdk/swagger.json
+++ b/hack/python-sdk/swagger.json
@@ -80,7 +80,7 @@
           "$ref": "#/definitions/jobset.v1alpha2.FailurePolicy"
         },
         "managedBy": {
-          "description": "ManagedBy is used to indicate the controller or entity that manages a JobSet",
+          "description": "ManagedBy is used to indicate the controller or entity that manages a JobSet. The built-in JobSet controller reconciles JobSets which don't have this field at all or the field value is the reserved string `jobset.sigs.k8s.io/jobset-controller`, but skips reconciling JobSets with a custom value for this field.\n\nThe value must be a valid domain-prefixed path (e.g. acme.io/foo) - all characters before the first \"/\" must be a valid subdomain as defined by RFC 1123. All characters trailing the first \"/\" must be valid HTTP Path characters as defined by RFC 3986. The value cannot exceed 63 characters. The field is immutable.",
           "type": "string"
         },
         "network": {

--- a/sdk/python/docs/JobsetV1alpha2JobSetSpec.md
+++ b/sdk/python/docs/JobsetV1alpha2JobSetSpec.md
@@ -5,7 +5,7 @@ JobSetSpec defines the desired state of JobSet
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **failure_policy** | [**JobsetV1alpha2FailurePolicy**](JobsetV1alpha2FailurePolicy.md) |  | [optional] 
-**managed_by** | **str** | ManagedBy is used to indicate the controller or entity that manages a JobSet | [optional] 
+**managed_by** | **str** | ManagedBy is used to indicate the controller or entity that manages a JobSet. The built-in JobSet controller reconciles JobSets which don&#39;t have this field at all or the field value is the reserved string &#x60;jobset.sigs.k8s.io/jobset-controller&#x60;, but skips reconciling JobSets with a custom value for this field.  The value must be a valid domain-prefixed path (e.g. acme.io/foo) - all characters before the first \&quot;/\&quot; must be a valid subdomain as defined by RFC 1123. All characters trailing the first \&quot;/\&quot; must be valid HTTP Path characters as defined by RFC 3986. The value cannot exceed 63 characters. The field is immutable. | [optional] 
 **network** | [**JobsetV1alpha2Network**](JobsetV1alpha2Network.md) |  | [optional] 
 **replicated_jobs** | [**list[JobsetV1alpha2ReplicatedJob]**](JobsetV1alpha2ReplicatedJob.md) | ReplicatedJobs is the group of jobs that will form the set. | [optional] 
 **startup_policy** | [**JobsetV1alpha2StartupPolicy**](JobsetV1alpha2StartupPolicy.md) |  | [optional] 

--- a/sdk/python/jobset/models/jobset_v1alpha2_job_set_spec.py
+++ b/sdk/python/jobset/models/jobset_v1alpha2_job_set_spec.py
@@ -112,7 +112,7 @@ class JobsetV1alpha2JobSetSpec(object):
     def managed_by(self):
         """Gets the managed_by of this JobsetV1alpha2JobSetSpec.  # noqa: E501
 
-        ManagedBy is used to indicate the controller or entity that manages a JobSet  # noqa: E501
+        ManagedBy is used to indicate the controller or entity that manages a JobSet. The built-in JobSet controller reconciles JobSets which don't have this field at all or the field value is the reserved string `jobset.sigs.k8s.io/jobset-controller`, but skips reconciling JobSets with a custom value for this field.  The value must be a valid domain-prefixed path (e.g. acme.io/foo) - all characters before the first \"/\" must be a valid subdomain as defined by RFC 1123. All characters trailing the first \"/\" must be valid HTTP Path characters as defined by RFC 3986. The value cannot exceed 63 characters. The field is immutable.  # noqa: E501
 
         :return: The managed_by of this JobsetV1alpha2JobSetSpec.  # noqa: E501
         :rtype: str
@@ -123,7 +123,7 @@ class JobsetV1alpha2JobSetSpec(object):
     def managed_by(self, managed_by):
         """Sets the managed_by of this JobsetV1alpha2JobSetSpec.
 
-        ManagedBy is used to indicate the controller or entity that manages a JobSet  # noqa: E501
+        ManagedBy is used to indicate the controller or entity that manages a JobSet. The built-in JobSet controller reconciles JobSets which don't have this field at all or the field value is the reserved string `jobset.sigs.k8s.io/jobset-controller`, but skips reconciling JobSets with a custom value for this field.  The value must be a valid domain-prefixed path (e.g. acme.io/foo) - all characters before the first \"/\" must be a valid subdomain as defined by RFC 1123. All characters trailing the first \"/\" must be valid HTTP Path characters as defined by RFC 3986. The value cannot exceed 63 characters. The field is immutable.  # noqa: E501
 
         :param managed_by: The managed_by of this JobsetV1alpha2JobSetSpec.  # noqa: E501
         :type: str


### PR DESCRIPTION
/kind documentation

- mention this is immutable (motivated by the [thread](https://github.com/kubernetes-sigs/kueue/pull/2048#discussion_r1595354688))
- describe validation rules as in k/k for Job [link](https://github.com/kubernetes/kubernetes/blob/57b406a18afc54c84725488e0ca3d4b4cabd61db/pkg/apis/batch/types.go#L472-L484)