### PR TITLE
Add missing external types to apply configurations

### DIFF
--- a/client-go/applyconfiguration/jobset/v1alpha2/replicatedjob.go
+++ b/client-go/applyconfiguration/jobset/v1alpha2/replicatedjob.go
@@ -15,16 +15,16 @@ limitations under the License.
 package v1alpha2
 
 import (
-	v1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/client-go/applyconfigurations/batch/v1"
 )
 
 // ReplicatedJobApplyConfiguration represents a declarative configuration of the ReplicatedJob type for use
 // with apply.
 type ReplicatedJobApplyConfiguration struct {
-	Name      *string                       `json:"name,omitempty"`
-	Template  *v1.JobTemplateSpec           `json:"template,omitempty"`
-	Replicas  *int32                        `json:"replicas,omitempty"`
-	DependsOn []DependsOnApplyConfiguration `json:"dependsOn,omitempty"`
+	Name      *string                               `json:"name,omitempty"`
+	Template  *v1.JobTemplateSpecApplyConfiguration `json:"template,omitempty"`
+	Replicas  *int32                                `json:"replicas,omitempty"`
+	DependsOn []DependsOnApplyConfiguration         `json:"dependsOn,omitempty"`
 }
 
 // ReplicatedJobApplyConfiguration constructs a declarative configuration of the ReplicatedJob type for use with
@@ -44,8 +44,8 @@ func (b *ReplicatedJobApplyConfiguration) WithName(value string) *ReplicatedJobA
 // WithTemplate sets the Template field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Template field is set to the value of the last call.
-func (b *ReplicatedJobApplyConfiguration) WithTemplate(value v1.JobTemplateSpec) *ReplicatedJobApplyConfiguration {
-	b.Template = &value
+func (b *ReplicatedJobApplyConfiguration) WithTemplate(value *v1.JobTemplateSpecApplyConfiguration) *ReplicatedJobApplyConfiguration {
+	b.Template = value
 	return b
 }
 

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -41,6 +41,7 @@ kube::codegen::gen_helpers \
 kube::codegen::gen_client \
     --with-watch \
     --with-applyconfig \
+    --applyconfig-externals "k8s.io/api/batch/v1.JobTemplateSpec:k8s.io/client-go/applyconfigurations/batch/v1" \
     --output-dir "${REPO_ROOT}/client-go" \
     --output-pkg sigs.k8s.io/jobset/client-go \
     --boilerplate "${REPO_ROOT}/hack/boilerplate.go.txt" \


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

/kind api-change

#### What this PR does / why we need it:

This PR adds the external types the JobSet API depends on to the code-generator command so the generated client apply configurations are complete and do not rely on "non-apply" types. 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Add missing external types to apply configurations
```
