### PR TITLE
Use config metrics binding address if flag is not set

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,10 +115,8 @@ func main() {
 	kubeConfig.QPS = *cfg.ClientConnection.QPS
 	kubeConfig.Burst = int(*cfg.ClientConnection.Burst)
 
-	if flagsSet["metrics-bind-address"] {
-		options.Metrics.BindAddress = metricsAddr
-	} else {
-		options.Metrics.BindAddress = cfg.Metrics.BindAddress
+	if !flagsSet["metrics-bind-address"] {
+		metricsAddr = cfg.Metrics.BindAddress
 	}
 
 	if flagsSet["health-probe-bind-address"] {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Metrics in options is directly [initialized by using the value](https://github.com/kubernetes-sigs/jobset/blob/ab3881469b6c5fbd5e4a8e979bf041013eb1add0/main.go#L160-L166) in `metricAddr` regardless of the value in config file (which should not happen). This PR overwrites the `metricAddr` by the value in config file unless flag is explicitly set.

#### Does this PR introduce a user-facing change?
```release-note
The BindAddress value in config file will be used unless flag is explicitly set
```