### PR TITLE
Automated cherry pick of #705: Propagate schedulingGates set on PodTemplate when resuming

### DIFF
--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -478,6 +478,10 @@ func (r *JobSetReconciler) resumeJob(ctx context.Context, job *batchv1.Job, repl
 			job.Spec.Template.Spec.Tolerations,
 			replicatedJobPodTemplate.Spec.Tolerations,
 		)
+		job.Spec.Template.Spec.SchedulingGates = collections.MergeSlices(
+			job.Spec.Template.Spec.SchedulingGates,
+			replicatedJobPodTemplate.Spec.SchedulingGates,
+		)
 	} else {
 		log.Error(nil, "job missing ReplicatedJobName label")
 	}


### PR DESCRIPTION
Cherry pick of #705 on release-7.0.
#705: Propagate schedulingGates set on PodTemplate when resuming
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
Propagate schedulingGates, set on the PodTemplate, down to Jobs when resuming a JobSet.
```