### PR TITLE
update reference data

### DIFF
--- a/site/content/en/docs/reference/jobset.v1alpha2.md
+++ b/site/content/en/docs/reference/jobset.v1alpha2.md
@@ -88,6 +88,51 @@ the coordinator pod.</p>
 </tbody>
 </table>
 
+## `DependsOn`     {#jobset-x-k8s-io-v1alpha2-DependsOn}
+    
+
+**Appears in:**
+
+- [ReplicatedJob](#jobset-x-k8s-io-v1alpha2-ReplicatedJob)
+
+
+<p>DependsOn defines the dependency on the previous ReplicatedJob status.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Name of the previous ReplicatedJob.</p>
+</td>
+</tr>
+<tr><td><code>status</code> <B>[Required]</B><br/>
+<a href="#jobset-x-k8s-io-v1alpha2-DependsOnStatus"><code>DependsOnStatus</code></a>
+</td>
+<td>
+   <p>Status defines the condition for the ReplicatedJob. Only Ready or Complete status can be set.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `DependsOnStatus`     {#jobset-x-k8s-io-v1alpha2-DependsOnStatus}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [DependsOn](#jobset-x-k8s-io-v1alpha2-DependsOn)
+
+
+
+
+
 ## `FailurePolicy`     {#jobset-x-k8s-io-v1alpha2-FailurePolicy}
     
 
@@ -108,6 +153,14 @@ the coordinator pod.</p>
 <td>
    <p>MaxRestarts defines the limit on the number of JobSet restarts.
 A restart is achieved by recreating all active child jobs.</p>
+</td>
+</tr>
+<tr><td><code>restartStrategy</code><br/>
+<a href="#jobset-x-k8s-io-v1alpha2-JobSetRestartStrategy"><code>JobSetRestartStrategy</code></a>
+</td>
+<td>
+   <p>RestartStrategy defines the strategy to use when restarting the JobSet.
+Defaults to Recreate.</p>
 </td>
 </tr>
 <tr><td><code>rules</code> <B>[Required]</B><br/>
@@ -193,6 +246,18 @@ An empty list will apply to all replicatedJobs.</p>
 </tbody>
 </table>
 
+## `JobSetRestartStrategy`     {#jobset-x-k8s-io-v1alpha2-JobSetRestartStrategy}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [FailurePolicy](#jobset-x-k8s-io-v1alpha2-FailurePolicy)
+
+
+
+
+
 ## `JobSetSpec`     {#jobset-x-k8s-io-v1alpha2-JobSetSpec}
     
 
@@ -247,7 +312,8 @@ finished with status failed.</p>
 <a href="#jobset-x-k8s-io-v1alpha2-StartupPolicy"><code>StartupPolicy</code></a>
 </td>
 <td>
-   <p>StartupPolicy, if set, configures in what order jobs must be started</p>
+   <p>StartupPolicy, if set, configures in what order jobs must be started
+Deprecated: StartupPolicy is deprecated, please use the DependsOn API.</p>
 </td>
 </tr>
 <tr><td><code>suspend</code> <B>[Required]</B><br/>
@@ -446,6 +512,21 @@ for the Job name.</p>
 <td>
    <p>Replicas is the number of jobs that will be created from this ReplicatedJob's template.
 Jobs names will be in the format: &lt;jobSet.name&gt;-&lt;spec.replicatedJob.name&gt;-<!-- raw HTML omitted --></p>
+</td>
+</tr>
+<tr><td><code>dependsOn</code><br/>
+<a href="#jobset-x-k8s-io-v1alpha2-DependsOn"><code>[]DependsOn</code></a>
+</td>
+<td>
+   <p>DependsOn is an optional list that specifies the preceding ReplicatedJobs upon which
+the current ReplicatedJob depends. If specified, the ReplicatedJob will be created
+only after the referenced ReplicatedJobs reach their desired state.
+The Order of ReplicatedJobs is defined by their enumeration in the slice.
+Note, that the first ReplicatedJob in the slice cannot use the DependsOn API.
+Currently, only a single item is supported in the DependsOn list.
+If JobSet is suspended the all active ReplicatedJobs will be suspended. When JobSet is
+resumed the Job sequence starts again.
+This API is mutually exclusive with the StartupPolicy API.</p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Generate api references
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```