### PR TITLE
Enable TLS metrics

### DIFF
--- a/api/config/v1alpha1/configuration_types.go
+++ b/api/config/v1alpha1/configuration_types.go
@@ -83,6 +83,12 @@ type ControllerMetrics struct {
 	// It can be set to "0" to disable the metrics serving.
 	// +optional
 	BindAddress string `json:"bindAddress,omitempty"`
+
+	// CertDir is the directory that contains the server key and certificate.
+	// If not set, a self-signed certificate will be used. The server key and
+	// certificate must be named tls.key and tls.crt, respectively.
+	// +optional
+	CertDir string `json:"certDir,omitempty"`
 }
 
 // ControllerHealth defines the health configs.

--- a/charts/jobset/README.md
+++ b/charts/jobset/README.md
@@ -91,6 +91,8 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | certManager.enable | bool | `false` | Whether to use cert-manager to generate certificates for the jobset webhook. |
 | certManager.issuerRef | object | `{}` | The reference to the issuer. If empty, self-signed issuer will be created and used. |
 | prometheus.enable | bool | `false` | Whether to enable Prometheus metrics exporting. |
+| prometheus.prometheusNamespace | string | `"monitoring"` |  |
+| prometheus.prometheusClientCertSecretName | string | `"jobset-metrics-server-cert"` |  |
 
 ## Maintainers
 

--- a/charts/jobset/templates/NOTES.txt
+++ b/charts/jobset/templates/NOTES.txt
@@ -16,7 +16,5 @@ limitations under the License.
 
 Thank you for installing {{ .Chart.Name }}. The JobSet controller is now deployed in your cluster. To verify that the controller is running, you can run:
   kubectl get deployment -n {{ .Release.Namespace }} {{ include "jobset.controller.deployment.name" . }}
-{{- if .Values.prometheus.enable }}
 To access the metrics endpoint:
-  kubectl port-forward svc/{{ include "jobset.metrics.service.name" . }} 443
-{{- end }}
+  kubectl port-forward svc/{{ include "jobset.metrics.service.name" . }} 8443

--- a/charts/jobset/templates/certmanager/_helpers.tpl
+++ b/charts/jobset/templates/certmanager/_helpers.tpl
@@ -28,3 +28,11 @@ Create the name of the jobset webhook certificate.
 {{- define "jobset.certManager.certificate.name" -}}
 {{ include "jobset.name" . }}-cert
 {{- end -}}
+
+
+{{/*
+Create the name of the jobset metrics certificate.
+*/}}
+{{- define "jobset.certManager.metricsCertificate.name" -}}
+{{ include "jobset.name" . }}-metrics-cert
+{{- end -}}

--- a/charts/jobset/templates/certmanager/certificate.yaml
+++ b/charts/jobset/templates/certmanager/certificate.yaml
@@ -32,7 +32,7 @@ spec:
   {{- else }}
     {{- toYaml .Values.certManager.issuerRef | nindent 4 }}
   {{- end }}
-  commonName: {{ include "jobset.webhook.service.name" . }}.{{ .Release.Namespace }}.svc
+  commonName: {{ include "jobset.name" . }}-webhook
   dnsNames:
   - {{ include "jobset.webhook.service.name" . }}.{{ .Release.Namespace }}.svc
   - {{ include "jobset.webhook.service.name" . }}.{{ .Release.Namespace }}.svc.cluster.local

--- a/charts/jobset/templates/certmanager/certificate_metrics.yaml
+++ b/charts/jobset/templates/certmanager/certificate_metrics.yaml
@@ -32,7 +32,7 @@ spec:
     kind: Issuer
     name: {{ include "jobset.certManager.issuer.name" . }}
   {{- end }}
-  commonName: {{ include "jobset.metrics.service.name" . }}.{{ .Release.Namespace }}.svc
+  commonName: {{ include "jobset.name" . }}-metrics
   dnsNames:
   - {{ include "jobset.metrics.service.name" . }}.{{ .Release.Namespace }}.svc
   - {{ include "jobset.metrics.service.name" . }}.{{ .Release.Namespace }}.svc.cluster.local

