### PR TITLE
inject namespace in case we want to test against non standard deployment

### DIFF
--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -1,6 +1,9 @@
 export KUSTOMIZE=$PWD/bin/kustomize
 export GINKGO=$PWD/bin/ginkgo
 export KIND=$PWD/bin/kind
+# E2E tests for Kind can use jobset-system
+# For testing against existing clusters, one needs to set this environment variable
+export NAMESPACE="jobset-system"
 
 function cleanup {
     if [ $USE_EXISTING_CLUSTER == 'false' ] 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -16,6 +16,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -43,6 +44,13 @@ var (
 	ctx       context.Context
 )
 
+func getNamespace() string {
+	namespace := os.Getenv("NAMESPACE")
+	if namespace == "" {
+		namespace = "jobset-system"
+	}
+	return namespace
+}
 func TestAPIs(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t,
@@ -67,7 +75,7 @@ var _ = ginkgo.BeforeSuite(func() {
 
 func jobSetReadyForTesting(k8sClient client.Client) {
 	ginkgo.By("waiting for resources to be ready for testing")
-	deploymentKey := types.NamespacedName{Namespace: "jobset-system", Name: "jobset-controller-manager"}
+	deploymentKey := types.NamespacedName{Namespace: getNamespace(), Name: "jobset-controller-manager"}
 	deployment := &appsv1.Deployment{}
 	pods := &corev1.PodList{}
 	gomega.Eventually(func(g gomega.Gomega) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Running e2e tests against an existing cluster where jobset is deployed differently.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #748 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```