### PR TITLE
Propagate job labels and annotations

### DIFF
--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -738,6 +738,7 @@ func labelAndAnnotateObject(obj metav1.Object, js *jobset.JobSet, rjob *jobset.R
 
 	// Set labels on the object.
 	labels := make(map[string]string)
+	maps.Copy(labels, obj.GetLabels())
 	labels[jobset.JobSetNameKey] = js.Name
 	labels[jobset.ReplicatedJobNameKey] = rjob.Name
 	labels[constants.RestartsKey] = strconv.Itoa(int(js.Status.Restarts))
@@ -748,6 +749,7 @@ func labelAndAnnotateObject(obj metav1.Object, js *jobset.JobSet, rjob *jobset.R
 	labels[jobset.JobGlobalIndexKey] = globalJobIndex(js, rjob.Name, jobIdx)
 
 	annotations := make(map[string]string)
+	maps.Copy(annotations, obj.GetAnnotations())
 	annotations[jobset.JobSetNameKey] = js.Name
 	annotations[jobset.ReplicatedJobNameKey] = rjob.Name
 	annotations[constants.RestartsKey] = strconv.Itoa(int(js.Status.Restarts))

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -1356,7 +1356,6 @@ func makeJob(args *makeJobArgs) *testutils.JobWrapper {
 		PodLabels(labels).
 		PodLabels(args.podLabels).
 		PodAnnotations(annotations)
-		PodAnnotations(args.podAnnotations)
 	return jobWrapper
 }
 

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -470,7 +470,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 		{
 			name: "exclusive placement for entire JobSet",
 			js: testutils.MakeJobSet(jobSetName, ns).
-				SetAnnotations(map[string]string{jobset.ExclusiveKey: topologyDomain, "foo": "bar"}).
+				SetAnnotations(map[string]string{jobset.ExclusiveKey: topologyDomain).
 				// Replicated Job A has.
 				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName + "-A").
 					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -145,8 +145,8 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			"pod-annotation-key2":  "pod-annotation-value2",
 		}
 		podLabels = map[string]string{
-			"hello":  "world",
-			"hello1": "world",
+                         "pod-label-key1":  "pod-label-value1",
+			"pod-label-key2":  "pod-label-value2",
 		}
 		topologyDomain      = "test-topology-domain"
 		coordinatorKeyValue = map[string]string{

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -1336,7 +1336,6 @@ func makeJob(args *makeJobArgs) *testutils.JobWrapper {
 		constants.RestartsKey:        strconv.Itoa(args.restarts),
 		jobset.JobKey:                jobHashKey(args.ns, args.jobName),
 	}
-
 	// Only set exclusive key if we are using exclusive placement per topology.
 	if args.topology != "" {
 		annotations[jobset.ExclusiveKey] = args.topology

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -128,17 +128,17 @@ func TestIsJobFinished(t *testing.T) {
 
 func TestConstructJobsFromTemplate(t *testing.T) {
 	var (
-		jobSetName          = "test-jobset"
-		replicatedJobName   = "replicated-job"
-		jobName             = "test-job"
-		ns                  = "default"
-		annotations         = map[string]string{
-			"foo": "bar",
-			"foo1": "bar"
+		jobSetName        = "test-jobset"
+		replicatedJobName = "replicated-job"
+		jobName           = "test-job"
+		ns                = "default"
+		annotations       = map[string]string{
+			"foo":  "bar",
+			"foo1": "bar",
 		}
-		labels              = map[string]string{
-			"foo": "bar",
-			"foo1": "bar"
+		labels = map[string]string{
+			"foo":  "bar",
+			"foo1": "bar",
 		}
 		topologyDomain      = "test-topology-domain"
 		coordinatorKeyValue = map[string]string{
@@ -470,7 +470,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 		{
 			name: "exclusive placement for entire JobSet",
 			js: testutils.MakeJobSet(jobSetName, ns).
-				SetAnnotations(map[string]string{jobset.ExclusiveKey: topologyDomain).
+				SetAnnotations(map[string]string{jobset.ExclusiveKey: topologyDomain}).
 				// Replicated Job A has.
 				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName + "-A").
 					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -141,8 +141,8 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			"job-label-key2":  "job-label-value2",
 		}
 		podAnnotations = map[string]string{
-			"hello":  "world",
-			"hello1": "world",
+			"pod-annotation-key1":  "pod-annotation-value1",
+			"pod-annotation-key2":  "pod-annotation-value2",
 		}
 		podLabels = map[string]string{
 			"hello":  "world",

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -1365,9 +1365,13 @@ func makeJob(args *makeJobArgs) *testutils.JobWrapper {
 	maps.Copy(args.podAnnotations, annotations)
 
 	jobWrapper := testutils.MakeJob(args.jobName, args.ns).
+		JobLabels(labels).
 		JobLabels(args.jobLabels).
+		JobAnnotations(annotations).
 		JobAnnotations(args.jobAnnotations).
+		PodLabels(labels).
 		PodLabels(args.podLabels).
+		PodAnnotations(annotations)
 		PodAnnotations(args.podAnnotations)
 	return jobWrapper
 }

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -137,8 +137,8 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			"job-annotation-key2":  "job-annotation-value2",
 		}
 		jobLabels = map[string]string{
-			"foo":  "bar",
-			"foo1": "bar",
+                         "job-label-key1":  "job-label-value1",
+			"job-label-key2":  "job-label-value2",
 		}
 		podAnnotations = map[string]string{
 			"hello":  "world",

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -1355,6 +1355,8 @@ func makeJob(args *makeJobArgs) *testutils.JobWrapper {
 		JobAnnotations(args.jobAnnotations).
 		PodLabels(labels).
 		PodLabels(args.podLabels).
+		PodAnnotations(args.podAnnotations).
+
 		PodAnnotations(annotations)
 	return jobWrapper
 }

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"strconv"
 	"strings"
 	"testing"

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -136,7 +136,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			"job-annotation-key2": "job-annotation-value2",
 		}
 		jobLabels = map[string]string{
-                         "job-label-key1": "job-label-value1",
+			"job-label-key1": "job-label-value1",
 			"job-label-key2": "job-label-value2",
 		}
 		podAnnotations = map[string]string{
@@ -144,7 +144,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			"pod-annotation-key2": "pod-annotation-value2",
 		}
 		podLabels = map[string]string{
-                        "pod-label-key1": "pod-label-value1",
+			"pod-label-key1": "pod-label-value1",
 			"pod-label-key2": "pod-label-value2",
 		}
 		topologyDomain      = "test-topology-domain"

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -144,7 +144,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			"pod-annotation-key2": "pod-annotation-value2",
 		}
 		podLabels = map[string]string{
-                         "pod-label-key1": "pod-label-value1",
+                        "pod-label-key1": "pod-label-value1",
 			"pod-label-key2": "pod-label-value2",
 		}
 		topologyDomain      = "test-topology-domain"

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -132,20 +132,20 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 		jobName           = "test-job"
 		ns                = "default"
 		jobAnnotations    = map[string]string{
-			"job-annotation-key1":  "job-annotation-value1",
-			"job-annotation-key2":  "job-annotation-value2",
+			"job-annotation-key1": "job-annotation-value1",
+			"job-annotation-key2": "job-annotation-value2",
 		}
 		jobLabels = map[string]string{
-                         "job-label-key1":  "job-label-value1",
-			"job-label-key2":  "job-label-value2",
+                         "job-label-key1": "job-label-value1",
+			"job-label-key2": "job-label-value2",
 		}
 		podAnnotations = map[string]string{
-			"pod-annotation-key1":  "pod-annotation-value1",
-			"pod-annotation-key2":  "pod-annotation-value2",
+			"pod-annotation-key1": "pod-annotation-value1",
+			"pod-annotation-key2": "pod-annotation-value2",
 		}
 		podLabels = map[string]string{
-                         "pod-label-key1":  "pod-label-value1",
-			"pod-label-key2":  "pod-label-value2",
+                         "pod-label-key1": "pod-label-value1",
+			"pod-label-key2": "pod-label-value2",
 		}
 		topologyDomain      = "test-topology-domain"
 		coordinatorKeyValue = map[string]string{

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -133,8 +133,8 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 		jobName           = "test-job"
 		ns                = "default"
 		jobAnnotations    = map[string]string{
-			"foo":  "bar",
-			"foo1": "bar",
+			"job-annotation-key1":  "job-annotation-value1",
+			"job-annotation-key2":  "job-annotation-value2",
 		}
 		jobLabels = map[string]string{
 			"foo":  "bar",

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -1347,22 +1347,6 @@ func makeJob(args *makeJobArgs) *testutils.JobWrapper {
 		}
 	}
 
-	if args.jobLabels == nil {
-		args.jobLabels = make(map[string]string)
-	}
-	if args.podLabels == nil {
-		args.podLabels = make(map[string]string)
-	}
-	if args.jobAnnotations == nil {
-		args.jobAnnotations = make(map[string]string)
-	}
-	if args.podAnnotations == nil {
-		args.podAnnotations = make(map[string]string)
-	}
-	maps.Copy(args.jobLabels, labels)
-	maps.Copy(args.podLabels, labels)
-	maps.Copy(args.jobAnnotations, annotations)
-	maps.Copy(args.podAnnotations, annotations)
 
 	jobWrapper := testutils.MakeJob(args.jobName, args.ns).
 		JobLabels(labels).

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -1345,8 +1345,6 @@ func makeJob(args *makeJobArgs) *testutils.JobWrapper {
 			annotations[jobset.NodeSelectorStrategyKey] = "true"
 		}
 	}
-
-
 	jobWrapper := testutils.MakeJob(args.jobName, args.ns).
 		JobLabels(labels).
 		JobLabels(args.jobLabels).

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -132,8 +132,14 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 		replicatedJobName   = "replicated-job"
 		jobName             = "test-job"
 		ns                  = "default"
-		annotations         = map[string]string{"foo": "bar"}
-		labels              = map[string]string{"foo": "bar"}
+		annotations         = map[string]string{
+			"foo": "bar",
+			"foo1": "bar"
+		}
+		labels              = map[string]string{
+			"foo": "bar",
+			"foo1": "bar"
+		}
 		topologyDomain      = "test-topology-domain"
 		coordinatorKeyValue = map[string]string{
 			jobset.CoordinatorKey: fmt.Sprintf("%s-%s-%d-%d.%s", jobSetName, replicatedJobName, 0, 0, jobSetName),
@@ -376,23 +382,16 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 		{
 			name: "exclusive placement for a ReplicatedJob",
 			js: testutils.MakeJobSet(jobSetName, ns).
-				SetAnnotations(annotations).
 				// Replicated Job A has exclusive placement annotation.
 				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName + "-A").
 					Job(testutils.MakeJobTemplate(jobName, ns).
-						SetLabels(labels).
-						SetAnnotations(map[string]string{
-							jobset.ExclusiveKey: topologyDomain,
-							"foo":               "bar",
-						}).
+						SetAnnotations(map[string]string{jobset.ExclusiveKey: topologyDomain}).
 						Obj()).
 					Replicas(1).
 					Obj()).
 				// Replicated Job B has no exclusive placement annotation.
 				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName + "-B").
 					Job(testutils.MakeJobTemplate(jobName, ns).
-						SetLabels(labels).
-						SetAnnotations(annotations).
 						Obj()).
 					Replicas(1).
 					Obj()).
@@ -404,11 +403,6 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 					replicatedJobName: replicatedJobName + "-A",
 					jobName:           "test-jobset-replicated-job-A-0",
 					ns:                ns,
-					labels:            labels,
-					annotations: map[string]string{
-						jobset.ExclusiveKey: topologyDomain,
-						"foo":               "bar",
-					},
 					replicas: 1,
 					jobIdx:   0,
 					topology: topologyDomain}).
@@ -418,8 +412,6 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 					replicatedJobName: replicatedJobName + "-B",
 					jobName:           "test-jobset-replicated-job-B-0",
 					ns:                ns,
-					labels:            labels,
-					annotations:       annotations,
 					replicas:          1,
 					jobIdx:            0}).
 					Suspend(false).Obj(),
@@ -482,18 +474,12 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 				SetAnnotations(map[string]string{jobset.ExclusiveKey: topologyDomain, "foo": "bar"}).
 				// Replicated Job A has.
 				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName + "-A").
-					Job(testutils.MakeJobTemplate(jobName, ns).
-						SetLabels(labels).
-						SetAnnotations(annotations).
-						Obj()).
+					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
 					Replicas(1).
 					Obj()).
 				// Replicated Job B.
 				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName + "-B").