--- a/charts/jobset/templates/certmanager/certificate_metrics.yaml
+++ b/charts/jobset/templates/certmanager/certificate_metrics.yaml
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */ -}}
 
-{{- if and .Values.prometheus.enable .Values.certManager.enable }}
+{{- if .Values.certManager.enable }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/charts/jobset/templates/certmanager/certificatemetrics.yaml
+++ b/charts/jobset/templates/certmanager/certificatemetrics.yaml
@@ -1,0 +1,44 @@
+{{- /*
+Copyright 2025 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ -}}
+
+{{- if and .Values.prometheus.enable .Values.certManager.enable }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "jobset.certManager.metricsCertificate.name" . }}
+  namespace: {{ .Release.Namespace}}
+  labels:
+    {{- include "jobset.labels" . | nindent 4 }}
+spec:
+  secretName: {{ include "jobset.metrics.secret.name" . }}
+  issuerRef:
+  {{- with .Values.certManager.issuerRef }}
+    {{ toYaml . | nindent 4 }}
+  {{- else }}
+    group: cert-manager.io
+    kind: Issuer
+    name: {{ include "jobset.certManager.issuer.name" . }}
+  {{- end }}
+  commonName: {{ include "jobset.metrics.service.name" . }}.{{ .Release.Namespace }}.svc
+  dnsNames:
+  - {{ include "jobset.metrics.service.name" . }}.{{ .Release.Namespace }}.svc
+  - {{ include "jobset.metrics.service.name" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  duration: 8760h
+  renewBefore: 720h
+  usages:
+  - server auth
+  - client auth
+{{- end }}

--- a/charts/jobset/templates/controller/deployment.yaml
+++ b/charts/jobset/templates/controller/deployment.yaml
@@ -62,7 +62,7 @@ spec:
         - name: webhook-cert
           mountPath: /tmp/k8s-webhook-server/serving-certs
           readOnly: true
-        {{- if and .Values.prometheus.enable .Values.certManager.enable }}
+        {{- if .Values.certManager.enable }}
         - mountPath: /tmp/k8s-metrics-server/serving-certs
           name: metrics-certs
           readOnly: true
@@ -116,7 +116,7 @@ spec:
         secret:
           secretName: {{ include "jobset.webhook.secret.name" . }}
           defaultMode: 420
-      {{- if and .Values.prometheus.enable .Values.certManager.enable }}
+      {{- if .Values.certManager.enable }}
       - name: metrics-certs
         secret:
           defaultMode: 420

--- a/charts/jobset/templates/controller/deployment.yaml
+++ b/charts/jobset/templates/controller/deployment.yaml
@@ -62,6 +62,11 @@ spec:
         - name: webhook-cert
           mountPath: /tmp/k8s-webhook-server/serving-certs
           readOnly: true
+        {{- if and .Values.prometheus.enable .Values.certManager.enable }}
+        - mountPath: /tmp/k8s-metrics-server/serving-certs
+          name: metrics-certs
+          readOnly: true
+        {{- end }}
         ports:
         - name: health-probe
           containerPort: 8081
@@ -111,6 +116,12 @@ spec:
         secret:
           secretName: {{ include "jobset.webhook.secret.name" . }}
           defaultMode: 420
+      {{- if and .Values.prometheus.enable .Values.certManager.enable }}
+      - name: metrics-certs
+        secret:
+          defaultMode: 420
+          secretName: {{ include "jobset.metrics.secret.name" . }}
+      {{- end }}
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/jobset/templates/controller/deployment.yaml
+++ b/charts/jobset/templates/controller/deployment.yaml
@@ -74,11 +74,9 @@ spec:
         - name: webhook
           containerPort: 9443
           protocol: TCP
-        {{- if .Values.prometheus.enable }}
         - name: metrics
           containerPort: 8443
           protocol: TCP
-        {{- end }}
         livenessProbe:
           httpGet:
             port: 8081

--- a/charts/jobset/templates/prometheus/_helpers.tpl
+++ b/charts/jobset/templates/prometheus/_helpers.tpl
@@ -34,3 +34,10 @@ Create the name of the jobset Prometheus service monitor.
 {{- define "jobset.metrics.serviceMonitor.name" -}}
 {{ include "jobset.metrics.name" . }}-service-monitor
 {{- end -}}
+
+{{/*
+Create the name of the jobset serving metrics TLS secret.
+*/}}
+{{- define "jobset.metrics.secret.name" -}}
+{{ include "jobset.fullname" . }}-metrics-server-cert
+{{- end -}}

--- a/charts/jobset/templates/prometheus/role.yaml
+++ b/charts/jobset/templates/prometheus/role.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.prometheus.enable }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "jobset.fullname" . }}-prometheus-k8s
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "jobset.controller.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}

