### PR TITLE
Set readOnlyRootFilesystem explicitly to true

### DIFF
--- a/charts/jobset/values.yaml
+++ b/charts/jobset/values.yaml
@@ -58,6 +58,7 @@ controller:
   # -- Security context of the jobset controller container.
   securityContext:
     allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
     capabilities:
       drop:
         - ALL

--- a/config/components/manager/manager.yaml
+++ b/config/components/manager/manager.yaml
@@ -74,6 +74,7 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           capabilities:
             drop:
               - "ALL"


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
As in here https://github.com/kubernetes-sigs/lws/pull/457, this PR sets `readOnlyRootFilesystem` to true. 

#### Does this PR introduce a user-facing change?
```release-note
Setting the pods readOnlyRootFilesystem to true
```