### PR TITLE
Add a JobSet label for Pods with the UID of the JobSet.

### DIFF
--- a/api/jobset/v1alpha2/jobset_types.go
+++ b/api/jobset/v1alpha2/jobset_types.go
@@ -21,6 +21,7 @@ import (
 
 const (
 	JobSetNameKey         string = "jobset.sigs.k8s.io/jobset-name"
+	JobSetUIDKey          string = "jobset.sigs.k8s.io/jobset-uid"
 	ReplicatedJobReplicas string = "jobset.sigs.k8s.io/replicatedjob-replicas"
 	// GlobalReplicasKey is a label/annotation set to the total number of replicatedJob replicas.
 	// For each JobSet, this value will be equal to the sum of `replicas`, where `replicas`

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -769,6 +769,7 @@ func labelAndAnnotateObject(obj metav1.Object, js *jobset.JobSet, rjob *jobset.R
 	labels := make(map[string]string)
 	maps.Copy(labels, obj.GetLabels())
 	labels[jobset.JobSetNameKey] = js.Name
+	labels[jobset.JobSetUIDKey] = string(js.GetUID())
 	labels[jobset.ReplicatedJobNameKey] = rjob.Name
 	labels[constants.RestartsKey] = strconv.Itoa(int(js.Status.Restarts))
 	labels[jobset.ReplicatedJobReplicas] = strconv.Itoa(int(rjob.Replicas))
@@ -783,6 +784,7 @@ func labelAndAnnotateObject(obj metav1.Object, js *jobset.JobSet, rjob *jobset.R
 	annotations := make(map[string]string)
 	maps.Copy(annotations, obj.GetAnnotations())
 	annotations[jobset.JobSetNameKey] = js.Name
+	annotations[jobset.JobSetUIDKey] = string(js.GetUID())
 	annotations[jobset.ReplicatedJobNameKey] = rjob.Name
 	annotations[constants.RestartsKey] = strconv.Itoa(int(js.Status.Restarts))
 	annotations[jobset.ReplicatedJobReplicas] = strconv.Itoa(int(rjob.Replicas))

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -1409,6 +1409,7 @@ func jobWithFailedConditionAndOpts(name string, failureTime time.Time, opts *fai
 
 type makeJobArgs struct {
 	jobSetName           string
+	jobSetUID            string
 	replicatedJobName    string
 	groupName            string
 	jobName              string
@@ -1428,6 +1429,7 @@ type makeJobArgs struct {
 func makeJob(args *makeJobArgs) *testutils.JobWrapper {
 	labels := map[string]string{
 		jobset.JobSetNameKey:         args.jobSetName,
+		jobset.JobSetUIDKey:          args.jobSetUID,
 		jobset.ReplicatedJobNameKey:  args.replicatedJobName,
 		jobset.GroupNameKey:          args.groupName,
 		jobset.ReplicatedJobReplicas: strconv.Itoa(args.replicas),
@@ -1437,6 +1439,7 @@ func makeJob(args *makeJobArgs) *testutils.JobWrapper {
 	}
 	annotations := map[string]string{
 		jobset.JobSetNameKey:         args.jobSetName,
+		jobset.JobSetUIDKey:          args.jobSetUID,
 		jobset.ReplicatedJobNameKey:  args.replicatedJobName,
 		jobset.GroupNameKey:          args.groupName,
 		jobset.ReplicatedJobReplicas: strconv.Itoa(args.replicas),

--- a/pkg/controllers/pod_controller_test.go
+++ b/pkg/controllers/pod_controller_test.go
@@ -325,6 +325,7 @@ func TestDeleteFollowerPods(t *testing.T) {
 
 type makePodArgs struct {
 	jobSetName        string
+	jobSetUID         string
 	replicatedJobName string
 	jobName           string
 	podName           string
@@ -337,12 +338,14 @@ type makePodArgs struct {
 func makePod(args *makePodArgs) *testutils.PodWrapper {
 	labels := map[string]string{
 		jobset.JobSetNameKey:        args.jobSetName,
+		jobset.JobSetUIDKey:         args.jobSetUID,
 		jobset.ReplicatedJobNameKey: args.replicatedJobName,
 		jobset.JobIndexKey:          strconv.Itoa(args.jobIdx),
 		jobset.JobKey:               jobHashKey(args.ns, args.jobName),
 	}
 	annotations := map[string]string{
 		jobset.JobSetNameKey: args.jobSetName,
+		jobset.JobSetUIDKey:  args.jobSetUID,
 		jobset.JobIndexKey:   strconv.Itoa(args.jobIdx),
 		jobset.JobKey:        jobHashKey(args.ns, args.jobName),
 	}

--- a/site/content/en/docs/concepts/_index.md
+++ b/site/content/en/docs/concepts/_index.md
@@ -90,6 +90,7 @@ pytorch-workers-0-3-mn8c8   1/1     Running   0          13m
 
 JobSet labels will have `jobset.x-k8s.io/` prefix. JobSet sets the following labels on both the jobs and pods:
 - `jobset.sigs.k8s.io/jobset-name`: `.metadata.name`
+- `jobset.sigs.k8s.io/jobset-uid`: `.metadata.uid`
 - `jobset.sigs.k8s.io/replicatedjob-name`: `.spec.replicatedJobs[*].name`
 - `jobset.sigs.k8s.io/replicatedjob-replicas`: `.spec.replicatedJobs[*].replicas`
 - `jobset.sigs.k8s.io/job-index`: ordinal index of a job within a `spec.replicatedJobs[*]`


### PR DESCRIPTION
This adds a  `jobset.sigs.k8s.io/jobset-uid` label to the list from https://jobset.sigs.k8s.io/docs/concepts/#jobset-labels.

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds a `jobset.sigs.k8s.io/jobset-uid` label to the Pods created under that JobSet with the value of the JobSet's UID. This complements the existing `jobset.sigs.k8s.io/jobset-name` label documented in https://jobset.sigs.k8s.io/docs/concepts/#jobset-labels and allows us to easily map back from the Pod to the JobSet that indirectly owns it.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Add a  `jobset.sigs.k8s.io/jobset-uid` label to the list of JobSet labels documented at https://jobset.sigs.k8s.io/docs/concepts/#jobset-labels.
```