### PR TITLE
Image support multi-arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM --platform=${BUILDPLATFORM} gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,7 @@ image-local-push: image-local-build
 .PHONY: image-build
 image-build:
 	$(IMAGE_BUILD_CMD) -t $(IMAGE_TAG) \
+		--platform=$(PLATFORMS) \
 		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
 		--build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) \
 		$(PUSH) \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
- Image support multi-arch

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #237 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Image support multi-arch
```

#### Build result
```bash
make image-build
docker buildx build -t gcr.io/k8s-staging-jobset/jobset:8a59936-dirty \
        --platform=linux/amd64,linux/arm64 \
        --build-arg BASE_IMAGE=gcr.io/distroless/static:nonroot \
        --build-arg BUILDER_IMAGE=golang:1.23.0 \
         \
         ./
[+] Building 163.4s (23/23) FINISHED                                                                     docker:default
 => [internal] load build definition from Dockerfile                                                               0.0s
 => => transferring dockerfile: 1.37kB                                                                             0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 4)                                     0.0s
 => WARN: InvalidDefaultArgInFrom: Default value for ARG ${BUILDER_IMAGE} results in empty or invalid base image   0.0s
 => [linux/amd64 internal] load metadata for gcr.io/distroless/static:nonroot                                      0.3s
 => [linux/amd64 internal] load metadata for docker.io/library/golang:1.23.0                                       2.4s
 => [internal] load .dockerignore                                                                                  0.0s
 => => transferring context: 51B                                                                                   0.0s
 => CACHED [linux/amd64 stage-1 1/3] FROM gcr.io/distroless/static:nonroot@sha256:3a03fc0826340c7deb82d4755ca391b  0.0s
 => => resolve gcr.io/distroless/static:nonroot@sha256:3a03fc0826340c7deb82d4755ca391bef5adcedb8892e58412e1a60081  0.0s
 => [internal] load build context                                                                                  0.0s
 => => transferring context: 2.90kB                                                                                0.0s
 => [linux/amd64 builder 1/9] FROM docker.io/library/golang:1.23.0@sha256:acfb46be39840f8c2a6b9efdd673c662701120  35.2s
 => => resolve docker.io/library/golang:1.23.0@sha256:acfb46be39840f8c2a6b9efdd673c6627011200c73bab4e6d18b8b9ab46  0.0s
 => => sha256:c4b14fb4020d7e427735797bf663a02a5a028e40fae0f8993ed5dfe75f15417a 73.97MB / 73.97MB                   7.6s
 => => sha256:20663332bcc9b53cdcb67c88a48326dc358db93b72dc2032af41c46239a3574c 92.26MB / 92.26MB                  30.7s
 => => sha256:2e66a70da0bec13fb3d492fcdef60fd8a5ef0a1a65c4e8a4909e26742852f0f2 64.15MB / 64.15MB                  25.4s
 => => sha256:2e6afa3f266c11e8960349e7866203a9df478a50362bb5488c45fe39d99b2707 24.05MB / 24.05MB                   9.3s
 => => sha256:8cd46d290033f265db57fd808ac81c444ec5a5b3f189c3d6d85043b647336913 49.56MB / 49.56MB                  13.2s
 => => extracting sha256:8cd46d290033f265db57fd808ac81c444ec5a5b3f189c3d6d85043b647336913                          1.1s
 => => extracting sha256:2e6afa3f266c11e8960349e7866203a9df478a50362bb5488c45fe39d99b2707                          0.4s
 => => extracting sha256:2e66a70da0bec13fb3d492fcdef60fd8a5ef0a1a65c4e8a4909e26742852f0f2                          1.3s
 => => extracting sha256:20663332bcc9b53cdcb67c88a48326dc358db93b72dc2032af41c46239a3574c                          1.4s
 => => extracting sha256:c4b14fb4020d7e427735797bf663a02a5a028e40fae0f8993ed5dfe75f15417a                          3.0s
 => => extracting sha256:01c85014d0d1b661aa84465b70040e742ef94cbf936533fb4bc455bd11c715e8                          0.0s
 => => extracting sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1                          0.0s
 => [linux/amd64 builder 2/9] WORKDIR /workspace                                                                   0.8s
 => [linux/amd64 builder 3/9] COPY go.mod go.mod                                                                   0.1s
 => [linux/amd64 builder 4/9] COPY go.sum go.sum                                                                   0.1s
 => [linux/amd64->arm64 builder 5/9] RUN go mod download                                                          28.9s
 => [linux/amd64 builder 5/9] RUN go mod download                                                                 27.2s
 => [linux/amd64 builder 6/9] COPY main.go main.go                                                                 0.2s
 => [linux/amd64 builder 7/9] COPY api/ api/                                                                       0.1s
 => [linux/amd64 builder 8/9] COPY pkg/ pkg/                                                                       0.1s
 => [linux/amd64 builder 9/9] RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=amd64 go build -a -o manager main  92.2s
 => [linux/amd64->arm64 builder 6/9] COPY main.go main.go                                                          0.2s
 => [linux/amd64->arm64 builder 7/9] COPY api/ api/                                                                0.1s
 => [linux/amd64->arm64 builder 8/9] COPY pkg/ pkg/                                                                0.1s
 => [linux/amd64->arm64 builder 9/9] RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=arm64 go build -a -o manag  92.2s
 => [linux/amd64 stage-1 2/3] COPY --from=builder /workspace/manager .                                             0.3s
 => [linux/amd64 stage-1 2/3] COPY --from=builder /workspace/manager .                                             0.4s
 => exporting to image                                                                                             2.7s
 => => exporting layers                                                                                            2.2s
 => => exporting manifest sha256:b9a92fd3b1edf12a23f536ba7f97ed639769a8fd1b8970912280f2cb1d78f293                  0.0s
 => => exporting config sha256:811377f53b7205590f14839c8f9d9b77552af67831c195b0848520fed09330f2                    0.0s
 => => exporting attestation manifest sha256:f53518d915c1f97b623b02a92e0877332e1f9251352ae7ec9c59e5a8e7bb3f7d      0.1s
 => => exporting manifest sha256:b70ef876f3dad8daf655092855e8f2f973e2431b7b75d5453c484b2c5a814467                  0.0s
 => => exporting config sha256:9b83a9a382d2bc5dbfdad51305c906069523603ed9095573d87a12893808d7eb                    0.0s
 => => exporting attestation manifest sha256:9951b8609ccefa1c8c89be28e0b444750834732eae6d5009d5a1041bfff045ff      0.1s
 => => exporting manifest list sha256:c88dc1e27ceda906cfc8d7739141a9ac602f76044a804366f0b06a60e30e18a0             0.0s
 => => naming to gcr.io/k8s-staging-jobset/jobset:8a59936-dirty                                                    0.0s
 => => unpacking to gcr.io/k8s-staging-jobset/jobset:8a59936-dirty                                                 0.2s
```