### PR TITLE
helm: disable Promethues metrics exporting by default

### DIFF
--- a/charts/jobset/README.md
+++ b/charts/jobset/README.md
@@ -81,7 +81,7 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | controller.podSecurityContext | object | `{"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context of the jobset controller pods. |
 | certManager.enable | bool | `false` | Whether to use cert-manager to generate certificates for the jobset webhook. |
 | certManager.issuerRef | object | `{}` | The reference to the issuer. If empty, self-signed issuer will be created and used. |
-| prometheus.enable | bool | `true` | Whether to enable Prometheus metrics exporting. |
+| prometheus.enable | bool | `false` | Whether to enable Prometheus metrics exporting. |
 
 ## Maintainers
 

--- a/charts/jobset/templates/prometheus/service_monitor.yaml
+++ b/charts/jobset/templates/prometheus/service_monitor.yaml
@@ -15,6 +15,9 @@ limitations under the License.
 */ -}}
 
 {{- if .Values.prometheus.enable }}
+{{- if not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor") }}
+{{- fail "The cluster does not support the required API resource `monitoring.coreos.com/v1/ServiceMonitor`." }}
+{{- end -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/jobset/tests/prometheus/service_monitor_test.yaml
+++ b/charts/jobset/tests/prometheus/service_monitor_test.yaml
@@ -24,7 +24,15 @@ release:
   namespace: jobset-system
 
 tests:
+  - it: Should not create Prometheus ServiceMonitor by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: Should create Prometheus ServiceMonitor if `prometheus.enable` is `true`
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1/ServiceMonitor
     set:
       prometheus:
         enable: true
@@ -33,3 +41,11 @@ tests:
           apiVersion: monitoring.coreos.com/v1
           kind: ServiceMonitor
           name: jobset-metrics-service-monitor
+
+  - it: Should fail if the cluster does not support the required API resource `monitoring.coreos.com/v1/ServiceMonitor`
+    set:
+      prometheus:
+        enable: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "The cluster does not support the required API resource `monitoring.coreos.com/v1/ServiceMonitor`."

--- a/charts/jobset/tests/prometheus/service_test.yaml
+++ b/charts/jobset/tests/prometheus/service_test.yaml
@@ -24,6 +24,11 @@ release:
   namespace: jobset-system
 
 tests:
+  - it: Should not create Prometheus metrics service by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: Should create Prometheus Service if `prometheus.enable` is `true`
     set:
       prometheus:

--- a/charts/jobset/values.yaml
+++ b/charts/jobset/values.yaml
@@ -107,4 +107,4 @@ certManager:
 
 prometheus:
   # -- Whether to enable Prometheus metrics exporting.
-  enable: true
+  enable: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

We should disable Prometheus metrics exporting by default in Helm, to keep the same as kustomize.

I also add some helm unittests to make it can work as expected. When Prometheus operator is not installed in the cluster, one wail fail to install the helm chart if he wants to enable metrics exporting by setting `prometheus.enable=true`. 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```