### PR TITLE
support elastic jobset

### DIFF
--- a/pkg/controllers/elastic_jobset.go
+++ b/pkg/controllers/elastic_jobset.go
@@ -15,6 +15,7 @@ package controllers
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -22,29 +23,64 @@ import (
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 )
 
-// jobsToDeleteDownScale gathers the excess jobs during a downscale
+func indexFunc(a, b batchv1.Job) int {
+	jobIndexA, errA := strconv.Atoi(a.Labels[jobset.JobIndexKey])
+	jobIndexB, errB := strconv.Atoi(b.Labels[jobset.JobIndexKey])
+	if errA != nil {
+		return 0
+	}
+	if errB != nil {
+		return 0
+	}
+	if jobIndexA > jobIndexB {
+		return 1
+	} else if jobIndexA < jobIndexB {
+		return -1
+	} else {
+		return 0
+	}
+}
+
+// jobsToDeleteForDownScale gathers the excess jobs during a downscale
 // and deletes the jobs
-func jobsToDeleteDownScale(replicatedJobs []jobset.ReplicatedJob, replicatedJobStatus []jobset.ReplicatedJobStatus, jobItems []batchv1.Job) ([]*batchv1.Job, error) {
+func jobsToDeleteForDownScale(replicatedJobs []jobset.ReplicatedJob, replicatedJobStatuses []jobset.ReplicatedJobStatus, jobItems []batchv1.Job) ([]*batchv1.Job, error) {
 	jobsToDelete := []*batchv1.Job{}
+	type payload struct {
+		batchJobs []batchv1.Job
+		rjStatus  jobset.ReplicatedJobStatus
+		replicas  int32
+	}
+	replicatedJobToBatchJobMap := map[string]payload{}
 	for _, replicatedJob := range replicatedJobs {
-		status := findReplicatedJobStatus(replicatedJobStatus, replicatedJob.Name)
-		countOfJobsToDelete := status.Ready - replicatedJob.Replicas
+		status := findReplicatedJobStatus(replicatedJobStatuses, replicatedJob.Name)
+		newPayload := &payload{}
+		newPayload.rjStatus = status
+		newPayload.replicas = replicatedJob.Replicas
+		for _, val := range jobItems {
+			if val.Labels[jobset.ReplicatedJobNameKey] != replicatedJob.Name {
+				continue
+			}
+			newPayload.batchJobs = append(newPayload.batchJobs, val)
+		}
+		slices.SortFunc(newPayload.batchJobs, indexFunc)
+		replicatedJobToBatchJobMap[replicatedJob.Name] = *newPayload
+	}
+	for _, jobAndStatus := range replicatedJobToBatchJobMap {
+		countOfJobsToDelete := jobAndStatus.rjStatus.Ready - jobAndStatus.replicas
 		if countOfJobsToDelete > 0 {
 			jobsWeDeleted := 0
-			for _, val := range jobItems {
-				if val.Labels[jobset.ReplicatedJobNameKey] != replicatedJob.Name {
-					continue
-				}
-				jobIndex, err := strconv.Atoi(val.Labels[jobset.JobIndexKey])
+			for i := len(jobAndStatus.batchJobs) - 1; i >= 0; i-- {
+
+				jobIndex, err := strconv.Atoi(jobAndStatus.batchJobs[i].Labels[jobset.JobIndexKey])
 				if err != nil {
 					return nil, fmt.Errorf("unable get integer from job index key")
 				}
 				if jobIndex >= int(countOfJobsToDelete) {
 					jobsWeDeleted = jobsWeDeleted + 1
-					jobsToDelete = append(jobsToDelete, &val)
+					jobsToDelete = append(jobsToDelete, &jobAndStatus.batchJobs[i])
 				}
 				if jobsWeDeleted == int(countOfJobsToDelete) {
-					continue
+					break
 				}
 			}
 		}

--- a/pkg/controllers/elastic_jobset.go
+++ b/pkg/controllers/elastic_jobset.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"fmt"
+	"strconv"
+
+	batchv1 "k8s.io/api/batch/v1"
+
+	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+)
+
+// jobsToDeleteDownScale gathers the excess jobs during a downscale
+// and deletes the jobs
+func jobsToDeleteDownScale(replicatedJobs []jobset.ReplicatedJob, replicatedJobStatus []jobset.ReplicatedJobStatus, jobItems []batchv1.Job) ([]*batchv1.Job, error) {
+	jobsToDelete := []*batchv1.Job{}
+	for _, replicatedJob := range replicatedJobs {
+		status := findReplicatedJobStatus(replicatedJobStatus, replicatedJob.Name)
+		countOfJobsToDelete := status.Ready - replicatedJob.Replicas
+		if countOfJobsToDelete > 0 {
+			jobsWeDeleted := 0
+			for _, val := range jobItems {
+				if val.Labels[jobset.ReplicatedJobNameKey] != replicatedJob.Name {
+					continue
+				}
+				jobIndex, err := strconv.Atoi(val.Labels[jobset.JobIndexKey])
+				if err != nil {
+					return nil, fmt.Errorf("unable get integer from job index key")
+				}
+				if jobIndex >= int(countOfJobsToDelete) {
+					jobsWeDeleted = jobsWeDeleted + 1
+					jobsToDelete = append(jobsToDelete, &val)
+				}
+				if jobsWeDeleted == int(countOfJobsToDelete) {
+					continue
+				}
+			}
+		}
+	}
+	return jobsToDelete, nil
+}

--- a/pkg/controllers/elastic_jobset_test.go
+++ b/pkg/controllers/elastic_jobset_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+)
+
+func TestJobsToDeleteDownScale(t *testing.T) {
+
+	tests := []struct {
+		name                 string
+		replicatedJobs       []jobset.ReplicatedJob
+		replicatedJobStatus  []jobset.ReplicatedJobStatus
+		jobs                 []batchv1.Job
+		expectedJobsToDelete int32
+		gotError             error
+	}{
+		{
+			name: "no elastic downscale",
+			replicatedJobs: []jobset.ReplicatedJob{
+				{
+					Name:     "test",
+					Template: batchv1.JobTemplateSpec{},
+					Replicas: 2,
+				},
+			},
+			replicatedJobStatus: []jobset.ReplicatedJobStatus{
+				{
+					Name:  "test",
+					Ready: 1,
+				},
+			},
+			jobs: []batchv1.Job{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Labels: map[string]string{
+							jobset.ReplicatedJobNameKey: "test",
+							jobset.JobIndexKey:          "0",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "elastic upscale; do nothing",
+			replicatedJobs: []jobset.ReplicatedJob{
+				{
+					Name:     "test",
+					Template: batchv1.JobTemplateSpec{},
+					Replicas: 2,
+				},
+			},
+			replicatedJobStatus: []jobset.ReplicatedJobStatus{
+				{
+					Name:  "test",
+					Ready: 1,
+				},
+			},
+			jobs: []batchv1.Job{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Labels: map[string]string{
+							jobset.ReplicatedJobNameKey: "test",
+							jobset.JobIndexKey:          "0",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "elastic downscale is needed",
+			replicatedJobs: []jobset.ReplicatedJob{
+				{
+					Name:     "test",
+					Template: batchv1.JobTemplateSpec{},
+					Replicas: 1,
+				},
+			},
+			replicatedJobStatus: []jobset.ReplicatedJobStatus{
+				{
+					Name:  "test",
+					Ready: 2,
+				},
+			},
+			jobs: []batchv1.Job{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Labels: map[string]string{
+							jobset.ReplicatedJobNameKey: "test",
+							jobset.JobIndexKey:          "0",
+						},
+					},
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Labels: map[string]string{
+							jobset.ReplicatedJobNameKey: "test",
+							jobset.JobIndexKey:          "1",
+						},
+					},
+				},
+			},
+			expectedJobsToDelete: 1,
+		},
+		{
+			name: "elastic downscale is needed for second replicated job",
+			replicatedJobs: []jobset.ReplicatedJob{
+				{
+					Name:     "test",
+					Template: batchv1.JobTemplateSpec{},
+					Replicas: 2,
+				},
+				{
+					Name:     "test-2",
+					Template: batchv1.JobTemplateSpec{},
+					Replicas: 2,
+				},
+			},
+			replicatedJobStatus: []jobset.ReplicatedJobStatus{
+				{
+					Name:  "test",
+					Ready: 2,
+				},
+				{
+					Name:  "test-2",
+					Ready: 4,
+				},
+			},
+			jobs: []batchv1.Job{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Labels: map[string]string{
+							jobset.ReplicatedJobNameKey: "test",
+							jobset.JobIndexKey:          "0",
+						},
+					},
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Labels: map[string]string{
+							jobset.ReplicatedJobNameKey: "test",
+							jobset.JobIndexKey:          "1",
+						},
+					},
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Labels: map[string]string{
+							jobset.ReplicatedJobNameKey: "test-2",
+							jobset.JobIndexKey:          "0",
+						},
+					},
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Labels: map[string]string{
+							jobset.ReplicatedJobNameKey: "test-2",
+							jobset.JobIndexKey:          "1",
+						},
+					},
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Labels: map[string]string{
+							jobset.ReplicatedJobNameKey: "test-2",
+							jobset.JobIndexKey:          "2",
+						},
+					},
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Labels: map[string]string{
+							jobset.ReplicatedJobNameKey: "test-2",
+							jobset.JobIndexKey:          "3",
+						},
+					},
+				},
+			},
+			expectedJobsToDelete: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := jobsToDeleteDownScale(tc.replicatedJobs, tc.replicatedJobStatus, tc.jobs)
+			if diff := cmp.Diff(tc.gotError, err); diff != "" {
+				t.Errorf("unexpected finished value (+got/-want): %s", diff)
+			}
+			if diff := cmp.Diff(tc.expectedJobsToDelete, int32(len(actual))); diff != "" {
+				t.Errorf("unexpected finished value (+got/-want): %s", diff)
+			}
+		})
+	}
+}

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -536,7 +536,7 @@ func (r *JobSetReconciler) downscaleElasticJobs(ctx context.Context, js *jobset.
 		return err
 	}
 
