### PR TITLE
Propagate schedulingGates set on PodTemplate when resuming JobSet

### DIFF
--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -480,6 +480,10 @@ func (r *JobSetReconciler) resumeJob(ctx context.Context, job *batchv1.Job, repl
 			job.Spec.Template.Spec.Tolerations,
 			replicatedJobPodTemplate.Spec.Tolerations,
 		)
+		job.Spec.Template.Spec.SchedulingGates = collections.MergeSlices(
+			job.Spec.Template.Spec.SchedulingGates,
+			replicatedJobPodTemplate.Spec.SchedulingGates,
+		)
 	} else {
 		log.Error(nil, "job missing ReplicatedJobName label")
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

To support integration with Kueue for TAS.

#### Special notes for your reviewer:

I mark the PR as a bug because this was my intention while working on https://github.com/kubernetes-sigs/jobset/pull/623, but I forgot to actually propagate them (merge) back then. The previous PR on its own isn't enough. 

Now I realized the issue exists while working on TAS for Kueue, which is using the `ueue.x-k8s.io/topology` scheduling gate. See [here](https://github.com/kubernetes-sigs/kueue/blob/66185bc7be97d7ffb61124af0fd34c6493da0c39/apis/kueue/v1alpha1/tas_types.go#L41-L45).

It will be great to cherry-pick to 0.7.1 or even 0.6.1

#### Does this PR introduce a user-facing change?

```release-note
Propagate schedulingGates set on PodTemplate when resuming JobSet
```