### PR TITLE
Updating the documentation for Pod DNS and underlying headless service.

### DIFF
--- a/site/content/en/docs/concepts/_index.md
+++ b/site/content/en/docs/concepts/_index.md
@@ -109,10 +109,9 @@ The Job name will have the following format: `<jobSetName>-<replicatedJobName>-<
 
 ### DNS hostnames for Pods
 
-By default, JobSet configures DNS for Pods by creating a headless service for each `spec.replicatedJobs`. 
-The headless service name, which determines the subdomain, is `.metadata.name-.spec.replicatedJobs[*].name`
+By default, JobSet configures DNS for Pods by creating a headless service with name `spec.network.subdomain` which defaults to `.metadata.name` if not set.   
 
-To list all the headless services that belong to a JobSet, you can use a command like this:
+To list the headless service that belong to a JobSet, you can use a command like this:
 
 ```shell
 kubectl get services --selector=jobset.sigs.k8s.io/jobset-name=pytorch
@@ -123,6 +122,24 @@ The output is similar to
 ```
 NAME              TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
 pytorch-workers   ClusterIP   None         <none>        <none>    25m
+```
+
+The hostname for pod will have the following format: `<jobSetName>-<spec.replicatedJob[*].name>-<spec.replicatedJob[*].replicas[*]>-<pod-index>.<subdomain>`.  
+
+To list all the hostname for the pods that belong to a JobSet, you can use a command like this:
+
+```shell
+kubectl get pods -o custom-columns=Name:.metadata.name,HOSTNAME:.spec.hostname --selector=jobset.sigs.k8s.io/jobset-name=pytorch
+```
+
+The output is similar to 
+
+```
+Name                         HOSTNAME
+pytorch-workers-0-0-tcngx   pytorch-workers-0-0
+pytorch-workers-0-1-sbhxs   pytorch-workers-0-1
+pytorch-workers-0-2-5m6d6   pytorch-workers-0-2
+pytorch-workers-0-3-mn8c8.  pytorch-workers-0-3
 ```
 
 ### Exclusive Job to topology placement

--- a/site/content/en/docs/concepts/_index.md
+++ b/site/content/en/docs/concepts/_index.md
@@ -124,22 +124,25 @@ NAME              TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
 pytorch-workers   ClusterIP   None         <none>        <none>    25m
 ```
 
-The hostname for pod will have the following format: `<jobSetName>-<spec.replicatedJob[*].name>-<spec.replicatedJob[*].replicas[*]>-<pod-index>.<subdomain>`.  
+The hostname for pod will have the following format: `<jobSetName>-<spec.replicatedJob[*].name>-<spec.replicatedJob[*].replicas[*]>-<pod-index>`. 
+
+The FQDN for pod will have the following format: `<jobSetName>-<spec.replicatedJob[*].name>-<spec.replicatedJob[*].replicas[*]>-<pod-index>.<subdomain>`. 
 
 To list all the hostname for the pods that belong to a JobSet, you can use a command like this:
 
 ```shell
-kubectl get pods -o custom-columns=Name:.metadata.name,HOSTNAME:.spec.hostname --selector=jobset.sigs.k8s.io/jobset-name=pytorch
+kubectl get pods -o custom-columns=Name:.metadata.name,HOSTNAME:.spec.hostname,Subdomain:.spec.subdomain --selector=jobset.sigs.k8s.io/jobset-name=pytorch
+
 ```
 
 The output is similar to 
 
 ```
-Name                         HOSTNAME
-pytorch-workers-0-0-tcngx   pytorch-workers-0-0
-pytorch-workers-0-1-sbhxs   pytorch-workers-0-1
-pytorch-workers-0-2-5m6d6   pytorch-workers-0-2
-pytorch-workers-0-3-mn8c8.  pytorch-workers-0-3
+Name                         HOSTNAME                 Subdomain
+pytorch-workers-0-0-tcngx   pytorch-workers-0-0.      pytorch
+pytorch-workers-0-1-sbhxs   pytorch-workers-0-1       pytorch
+pytorch-workers-0-2-5m6d6   pytorch-workers-0-2       pytorch
+pytorch-workers-0-3-mn8c8.  pytorch-workers-0-3       pytorch
 ```
 
 ### Exclusive Job to topology placement


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation


#### What this PR does / why we need it:
This PR is for updating the public doc around the pod DNS and how the underlying headless is created for a jobset. Each jobset create one headless service and not headless service per replicatedjob. Also added command on how to query for the pod hostname and format for the pod DNS created.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # Documentation around pod DNS for Jobset

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```