-	jobsToDelete, err := jobsToDeleteDownScale(js.Spec.ReplicatedJobs, replicatedJobStatus, childJobList.Items)
+	jobsToDelete, err := jobsToDeleteForDownScale(js.Spec.ReplicatedJobs, replicatedJobStatus, childJobList.Items)
 	if err != nil {
 		return err
 	}

--- a/site/content/en/docs/concepts/_index.md
+++ b/site/content/en/docs/concepts/_index.md
@@ -154,3 +154,12 @@ A JobSet failure is counted when ANY of its child Jobs fail. `spec.failurePolicy
 to automatically restart the JobSet. A restart is done by recreating all child jobs.
 
 A JobSet is terminally failed when the number of failures reaches `spec.failurePolicy.maxRestarts`
+
+## Elastic JobSets
+
+JobSets have the ability to upscale or downscale after the job is created.
+
+JobSet supports this feature by allowing mutable changes for the replicas of a JobSet.
+
+One can increase or decrease the replicas of a ReplicatedJob.
+Templates and Names of replicate jobs are not allowed to change during updates.


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/jobset/issues/463

Add elastic jobset support (downscale/upscaling replicas of a Replicated Job).

Before this change, we treated ReplicateJobs (in JobSet.Spec) as immutable. This relaxes that restriction.

I choose to validate that names cannot be changed and the job templates must not change during updates. I don't see a reason for names to change and we also don't allow order change of the replicated job list so we can detect differences easily.

I am reopening this to resolve the rebase labels..