### PR TITLE
Default to 8443 as metrics port to align service instead of 8080

### DIFF
--- a/api/config/v1alpha1/defaults.go
+++ b/api/config/v1alpha1/defaults.go
@@ -28,7 +28,7 @@ const (
 	DefaultWebhookSecretName                   = "jobset-webhook-server-cert"
 	DefaultWebhookPort                         = 9443
 	DefaultHealthProbeBindAddress              = ":8081"
-	DefaultMetricsBindAddress                  = ":8080"
+	DefaultMetricsBindAddress                  = ":8443"
 	DefaultLeaderElectionID                    = "6d4f6a47.jobset.x-k8s.io"
 	DefaultLeaderElectionLeaseDuration         = 15 * time.Second
 	DefaultLeaderElectionRenewDeadline         = 10 * time.Second

--- a/charts/jobset/templates/controller/deployment.yaml
+++ b/charts/jobset/templates/controller/deployment.yaml
@@ -71,7 +71,7 @@ spec:
           protocol: TCP
         {{- if .Values.prometheus.enable }}
         - name: metrics
-          containerPort: 8080
+          containerPort: 8443
           protocol: TCP
         {{- end }}
         livenessProbe:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -35,6 +35,8 @@ patchesStrategicMerge:
 # Other configurations
 - manager_config_patch.yaml
 
+- manager_metrics_patch.yaml
+
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection

--- a/config/default/manager_metrics_patch.yaml
+++ b/config/default/manager_metrics_patch.yaml
@@ -1,0 +1,15 @@
+# This patch exposes 8443 port used by metrics service
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          ports:
+            - containerPort: 8443
+              name: metrics
+              protocol: TCP

--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ func main() {
 	var burst int
 	var featureGates string
 	var configFile string
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8443", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -72,7 +72,7 @@ kind: Configuration
 health:
   healthProbeBindAddress: :8081
 metrics:
-  bindAddress: :8080
+  bindAddress: :8443
 leaderElection:
   leaderElect: true
   resourceName: 6d4f6a47.jobset.x-k8s.io
@@ -93,7 +93,7 @@ kind: Configuration
 health:
   healthProbeBindAddress: :8081
 metrics:
-  bindAddress: :8080
+  bindAddress: :8443
 leaderElection:
   leaderElect: true
   resourceName: 6d4f6a47.jobset.x-k8s.io
@@ -112,7 +112,7 @@ kind: Configuration
 health:
   healthProbeBindAddress: :8081
 metrics:
-  bindAddress: :8080
+  bindAddress: :8443
 leaderElection:
   leaderElect: false
 webhook:
@@ -128,7 +128,7 @@ kind: Configuration
 health:
   healthProbeBindAddress: :8081
 metrics:
-  bindAddress: :8080
+  bindAddress: :8443
 leaderElection:
   leaderElect: true
   resourceName: 6d4f6a47.jobset.x-k8s.io
@@ -149,7 +149,7 @@ invalidField: invalidValue
 health:
   healthProbeBindAddress: :8081
 metrics:
-  bindAddress: :8080
+  bindAddress: :8443
 leaderElection:
   leaderElect: true
   resourceName: 6d4f6a47.jobset.x-k8s.io


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Metrics service resource exposes 8443 port in https://github.com/kubernetes-sigs/jobset/blob/a2249cdd7d2abcdc05a2ba7f928e917b3b2116c4/config/default/manager_metrics_service.yaml#L12-L15

However, metrics-bind-address flag's default and configuration file's default do not match with this value.

This PR changes the default values to 8443 in order to align with the service resource.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes-sigs/jobset/issues/836

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Defaulting to 8443 as metrics bind address port number
```