### PR TITLE
update apiref to 1.32

### DIFF
--- a/hack/genref/config.yaml
+++ b/hack/genref/config.yaml
@@ -11,7 +11,7 @@ apis:
 
 externalPackages:
   - match: ^k8s\.io/(api|apimachinery/pkg/apis)/
-    target: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#{{- lower .TypeIdentifier -}}-{{- arrIndex .PackageSegments -1 -}}-{{- arrIndex .PackageSegments -2 -}}
+    target: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#{{- lower .TypeIdentifier -}}-{{- arrIndex .PackageSegments -1 -}}-{{- arrIndex .PackageSegments -2 -}}
   - match: ^k8s\.io/apimachinery/pkg/api/resource\.Quantity$
     target: https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity
   - match: ^k8s.io/component-base/config/v1alpha1.

--- a/site/content/en/docs/reference/jobset.v1alpha2.md
+++ b/site/content/en/docs/reference/jobset.v1alpha2.md
@@ -110,6 +110,14 @@ the coordinator pod.</p>
 A restart is achieved by recreating all active child jobs.</p>
 </td>
 </tr>
+<tr><td><code>restartStrategy</code><br/>
+<a href="#jobset-x-k8s-io-v1alpha2-JobSetRestartStrategy"><code>JobSetRestartStrategy</code></a>
+</td>
+<td>
+   <p>RestartStrategy defines the strategy to use when restarting the JobSet.
+Defaults to Recreate.</p>
+</td>
+</tr>
 <tr><td><code>rules</code> <B>[Required]</B><br/>
 <a href="#jobset-x-k8s-io-v1alpha2-FailurePolicyRule"><code>[]FailurePolicyRule</code></a>
 </td>
@@ -192,6 +200,18 @@ An empty list will apply to all replicatedJobs.</p>
 </tr>
 </tbody>
 </table>
+
+## `JobSetRestartStrategy`     {#jobset-x-k8s-io-v1alpha2-JobSetRestartStrategy}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [FailurePolicy](#jobset-x-k8s-io-v1alpha2-FailurePolicy)
+
+
+
+
 
 ## `JobSetSpec`     {#jobset-x-k8s-io-v1alpha2-JobSetSpec}
     
@@ -317,7 +337,7 @@ the JobSet becomes eligible to be deleted immediately after it finishes.</p>
     
   
 <tr><td><code>conditions</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta"><code>[]k8s.io/apimachinery/pkg/apis/meta/v1.Condition</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#condition-v1-meta"><code>[]k8s.io/apimachinery/pkg/apis/meta/v1.Condition</code></a>
 </td>
 <td>
    <span class="text-muted">No description provided.</span></td>
@@ -434,7 +454,7 @@ for the Job name.</p>
 </td>
 </tr>
 <tr><td><code>template</code> <B>[Required]</B><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#jobtemplatespec-v1-batch"><code>k8s.io/api/batch/v1.JobTemplateSpec</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#jobtemplatespec-v1-batch"><code>k8s.io/api/batch/v1.JobTemplateSpec</code></a>
 </td>
 <td>
    <p>Template defines the template of the Job that will be created.</p>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
APIREF was using 1.28 kubernetes.

Updating this to be 1.32.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
I don't think there was much changes for this so this isn't a big deal.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```