### PR TITLE
fix: fix log to avoid panic

### DIFF
--- a/pkg/controllers/failure_policy.go
+++ b/pkg/controllers/failure_policy.go
@@ -100,10 +100,10 @@ func findFirstFailedPolicyRuleAndJob(ctx context.Context, rules []jobset.Failure
 		}
 
 		if matchedFailedJob != nil {
-			log.V(2).Info("found a failed job matching failure policy rule with index %v and name %v", index, rule.Name)
+			log.V(2).Info(fmt.Sprintf("found a failed job matching failure policy rule with index %v and name %v", index, rule.Name))
 			return &rule, matchedFailedJob
 		}
-		log.V(2).Info("did not find a failed job matching failure policy rule with index %v and name %v", index, rule.Name)
+		log.V(2).Info(fmt.Sprintf("did not find a failed job matching failure policy rule with index %v and name %v", index, rule.Name))
 	}
 
 	log.V(2).Info("never found a matched failure policy rule.")
@@ -142,7 +142,7 @@ func ruleIsApplicable(ctx context.Context, rule jobset.FailurePolicyRule, failed
 	parentReplicatedJob, exists := parentReplicatedJobName(failedJob)
 	if !exists {
 		// If we cannot find the parent ReplicatedJob, we assume the rule does not apply.
-		log.V(2).Info("The failed job %v does not appear to have a parent replicatedJob.", failedJob.Name)
+		log.V(2).Info(fmt.Sprintf("The failed job %v does not appear to have a parent replicatedJob.", failedJob.Name))
 		return false
 	}
 


### PR DESCRIPTION
This way of printing logs will panic
/kind bug
```go
package main

import (
	"context"
	"flag"
	ctrl "sigs.k8s.io/controller-runtime"
	logf "sigs.k8s.io/controller-runtime/pkg/log"
	"sigs.k8s.io/controller-runtime/pkg/log/zap"
)

func main() {

	opts := zap.Options{
		Development: true,
	}
	opts.BindFlags(flag.CommandLine)
	flag.Parse()

	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
	log := logf.FromContext(context.TODO())

	log.Info("starting manager")
	log.Info("found a failed job matching failure policy rule with index %v and name %v", 1, "rule.Name")
}

```