-					Job(testutils.MakeJobTemplate(jobName, ns).
-						SetLabels(labels).
-						SetAnnotations(annotations).
-						Obj()).
+					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
 					Replicas(1).
 					Obj()).
 				Obj(),
@@ -504,8 +490,6 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 					replicatedJobName: replicatedJobName + "-A",
 					jobName:           "test-jobset-replicated-job-A-0",
 					ns:                ns,
-					labels:            labels,
-					annotations:       annotations,
 					replicas:          1,
 					jobIdx:            0,
 					topology:          topologyDomain}).
@@ -515,8 +499,6 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 					replicatedJobName: replicatedJobName + "-B",
 					jobName:           "test-jobset-replicated-job-B-0",
 					ns:                ns,
-					labels:            labels,
-					annotations:       annotations,
 					replicas:          1,
 					jobIdx:            0,
 					topology:          topologyDomain}).

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -1355,7 +1355,6 @@ func makeJob(args *makeJobArgs) *testutils.JobWrapper {
 		PodLabels(labels).
 		PodLabels(args.podLabels).
 		PodAnnotations(args.podAnnotations).
-
 		PodAnnotations(annotations)
 	return jobWrapper
 }

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -391,8 +391,7 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 					Obj()).
 				// Replicated Job B has no exclusive placement annotation.
 				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName + "-B").
