### PR TITLE
Set user agent for requests coming from the jobset controller to "jobset"

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,6 +44,8 @@ import (
 	"sigs.k8s.io/jobset/pkg/controllers"
 	"sigs.k8s.io/jobset/pkg/metrics"
 	"sigs.k8s.io/jobset/pkg/util/cert"
+	"sigs.k8s.io/jobset/pkg/util/useragent"
+	"sigs.k8s.io/jobset/pkg/version"
 	"sigs.k8s.io/jobset/pkg/webhooks"
 	//+kubebuilder:scaffold:imports
 )
@@ -94,6 +96,7 @@ func main() {
 		flagsSet[f.Name] = true
 	})
 
+	setupLog.Info("Initializing", "gitVersion", version.GitVersion, "gitCommit", version.GitCommit)
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	if err := utilfeature.DefaultMutableFeatureGate.Set(featureGates); err != nil {
@@ -106,6 +109,9 @@ func main() {
 	var options manager.Options
 
 	kubeConfig := ctrl.GetConfigOrDie()
+	if kubeConfig.UserAgent == "" {
+		kubeConfig.UserAgent = useragent.Default()
+	}
 
 	options, cfg, err := apply(configFile)
 	if err != nil {

--- a/pkg/util/useragent/useragent.go
+++ b/pkg/util/useragent/useragent.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package useragent
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	"sigs.k8s.io/jobset/pkg/constants"
+	"sigs.k8s.io/jobset/pkg/version"
+)
+
+// adjustVersion strips "alpha", "beta", etc. from version in form
+// major.minor.patch-[alpha|beta|etc].
+func adjustVersion(v string) string {
+	if len(v) == 0 {
+		return "unknown"
+	}
+	seg := strings.SplitN(v, "-", 2)
+	return seg[0]
+}
+
+// adjustCommit returns sufficient significant figures of the commit's git hash.
+func adjustCommit(c string) string {
+	if len(c) == 0 {
+		return "unknown"
+	}
+	if len(c) > 7 {
+		return c[:7]
+	}
+	return c
+}
+
+// Default returns User-Agent string built from static global vars.
+func Default() string {
+	return fmt.Sprintf("%s/%s (%s/%s) %s",
+		constants.JobSetSubsystemName,
+		adjustVersion(version.GitVersion),
+		runtime.GOOS,
+		runtime.GOARCH,
+		adjustCommit(version.GitCommit))
+}

--- a/pkg/util/useragent/useragent_test.go
+++ b/pkg/util/useragent/useragent_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package useragent
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+)
+
+func TestDefault(t *testing.T) {
+	want := fmt.Sprintf("jobset/v0.0.0 (%s/%s) abcd012", runtime.GOOS, runtime.GOARCH)
+	ua := Default()
+	if ua != want {
+		t.Errorf("Default()=%q, want %q", ua, want)
+	}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+// Base version information.
+//
+// This is the fallback data used when version information from git is not
+// provided via go ldflags.
+//
+// If you are looking at these fields in the git tree, they look
+// strange. They are modified on the fly by the build process.
+var (
+	GitVersion string = "v0.0.0-main"
+	GitCommit  string = "abcd01234" // sha1 from git, output of $(git rev-parse HEAD)
+)


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
-->

#### What this PR does / why we need it:

Set a meaningful user agent for requests coming from the jobset controller eg: jobset/v0.2.0 (linux/amd64)

#### Which issue(s) this PR fixes:
Fixes #768

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Modified user agent for requests coming from the jobset controller. Action required: None.
```