--- a/charts/jobset/templates/prometheus/role_binding.yaml
+++ b/charts/jobset/templates/prometheus/role_binding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.prometheus.enable }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "jobset.fullname" . }}-prometheus-k8s
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "jobset.controller.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "jobset.fullname" . }}-prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: '{{ .Values.prometheus.prometheusNamespace }}'
+- kind: ServiceAccount
+  name: prometheus-operator
+  namespace: '{{ .Values.prometheus.prometheusNamespace }}'
+{{- end }}

--- a/charts/jobset/templates/prometheus/service.yaml
+++ b/charts/jobset/templates/prometheus/service.yaml
@@ -21,7 +21,7 @@ metadata:
   name: {{ include "jobset.metrics.service.name" . }}
   namespace: {{ .Release.Namespace}}
   labels:
-    {{- include "jobset.labels" . | nindent 4 }}
+    {{- include "jobset.controller.selectorLabels" . | nindent 4 }}
 spec:
   type: ClusterIP
   selector:

--- a/charts/jobset/templates/prometheus/service.yaml
+++ b/charts/jobset/templates/prometheus/service.yaml
@@ -13,8 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */ -}}
-
-{{- if .Values.prometheus.enable }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -31,4 +29,3 @@ spec:
     port: 8443
     protocol: TCP
     targetPort: 8443
-{{- end }}

--- a/charts/jobset/templates/prometheus/service.yaml
+++ b/charts/jobset/templates/prometheus/service.yaml
@@ -27,8 +27,8 @@ spec:
   selector:
     {{- include "jobset.controller.selectorLabels" . | nindent 4 }}
   ports:
-  - name: metrics
+  - name: https
     port: 8443
-    targetPort: metrics
     protocol: TCP
+    targetPort: 8443
 {{- end }}

--- a/charts/jobset/templates/prometheus/service_monitor.yaml
+++ b/charts/jobset/templates/prometheus/service_monitor.yaml
@@ -30,5 +30,27 @@ spec:
     matchLabels:
       {{- include "jobset.controller.selectorLabels" . | nindent 6 }}
   endpoints:
-  - port: metrics
+  - port: https
+    path: /metrics
+    scheme: https
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+{{- if .Values.certManager.enable }}
+    tlsConfig:
+      ca:
+        secret:
+          key: ca.crt
+          name: {{ include "jobset.metrics.secret.name" . }}
+      cert:
+        secret:
+          key: tls.crt
+          name: {{ include "jobset.metrics.secret.name" . }}
+      insecureSkipVerify: false
+      keySecret:
+        key: tls.key
+        name: {{ include "jobset.metrics.secret.name" . }}
+      serverName: {{ include "jobset.metrics.service.name" . }}.{{ .Release.Namespace }}.svc
+{{- else }}
+    tlsConfig:
+      insecureSkipVerify: true
+{{- end }}
 {{- end }}

--- a/charts/jobset/templates/prometheus/service_monitor.yaml
+++ b/charts/jobset/templates/prometheus/service_monitor.yaml
@@ -43,11 +43,11 @@ spec:
       cert:
         secret:
           key: tls.crt
-          name: {{ include "jobset.metrics.secret.name" . }}
+          name: {{ .Values.prometheus.prometheusClientCertSecretName }}
       insecureSkipVerify: false
       keySecret:
         key: tls.key
-        name: {{ include "jobset.metrics.secret.name" . }}
+        name: {{ .Values.prometheus.prometheusClientCertSecretName }}
       serverName: {{ include "jobset.metrics.service.name" . }}.{{ .Release.Namespace }}.svc
 {{- else }}
     tlsConfig:

--- a/charts/jobset/tests/prometheus/service_test.yaml
+++ b/charts/jobset/tests/prometheus/service_test.yaml
@@ -24,12 +24,7 @@ release:
   namespace: jobset-system
 
 tests:
-  - it: Should not create Prometheus metrics service by default
-    asserts:
-      - hasDocuments:
-          count: 0
-
-  - it: Should create Prometheus Service if `prometheus.enable` is `true`
+  - it: Should create Prometheus Service by default
     set:
       prometheus:
         enable: true

--- a/charts/jobset/values.yaml
+++ b/charts/jobset/values.yaml
@@ -86,3 +86,11 @@ certManager:
 prometheus:
   # -- Whether to enable Prometheus metrics exporting.
   enable: false
+  # SHOULD BE CONFIGURED
+  prometheusNamespace: monitoring
+  # SHOULD BE CONFIGURED
+  # The same certificate for the server ("jobset-metrics-server-cert") can potentially be also used for the client.
+  # It is preferable to use prometheus client certificate if available:
+  # Either by creating a secret in the jobset controller namespace
+  # or by using prometheus mounted secret which can be configured via certFile and keyFile in the service_monitor.yaml
+  prometheusClientCertSecretName: "jobset-metrics-server-cert"

--- a/config/components/certmanager/certificate.yaml
+++ b/config/components/certmanager/certificate.yaml
@@ -33,7 +33,7 @@ spec:
   dnsNames:
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
-  commonName: $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
+  commonName: jobset-webhook
   duration: 8760h
   renewBefore: 720h
   usages:

--- a/config/components/certmanager/certificate.yaml
+++ b/config/components/certmanager/certificate.yaml
@@ -33,6 +33,12 @@ spec:
   dnsNames:
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  commonName: $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
+  duration: 8760h
+  renewBefore: 720h
+  usages:
+    - server auth
+    - client auth
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer

--- a/config/components/certmanager/certificate_metrics.yaml
+++ b/config/components/certmanager/certificate_metrics.yaml
@@ -5,12 +5,12 @@ kind: Certificate
 metadata:
   labels:
     app.kubernetes.io/name: certificate
-    app.kubernetes.io/instance: metrics-certs
+    app.kubernetes.io/instance: metrics-cert
     app.kubernetes.io/component: certificate
     app.kubernetes.io/created-by: jobset
     app.kubernetes.io/part-of: jobset
     app.kubernetes.io/managed-by: kustomize
-  name: metrics-certs  # this name should match the one appeared in kustomizeconfig.yaml
+  name: metrics-cert  # this name should match the one appeared in kustomizeconfig.yaml
   namespace: system
 spec:
   # METRICS_SERVICE_NAME and METRICS_SERVICE_NAMESPACE will be substituted by kustomize

--- a/config/components/certmanager/certificate_metrics.yaml
+++ b/config/components/certmanager/certificate_metrics.yaml
@@ -17,6 +17,12 @@ spec:
   dnsNames:
     - $(METRICS_SERVICE_NAME).$(METRICS_SERVICE_NAMESPACE).svc
     - $(METRICS_SERVICE_NAME).$(METRICS_SERVICE_NAMESPACE).svc.cluster.local
+  commonName: $(METRICS_SERVICE_NAME).$(METRICS_SERVICE_NAMESPACE).svc
+  duration: 8760h
+  renewBefore: 720h
+  usages:
+    - server auth
+    - client auth
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer

--- a/config/components/certmanager/certificate_metrics.yaml
+++ b/config/components/certmanager/certificate_metrics.yaml
@@ -1,0 +1,23 @@
+# The following manifests contain a certificate CR.
+# More document can be found at https://docs.cert-manager.io
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/name: certificate
+    app.kubernetes.io/instance: metrics-certs
+    app.kubernetes.io/component: certificate
+    app.kubernetes.io/created-by: jobset
+    app.kubernetes.io/part-of: jobset
+    app.kubernetes.io/managed-by: kustomize
+  name: metrics-certs  # this name should match the one appeared in kustomizeconfig.yaml
+  namespace: system
+spec:
+  # METRICS_SERVICE_NAME and METRICS_SERVICE_NAMESPACE will be substituted by kustomize
+  dnsNames:
+    - $(METRICS_SERVICE_NAME).$(METRICS_SERVICE_NAMESPACE).svc
+    - $(METRICS_SERVICE_NAME).$(METRICS_SERVICE_NAMESPACE).svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: metrics-server-cert # this secret will not be prefixed, since it's not managed by kustomize

--- a/config/components/certmanager/certificate_metrics.yaml
+++ b/config/components/certmanager/certificate_metrics.yaml
@@ -17,7 +17,7 @@ spec:
   dnsNames:
     - $(METRICS_SERVICE_NAME).$(METRICS_SERVICE_NAMESPACE).svc
     - $(METRICS_SERVICE_NAME).$(METRICS_SERVICE_NAMESPACE).svc.cluster.local
-  commonName: $(METRICS_SERVICE_NAME).$(METRICS_SERVICE_NAMESPACE).svc
+  commonName: jobset-metrics
   duration: 8760h
   renewBefore: 720h
   usages:

--- a/config/components/certmanager/kustomization.yaml
+++ b/config/components/certmanager/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - certificate.yaml
+- certificate_metrics.yaml
 
 configurations:
 - kustomizeconfig.yaml

--- a/config/components/certmanager/kustomizeconfig.yaml
+++ b/config/components/certmanager/kustomizeconfig.yaml
@@ -10,7 +10,4 @@ nameReference:
 varReference:
 - kind: Certificate
   group: cert-manager.io
-  path: spec/commonName
-- kind: Certificate
-  group: cert-manager.io
   path: spec/dnsNames

--- a/config/components/manager/controller_manager_config.yaml
+++ b/config/components/manager/controller_manager_config.yaml
@@ -3,3 +3,5 @@ apiVersion: config.jobset.x-k8s.io/v1alpha1
 kind: Configuration
 leaderElection:
   leaderElect: true
+internalCertManagement:
+  enable: true

--- a/config/components/prometheus/kustomization.yaml
+++ b/config/components/prometheus/kustomization.yaml
@@ -4,8 +4,15 @@ resources:
 
 # [PROMETHEUS WITH CERTMANAGER] The following patch configures the ServiceMonitor in ../prometheus
 # to securely reference certificates created and managed by cert-manager.
-# Additionally, ensure that you uncomment the [METRICS WITH CERTMANAGER] patch under config/default/kustomization.yaml
+# Ensure correct reference are set in the monitor_tls_patch.yaml file:
+# METRICS_SERVICE_NAME (e.g. jobset-controller-manager-metrics-service.jobset-system.svc),
+# and ${METRICS_PROMETHEUS_CLIENT_CERT_SECRET_NAME} (e.g. metrics-server-cert).
+# Additionally
+# - ensure that you uncomment the [METRICS WITH CERTMANAGER] patch under config/default/kustomization.yaml
 # to mount the "metrics-server-cert" secret in the Manager Deployment.
+# - ensure that you uncomment the [METRICS WITH CERTMANAGER] patch under config/certmanager/kustomization.yaml
+# to enable certmanager for metrics.
+# - ensure prometheus RoleBinding in ./role.yaml references a correct namespace
 #patches:
 #  - path: monitor_tls_patch.yaml
 #    target:

--- a/config/components/prometheus/kustomization.yaml
+++ b/config/components/prometheus/kustomization.yaml
@@ -1,3 +1,12 @@
 resources:
 - monitor.yaml
 - role.yaml
+
+# [PROMETHEUS WITH CERTMANAGER] The following patch configures the ServiceMonitor in ../prometheus
+# to securely reference certificates created and managed by cert-manager.
+# Additionally, ensure that you uncomment the [METRICS WITH CERTMANAGER] patch under config/default/kustomization.yaml
+# to mount the "metrics-server-cert" secret in the Manager Deployment.
+#patches:
+#  - path: monitor_tls_patch.yaml
+#    target:
+#      kind: ServiceMonitor

--- a/config/components/prometheus/monitor_tls_patch.yaml
+++ b/config/components/prometheus/monitor_tls_patch.yaml
@@ -1,5 +1,12 @@
 # Patch for Prometheus ServiceMonitor to enable secure TLS configuration
 # using certificates managed by cert-manager
+#
+# [PROMETHEUS WITH CERTMANAGER]
+# ${METRICS_PROMETHEUS_CLIENT_CERT_SECRET_NAME} should be replaced with a prometheus client secret.
+# The same certificate for the server ("metrics-server-cert") can potentially be also used for the client.
+# It is preferable to use prometheus client certificate if available:
+# Either by creating a secret in the jobset controller namespace
+# or by using prometheus mounted secret which can be configured via certFile and keyFile in the service_monitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -20,8 +27,8 @@ spec:
             key: ca.crt
         cert:
           secret:
-            name: $(CLIENT_CERT_NAME)
+            name: ${METRICS_PROMETHEUS_CLIENT_CERT_SECRET_NAME}
             key: tls.crt
         keySecret:
-          name: $(CLIENT_CERT_NAME)
+          name: ${METRICS_PROMETHEUS_CLIENT_CERT_SECRET_NAME}
           key: tls.key

--- a/config/components/prometheus/monitor_tls_patch.yaml
+++ b/config/components/prometheus/monitor_tls_patch.yaml
@@ -1,0 +1,27 @@
+# Patch for Prometheus ServiceMonitor to enable secure TLS configuration
+# using certificates managed by cert-manager
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: controller-manager-metrics-monitor
+  namespace: system
+spec:
+  endpoints:
+    - path: /metrics
+      port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: false
+        serverName: $(METRICS_SERVICE_NAME).$(METRICS_SERVICE_NAMESPACE).svc
+        ca:
+          secret:
+            name: metrics-server-cert
+            key: ca.crt
+        cert:
+          secret:
+            name: $(CLIENT_CERT_NAME)
+            key: tls.crt
+        keySecret:
+          name: $(CLIENT_CERT_NAME)
+          key: tls.key

--- a/config/components/prometheus/monitor_tls_patch.yaml
+++ b/config/components/prometheus/monitor_tls_patch.yaml
@@ -20,7 +20,7 @@ spec:
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:
         insecureSkipVerify: false
-        serverName: $(METRICS_SERVICE_NAME).$(METRICS_SERVICE_NAMESPACE).svc
+        serverName: ${METRICS_SERVICE_NAME}.${METRICS_SERVICE_NAMESPACE}.svc
         ca:
           secret:
             name: metrics-server-cert

--- a/config/default/certmanager_metrics_manager_patch.yaml
+++ b/config/default/certmanager_metrics_manager_patch.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          volumeMounts:
+            - mountPath: /tmp/k8s-metrics-server/serving-certs
+              name: metrics-certs
+              readOnly: true
+      volumes:
+        - name: metrics-certs
+          secret:
+            defaultMode: 420
+            secretName: metrics-server-cert

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
 # crd/kustomization.yaml
 - ../components/webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
+# - ../components/certmanager
 - ../components/internalcert
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -42,6 +42,13 @@ patchesStrategicMerge:
 # 'CERTMANAGER' needs to be enabled to use ca injection
 #- webhookcainjection_patch.yaml
 
+#  Uncomment the patches line if you enable Metrics and CertManager
+# [METRICS WITH CERTMANGER] To enable metrics protected with certmanager, uncomment the following line.
+# This patch will protect the metrics with certmanager self-signed certs.
+#- certmanager_metrics_manager_patch.yaml
+
+# [PROMETHEUS WITH CERTMANAGER] to enable prometheus with certmanager, ../prometheus dir should be configured
+
 # the following config is for teaching kustomize how to do var substitution
 #vars:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
@@ -71,3 +78,15 @@ patchesStrategicMerge:
 #    kind: Service
 #    version: v1
 #    name: webhook-service
+#- name: METRICS_SERVICE_NAMESPACE # namespace of the service
+#  objref:
+#    kind: Service
+#    version: v1
+#    name: controller-manager-metrics-service
+#  fieldref:
+#    fieldpath: metadata.namespace
+#- name: METRICS_SERVICE_NAME
+#  objref:
+#    kind: Service
+#    version: v1
+#    name: controller-manager-metrics-service

--- a/main.go
+++ b/main.go
@@ -166,6 +166,9 @@ func main() {
 		SecureServing:  true,
 		FilterProvider: filters.WithAuthenticationAndAuthorization,
 		TLSOpts:        []func(*tls.Config){disableHTTP2},
+		CertDir:        options.Metrics.CertDir,
+		CertName:       options.Metrics.CertName,
+		KeyName:        options.Metrics.KeyName,
 	}
 	options.Metrics = metricsServerOptions
 	mgr, err := ctrl.NewManager(kubeConfig, options)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -35,6 +36,16 @@ func addTo(o *ctrl.Options, cfg *configapi.Configuration) {
 
 	if o.Metrics.BindAddress == "" && cfg.Metrics.BindAddress != "" {
 		o.Metrics.BindAddress = cfg.Metrics.BindAddress
+	}
+
+	internalCertManagementEnabled := ptr.Deref(cfg.InternalCertManagement.Enable, false)
+	if o.Metrics.CertDir == "" && (cfg.Metrics.CertDir != "" || !internalCertManagementEnabled) {
+		o.Metrics.CertDir = cfg.Metrics.CertDir
+		if o.Metrics.CertDir == "" {
+			o.Metrics.CertDir = "/tmp/k8s-metrics-server/serving-certs"
+		}
+		o.Metrics.CertName = "tls.crt"
+		o.Metrics.KeyName = "tls.key"
 	}
 
 	if o.HealthProbeBindAddress == "" && cfg.Health.HealthProbeBindAddress != "" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:
Add an option `PROMETHEUS WITH CERTMANAGER` to use a certificate generated by the cert manager in metrics serving instead of a localhost self-signed certificate. Optionally another certifiicate can be configured in `metrics.certDir` when `PROMETHEUS` is used. ServiceMonitor can then be secured with this certificate CA and  `insecureSkipVerify: false` can now be used when collecting metrics.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #793 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add an option `PROMETHEUS WITH CERTMANAGER` to use a certificate generated by the cert manager in metrics serving instead of a localhost self-signed certificate. Optionally another certifiicate can be configured in `metrics.certDir` when `PROMETHEUS` is used. ServiceMonitor can then be secured with this certificate CA and  `insecureSkipVerify: false` can now be used when collecting metrics. Prometheus support in helm can now also be enabled.
```