-					Job(testutils.MakeJobTemplate(jobName, ns).
-						Obj()).
+					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
 					Replicas(1).
 					Obj()).
 				Obj(),
@@ -403,9 +402,9 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 					replicatedJobName: replicatedJobName + "-A",
 					jobName:           "test-jobset-replicated-job-A-0",
 					ns:                ns,
-					replicas: 1,
-					jobIdx:   0,
-					topology: topologyDomain}).
+					replicas:          1,
+					jobIdx:            0,
+					topology:          topologyDomain}).
 					Suspend(false).Obj(),
 				makeJob(&makeJobArgs{
 					jobSetName:        jobSetName,

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -267,17 +267,27 @@ func (j *JobTemplateWrapper) PodSpec(podSpec corev1.PodSpec) *JobTemplateWrapper
 	return j
 }
 
+// SetAnnotations sets the annotations on the Pod template.
+func (j *JobTemplateWrapper) SetPodAnnotations(annotations map[string]string) *JobTemplateWrapper {
+	j.Spec.Template.SetAnnotations(annotations)
+	return j
+}
+
+// SetLabels sets the labels on the Pod template.
+func (j *JobTemplateWrapper) SetPodLabels(labels map[string]string) *JobTemplateWrapper {
+	j.Spec.Template.SetLabels(labels)
+	return j
+}
+
 // SetAnnotations sets the annotations on the Job template.
 func (j *JobTemplateWrapper) SetAnnotations(annotations map[string]string) *JobTemplateWrapper {
 	j.Annotations = annotations
-	j.Spec.Template.SetAnnotations(annotations)
 	return j
 }
 
 // SetLabels sets the labels on the Job template.
 func (j *JobTemplateWrapper) SetLabels(labels map[string]string) *JobTemplateWrapper {
 	j.Labels = labels
-	j.Spec.Template.SetLabels(labels)
 	return j
 }
 

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -270,6 +270,14 @@ func (j *JobTemplateWrapper) PodSpec(podSpec corev1.PodSpec) *JobTemplateWrapper
 // SetAnnotations sets the annotations on the Job template.
 func (j *JobTemplateWrapper) SetAnnotations(annotations map[string]string) *JobTemplateWrapper {
 	j.Annotations = annotations
+	j.Spec.Template.SetAnnotations(annotations)
+	return j
+}
+
+// SetLabels sets the labels on the Job template.
+func (j *JobTemplateWrapper) SetLabels(labels map[string]string) *JobTemplateWrapper {
+	j.Labels = labels
+	j.Spec.Template.SetLabels(labels)
 	return j
 }
 


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
Addresses a regression introduced by https://github.com/kubernetes-sigs/jobset/pull/696 that drops pod labels and annotations.

Which issue(s) this PR fixes:
Fixes #696

Special notes for your reviewer:
Does this PR introduce a user-facing change?
No