### PR TITLE
Remove Namespace from the JobSet Config

### DIFF
--- a/api/config/v1alpha1/configuration_types.go
+++ b/api/config/v1alpha1/configuration_types.go
@@ -28,12 +28,6 @@ import (
 type Configuration struct {
 	metav1.TypeMeta `json:",inline"`
 
-	// Namespace is the namespace in which jobset controller is deployed.
-	// It is used as part of DNSName of the webhook Service.
-	// If not set, the value is set from the file /var/run/secrets/kubernetes.io/serviceaccount/namespace
-	// If the file doesn't exist, default value is kueue-system.
-	Namespace *string `json:"namespace,omitempty"`
-
 	// ControllerManager returns the configurations for controllers
 	ControllerManager `json:",inline"`
 

--- a/api/config/v1alpha1/defaults.go
+++ b/api/config/v1alpha1/defaults.go
@@ -17,8 +17,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"os"
-	"strings"
 	"time"
 
 	configv1alpha1 "k8s.io/component-base/config/v1alpha1"
@@ -26,7 +24,6 @@ import (
 )
 
 const (
-	DefaultNamespace                           = "jobset-system"
 	DefaultWebhookServiceName                  = "jobset-webhook-service"
 	DefaultWebhookSecretName                   = "jobset-webhook-server-cert"
 	DefaultWebhookPort                         = 9443
@@ -41,22 +38,10 @@ const (
 	DefaultClientConnectionBurst       int32   = 500
 )
 
-func getOperatorNamespace() string {
-	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
-		if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
-			return ns
-		}
-	}
-	return DefaultNamespace
-}
-
 // SetDefaults_Configuration sets default values for ComponentConfig.
 //
 //nolint:revive // format required by generated code for defaulting
 func SetDefaults_Configuration(cfg *Configuration) {
-	if cfg.Namespace == nil {
-		cfg.Namespace = ptr.To(getOperatorNamespace())
-	}
 	if cfg.Webhook.Port == nil {
 		cfg.Webhook.Port = ptr.To(DefaultWebhookPort)
 	}

--- a/api/config/v1alpha1/defaults_test.go
+++ b/api/config/v1alpha1/defaults_test.go
@@ -26,7 +26,6 @@ import (
 )
 
 const (
-	overwriteNamespace              = "jobset-tenant-a"
 	overwriteWebhookPort            = 9444
 	overwriteMetricBindAddress      = ":38081"
 	overwriteHealthProbeBindAddress = ":38080"
@@ -69,7 +68,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 			},
 			want: &Configuration{
-				Namespace:         ptr.To(DefaultNamespace),
 				ControllerManager: defaultCtrlManagerConfigurationSpec,
 				InternalCertManagement: &InternalCertManagement{
 					Enable: ptr.To(false),
@@ -89,7 +87,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 			},
 			want: &Configuration{
-				Namespace: ptr.To(DefaultNamespace),
 				ControllerManager: ControllerManager{
 					Webhook: ControllerWebhook{
 						Port: ptr.To(DefaultWebhookPort),
@@ -141,7 +138,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 			},
 			want: &Configuration{
-				Namespace: ptr.To(DefaultNamespace),
 				ControllerManager: ControllerManager{
 					Webhook: ControllerWebhook{
 						Port: ptr.To(overwriteWebhookPort),
@@ -179,7 +175,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 			},
 			want: &Configuration{
-				Namespace: ptr.To(DefaultNamespace),
 				ControllerManager: ControllerManager{
 					Webhook: ControllerWebhook{
 						Port: ptr.To(DefaultWebhookPort),
@@ -206,11 +201,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 			},
 		},
 		"defaulting InternalCertManagement": {
-			original: &Configuration{
-				Namespace: ptr.To(overwriteNamespace),
-			},
+			original: &Configuration{},
 			want: &Configuration{
-				Namespace:         ptr.To(overwriteNamespace),
 				ControllerManager: defaultCtrlManagerConfigurationSpec,
 				InternalCertManagement: &InternalCertManagement{
 					Enable:             ptr.To(true),
@@ -222,13 +214,11 @@ func TestSetDefaults_Configuration(t *testing.T) {
 		},
 		"should not default InternalCertManagement": {
 			original: &Configuration{
-				Namespace: ptr.To(overwriteNamespace),
 				InternalCertManagement: &InternalCertManagement{
 					Enable: ptr.To(false),
 				},
 			},
 			want: &Configuration{
-				Namespace:         ptr.To(overwriteNamespace),
 				ControllerManager: defaultCtrlManagerConfigurationSpec,
 				InternalCertManagement: &InternalCertManagement{
 					Enable: ptr.To(false),
@@ -238,7 +228,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 		},
 		"should not default values in custom ClientConnection": {
 			original: &Configuration{
-				Namespace: ptr.To(overwriteNamespace),
 				InternalCertManagement: &InternalCertManagement{
 					Enable: ptr.To(false),
 				},
@@ -248,7 +237,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 			},
 			want: &Configuration{
-				Namespace:         ptr.To(overwriteNamespace),
 				ControllerManager: defaultCtrlManagerConfigurationSpec,
 				InternalCertManagement: &InternalCertManagement{
 					Enable: ptr.To(false),
@@ -261,14 +249,12 @@ func TestSetDefaults_Configuration(t *testing.T) {
 		},
 		"should default empty custom ClientConnection": {
 			original: &Configuration{
-				Namespace: ptr.To(overwriteNamespace),
 				InternalCertManagement: &InternalCertManagement{
 					Enable: ptr.To(false),
 				},
 				ClientConnection: &ClientConnection{},
 			},
 			want: &Configuration{
-				Namespace:         ptr.To(overwriteNamespace),
 				ControllerManager: defaultCtrlManagerConfigurationSpec,
 				InternalCertManagement: &InternalCertManagement{
 					Enable: ptr.To(false),

--- a/api/config/v1alpha1/zz_generated.deepcopy.go
+++ b/api/config/v1alpha1/zz_generated.deepcopy.go
@@ -51,11 +51,6 @@ func (in *ClientConnection) DeepCopy() *ClientConnection {
 func (in *Configuration) DeepCopyInto(out *Configuration) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	if in.Namespace != nil {
-		in, out := &in.Namespace, &out.Namespace
-		*out = new(string)
-		**out = **in
-	}
 	in.ControllerManager.DeepCopyInto(&out.ControllerManager)
 	if in.InternalCertManagement != nil {
 		in, out := &in.InternalCertManagement, &out.InternalCertManagement

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -237,7 +237,6 @@ webhook:
 			name:       "default config",
 			configFile: "",
 			wantConfiguration: configapi.Configuration{
-				Namespace:              ptr.To(configapi.DefaultNamespace),
 				InternalCertManagement: enableDefaultInternalCertManagement,
 				ClientConnection:       defaultClientConnection,
 			},
@@ -276,7 +275,6 @@ webhook:
 					APIVersion: configapi.GroupVersion.String(),
 					Kind:       "Configuration",
 				},
-				Namespace:              ptr.To("jobset-tenant-a"),
 				InternalCertManagement: enableDefaultInternalCertManagement,
 				ClientConnection:       defaultClientConnection,
 			},
@@ -290,7 +288,6 @@ webhook:
 					APIVersion: configapi.GroupVersion.String(),
 					Kind:       "Configuration",
 				},
-				Namespace:              ptr.To(configapi.DefaultNamespace),
 				InternalCertManagement: enableDefaultInternalCertManagement,
 				ClientConnection:       defaultClientConnection,
 			},
@@ -320,7 +317,6 @@ webhook:
 					APIVersion: configapi.GroupVersion.String(),
 					Kind:       "Configuration",
 				},
-				Namespace: ptr.To(configapi.DefaultNamespace),
 				InternalCertManagement: &configapi.InternalCertManagement{
 					Enable:             ptr.To(true),
 					WebhookServiceName: ptr.To("jobset-tenant-a-webhook-service"),
@@ -338,7 +334,6 @@ webhook:
 					APIVersion: configapi.GroupVersion.String(),
 					Kind:       "Configuration",
 				},
-				Namespace: ptr.To(configapi.DefaultNamespace),
 				InternalCertManagement: &configapi.InternalCertManagement{
 					Enable: ptr.To(false),
 				},
@@ -354,7 +349,6 @@ webhook:
 					APIVersion: configapi.GroupVersion.String(),
 					Kind:       "Configuration",
 				},
-				Namespace:              ptr.To("jobset-system"),
 				InternalCertManagement: enableDefaultInternalCertManagement,
 				ClientConnection:       defaultClientConnection,
 			},
@@ -384,7 +378,6 @@ webhook:
 					APIVersion: configapi.GroupVersion.String(),
 					Kind:       "Configuration",
 				},
-				Namespace:              ptr.To(configapi.DefaultNamespace),
 				InternalCertManagement: enableDefaultInternalCertManagement,
 				ClientConnection: &configapi.ClientConnection{
 					QPS:   ptr.To[float32](50),
@@ -461,7 +454,6 @@ func TestEncode(t *testing.T) {
 			wantResult: map[string]any{
 				"apiVersion": "config.jobset.x-k8s.io/v1alpha1",
 				"kind":       "Configuration",
-				"namespace":  configapi.DefaultNamespace,
 				"webhook": map[string]any{
 					"port": int64(configapi.DefaultWebhookPort),
 				},

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -48,29 +48,10 @@ func TestLoad(t *testing.T) {
 
 	tmpDir := t.TempDir()
 
-	namespaceOverWriteConfig := filepath.Join(tmpDir, "namespace-overwrite.yaml")
-	if err := os.WriteFile(namespaceOverWriteConfig, []byte(`
-apiVersion: config.jobset.x-k8s.io/v1alpha1
-kind: Configuration
-namespace: jobset-tenant-a
-health:
-  healthProbeBindAddress: :8081
-metrics:
-  bindAddress: :8080
-leaderElection:
-  leaderElect: true
-  resourceName: 6d4f6a47.jobset.x-k8s.io
-webhook:
-  port: 9443
-`), os.FileMode(0600)); err != nil {
-		t.Fatal(err)
-	}
-
 	ctrlManagerConfigSpecOverWriteConfig := filepath.Join(tmpDir, "ctrl-manager-config-spec-overwrite.yaml")
 	if err := os.WriteFile(ctrlManagerConfigSpecOverWriteConfig, []byte(`
 apiVersion: config.jobset.x-k8s.io/v1alpha1
 kind: Configuration
-namespace: jobset-system
 health:
   healthProbeBindAddress: :38081
 metrics:
@@ -88,7 +69,6 @@ webhook:
 	if err := os.WriteFile(certOverWriteConfig, []byte(`
 apiVersion: config.jobset.x-k8s.io/v1alpha1
 kind: Configuration
-namespace: jobset-system
 health:
   healthProbeBindAddress: :8081
 metrics:
@@ -110,7 +90,6 @@ internalCertManagement:
 	if err := os.WriteFile(disableCertOverWriteConfig, []byte(`
 apiVersion: config.jobset.x-k8s.io/v1alpha1
 kind: Configuration
-namespace: jobset-system
 health:
   healthProbeBindAddress: :8081
 metrics:
@@ -130,7 +109,6 @@ internalCertManagement:
 	if err := os.WriteFile(leaderElectionDisabledConfig, []byte(`
 apiVersion: config.jobset.x-k8s.io/v1alpha1
 kind: Configuration
-namespace: jobset-system
 health:
   healthProbeBindAddress: :8081
 metrics:
@@ -147,7 +125,6 @@ webhook:
 	if err := os.WriteFile(clientConnectionConfig, []byte(`
 apiVersion: config.jobset.x-k8s.io/v1alpha1
 kind: Configuration
-namespace: jobset-system
 health:
   healthProbeBindAddress: :8081
 metrics:
@@ -168,7 +145,6 @@ clientConnection:
 	if err := os.WriteFile(invalidConfig, []byte(`
 apiVersion: config.jobset.x-k8s.io/v1alpha1
 kind: Configuration
-namespaces: jobset-system
 invalidField: invalidValue
 health:
   healthProbeBindAddress: :8081
@@ -266,19 +242,6 @@ webhook:
 				Path: ".",
 				Err:  errors.New("is a directory"),
 			},
-		},
-		{
-			name:       "namespace overwrite config",
-			configFile: namespaceOverWriteConfig,
-			wantConfiguration: configapi.Configuration{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: configapi.GroupVersion.String(),
-					Kind:       "Configuration",
-				},
-				InternalCertManagement: enableDefaultInternalCertManagement,
-				ClientConnection:       defaultClientConnection,
-			},
-			wantOptions: defaultControlOptions,
 		},
 		{
 			name:       "ControllerManagerConfigurationSpec overwrite config",
@@ -391,7 +354,6 @@ webhook:
 			configFile: invalidConfig,
 			wantError: runtime.NewStrictDecodingError([]error{
 				errors.New("unknown field \"invalidField\""),
-				errors.New("unknown field \"namespaces\""),
 			}),
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?

I removed namespace from the JobSet config as we discussed here: https://github.com/kubernetes-sigs/jobset/pull/719#discussion_r1866469895

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup
/assign @kannon92 @ahg-g @danielvegamyhre @tenzen-y 

#### What this PR does / why we need it:

The webhook and JobSet controller always have the same namespace, so user should not override this value in the Config.
The namespace is taken from the Pod's service account: `/var/run/secrets/kubernetes.io/serviceaccount/namespace`


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes-sigs/jobset/issues/720

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The namespace parameter has been removed from the JobSet manager config.
```