### PR TITLE
WIP: Run JobSet e2e tests with JobManagedBy enabled [TEST ONLY]

### DIFF
--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -18,7 +18,7 @@ function cleanup {
 function startup {
     if [ $USE_EXISTING_CLUSTER == 'false' ] 
     then 
-        $KIND create cluster --name $KIND_CLUSTER_NAME --image $E2E_KIND_VERSION --wait 1m
+        $KIND create cluster --name $KIND_CLUSTER_NAME --image $E2E_KIND_VERSION --config "hack/kind-cluster.yaml" --wait 1m
         kubectl get nodes > $ARTIFACTS/kind-nodes.log || true
         kubectl describe pods -n kube-system > $ARTIFACTS/kube-system-pods.log || true
     fi

--- a/hack/kind-cluster.yaml
+++ b/hack/kind-cluster.yaml
@@ -1,0 +1,9 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+featureGates:
+  JobManagedBy: true
+nodes:
+- role: control-plane
+- role: worker
+- role: worker
+- role: worker


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

To verify the e2e tests for JobSet pass with JobManagedBy enabled, which introduces multiple Job status validation rules.

Such a confirmation is part of the graduation criteria for Beta for the feature: https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/4368-support-managed-by-for-batch-jobs#beta.

#### Special notes for your reviewer:

The e2e tests pass for K8s>=1.30 which supports `JobManagedBy=true`. 1.28 and 1.29 fails as expected.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```