### PR TITLE
docs: fix typo, Github -> GitHub

### DIFF
--- a/site/content/en/_index.html
+++ b/site/content/en/_index.html
@@ -10,7 +10,7 @@ description = "JobSet is a unified API for deploying HPC and AI/ML training work
 		Read the docs <i class="fas fa-arrow-alt-circle-right ml-2"></i>
 	</a>
 	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://github.com/kubernetes-sigs/jobset">
-		Github <i class="fab fa-github ml-2 "></i>
+		GitHub <i class="fab fa-github ml-2 "></i>
 	</a>
 	<p class="lead mt-5">A unified API for deploying HPC and AI/ML training workloads on Kubernetes</p>
 	{{< blocks/link-down color="info" id="description" >}}


### PR DESCRIPTION
fix typo, `Github` -> `GitHub`