### PR TITLE
Increase memory limit and remove cpu limit for the default deployment

### DIFF
--- a/config/components/manager/manager.yaml
+++ b/config/components/manager/manager.yaml
@@ -96,7 +96,6 @@ spec:
             cpu: 500m
             memory: 128Mi
           limits:
-            cpu: 2
-            memory: 512Mi
+            memory: 4Gi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Increase memory limit, currently set too low at 500MB, for example 4GB, and completely remove the cpu limit so that the the jobset controller can burst to use all available resources on the node


Fixes #778 

