### PR TITLE
Add .helmignore file to ignore files when packging the Helm chart

### DIFF
--- a/charts/jobset/.helmignore
+++ b/charts/jobset/.helmignore
@@ -1,0 +1,39 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+
+ci/
+.helmignore
+
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+
+# Various IDEs
+*.tmproj
+.project
+.idea/
+.vscode/
+
+# MacOS
+.DS_Store
+
+# helm-unittest
+tests
+.debug
+__snapshot__
+
+# helm-docs
+README.md.gotmpl


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

We should ignore some files (e.g. helm unittest files and `README.md.gotmpl`) when publishing Helm charts to reduce the package size. For now, if you try to pull the jobset helm chart, you will find tests files are also packaged:

```
$ helm pull oci://us-central1-docker.pkg.dev/k8s-staging-images/charts/jobset --version v0.8.0

$ tar -zxvf jobset-v0.8.0.tgz
x jobset/Chart.yaml
x jobset/values.yaml
x jobset/templates/NOTES.txt
x jobset/templates/_helpers.tpl
x jobset/templates/certmanager/_helpers.tpl
x jobset/templates/certmanager/certificate.yaml
x jobset/templates/certmanager/issuer.yaml
x jobset/templates/controller/_helpers.tpl
x jobset/templates/controller/cluster_role.yaml
x jobset/templates/controller/cluster_role_binding.yaml
x jobset/templates/controller/configmap.yaml
x jobset/templates/controller/deployment.yaml
x jobset/templates/controller/role.yaml
x jobset/templates/controller/role_binding.yaml
x jobset/templates/controller/service_account.yaml
x jobset/templates/prometheus/_helpers.tpl
x jobset/templates/prometheus/service.yaml
x jobset/templates/prometheus/service_monitor.yaml
x jobset/templates/webhook/_helpers.tpl
x jobset/templates/webhook/mutating_webhook_configuration.yaml
x jobset/templates/webhook/secret.yaml
x jobset/templates/webhook/service.yaml
x jobset/templates/webhook/validating_webhook_configuration.yaml
x jobset/README.md
x jobset/README.md.gotmpl
x jobset/crds/jobset.x-k8s.io_jobsets.yaml
x jobset/tests/certmanager/certificate_test.yaml
x jobset/tests/certmanager/issuer_test.yaml
x jobset/tests/controller/deployment_test.yaml
x jobset/tests/prometheus/service_monitor_test.yaml
x jobset/tests/prometheus/service_test.yaml
x jobset/tests/webhook/secret_test.yaml
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
# Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
No
```