### PR TITLE
Automated cherry pick of #644: Allow to update jobSets on suspend

### DIFF
--- a/pkg/webhooks/jobset_webhook.go
+++ b/pkg/webhooks/jobset_webhook.go
@@ -219,9 +219,9 @@ func (j *jobSetWebhook) ValidateUpdate(ctx context.Context, old, newObj runtime.
 	}
 	mungedSpec := js.Spec.DeepCopy()
 
-	// Allow pod template to be mutated for suspended JobSets.
+	// Allow pod template to be mutated for suspended JobSets, or JobSets getting suspended.
 	// This is needed for integration with Kueue/DWS.
-	if ptr.Deref(oldJS.Spec.Suspend, false) {
+	if ptr.Deref(oldJS.Spec.Suspend, false) || ptr.Deref(js.Spec.Suspend, false) {
 		for index := range js.Spec.ReplicatedJobs {
 			// Pod values which must be mutable for Kueue are defined here: https://github.com/kubernetes-sigs/kueue/blob/a50d395c36a2cb3965be5232162cf1fded1bdb08/apis/kueue/v1beta1/workload_types.go#L256-L260
 			mungedSpec.ReplicatedJobs[index].Template.Spec.Template.Annotations = oldJS.Spec.ReplicatedJobs[index].Template.Spec.Template.Annotations

--- a/pkg/webhooks/jobset_webhook_test.go
+++ b/pkg/webhooks/jobset_webhook_test.go
@@ -1036,6 +1036,49 @@ func TestValidateUpdate(t *testing.T) {
 			},
 		},
 		{
+			name: "replicated job pod template can be updated for jobset getting suspended",
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					Suspend: ptr.To(true),
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 2,
+							Template: batchv1.JobTemplateSpec{
+								// Adding an annotation.
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](2),
+									Template: corev1.PodTemplateSpec{
+										ObjectMeta: metav1.ObjectMeta{
+											Annotations: map[string]string{"key": "value"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			oldJs: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					Suspend: ptr.To(false),
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](2),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "replicated job pod template cannot be updated for running jobset",
 			js: &jobset.JobSet{
 				ObjectMeta: validObjectMeta,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -108,7 +108,7 @@ var _ = ginkgo.Describe("JobSet", func() {
 	})
 
 	// This test is added to test the JobSet transitions as Kueue would when:
-	// doing: resume in RF1 -> suspend -> resume in RF2.
+	// doing: resume in ResourceFlavor1 -> suspend -> resume in ResourceFlavor2.
 	// In particular, Kueue updates the PodTemplate on suspending and resuming
 	// the JobSet.
 	ginkgo.When("JobSet is suspended and resumed", func() {
@@ -120,7 +120,6 @@ var _ = ginkgo.Describe("JobSet", func() {
 
 			ginkgo.By("Create a suspended JobSet", func() {
 				js.Spec.Suspend = ptr.To(true)
-				js.Spec.TTLSecondsAfterFinished = ptr.To[int32](5)
 				gomega.Expect(k8sClient.Create(ctx, js)).Should(gomega.Succeed())
 			})
 
@@ -138,6 +137,9 @@ var _ = ginkgo.Describe("JobSet", func() {
 			})
 
 			ginkgo.By("Await for all Jobs to be active", func() {
+				// In this step the Pods remain Pending due to the nodeSelector
+				// which does not match any nodes. Still, JobSet considers as
+				// active any Jobs which have at least one Pending or Running Pod.
 				gomega.Eventually(func() int32 {
 					gomega.Expect(k8sClient.Get(ctx, jsKey, js)).Should(gomega.Succeed())
 					if js.Status.ReplicatedJobsStatus == nil {


### PR DESCRIPTION
Cherry pick of #644 on release-0.5.
#644: Allow to update jobSets on suspend
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
```