### PR TITLE
Automated cherry pick of #590: propagate job pod template updates to suspended jobs when

### DIFF
--- a/pkg/util/collections/collections.go
+++ b/pkg/util/collections/collections.go
@@ -47,3 +47,41 @@ func IndexOf[T comparable](slice []T, item T) int {
 	}
 	return -1
 }
+
+// MergeMaps will merge the `old` and `new` maps and return the
+// merged map. If a key appears in both maps, the key-value pair
+// in the `new` map will overwrite the value in the `old` map.
+func MergeMaps[K comparable, V any](old, new map[K]V) map[K]V {
+	merged := make(map[K]V)
+	for k, v := range old {
+		merged[k] = v
+	}
+	for k, v := range new {
+		merged[k] = v // Overwrite if duplicate
+	}
+	return merged
+}
+
+func MergeSlices[T comparable](s1, s2 []T) []T {
+	mergedSet := make(map[T]bool)
+
+	// Add elements from s1 to the set
+	for _, item := range s1 {
+		mergedSet[item] = true
+	}
+
+	// Add elements from s2, only if they are not already in the set
+	for _, item := range s2 {
+		if _, exists := mergedSet[item]; !exists {
+			mergedSet[item] = true
+		}
+	}
+
+	// Convert the set back into a slice
+	mergedSlice := make([]T, 0, len(mergedSet))
+	for item := range mergedSet {
+		mergedSlice = append(mergedSlice, item)
+	}
+
+	return mergedSlice
+}

--- a/pkg/util/collections/collections_test.go
+++ b/pkg/util/collections/collections_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"golang.org/x/exp/slices"
 )
 
 func TestConcat(t *testing.T) {
@@ -147,6 +148,93 @@ func TestContains(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := Contains(tc.slice, tc.element); got != tc.want {
 				t.Errorf("got: %t, want %t", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMergeMaps(t *testing.T) {
+	testCases := []struct {
+		name     string
+		m1       map[string]int
+		m2       map[string]int
+		expected map[string]int
+	}{
+		{
+			name:     "Basic merge",
+			m1:       map[string]int{"a": 1, "b": 2},
+			m2:       map[string]int{"c": 3, "d": 4},
+			expected: map[string]int{"a": 1, "b": 2, "c": 3, "d": 4},
+		},
+		{
+			name:     "Overlapping keys",
+			m1:       map[string]int{"a": 1, "b": 2},
+			m2:       map[string]int{"b": 3, "c": 4},
+			expected: map[string]int{"a": 1, "b": 3, "c": 4}, // m2 value for 'b' overwrites
+		},
+		{
+			name:     "Empty maps",
+			m1:       map[string]int{},
+			m2:       map[string]int{},
+			expected: map[string]int{},
+		},
+		{
+			name:     "One empty map",
+			m1:       map[string]int{"a": 1, "b": 2},
+			m2:       map[string]int{},
+			expected: map[string]int{"a": 1, "b": 2},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			merged := MergeMaps(tc.m1, tc.m2)
+
+			if !reflect.DeepEqual(merged, tc.expected) {
+				t.Errorf("expected %v, got %v", tc.expected, merged)
+			}
+		})
+	}
+}
+
+func TestMergeSlices(t *testing.T) {
+	testCases := []struct {
+		name     string
+		s1       []int
+		s2       []int
+		expected []int
+	}{
+		{
+			name:     "merge with overlapping elements should not result in duplicates",
+			s1:       []int{1, 2, 3},
+			s2:       []int{3, 4, 5},
+			expected: []int{1, 2, 3, 4, 5},
+		},
+		{
+			name:     "empty slices",
+			s1:       []int{},
+			s2:       []int{},
+			expected: []int{},
+		},
+		{
+			name:     "one empty slice",
+			s1:       []int{1, 2},
+			s2:       []int{},
+			expected: []int{1, 2},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			merged := MergeSlices(tc.s1, tc.s2)
+
+			// Sort before comparison so slices with the same elements
+			// should be the same.
+			slices.Sort(merged)
+			slices.Sort(tc.expected)
+
+			if !reflect.DeepEqual(merged, tc.expected) {
+				t.Errorf("Expected %v, got %v", tc.expected, merged)
 			}
 		})
 	}


### PR DESCRIPTION
Cherry pick of #590 on release-0.5.
#590: propagate job pod template updates to suspended jobs when
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
```