### PR TITLE
feature: add terminal_state metrics

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -39,6 +39,14 @@ var (
 			Help:      `The total number of completed JobSets`,
 		}, []string{"jobset_name"},
 	)
+
+	JobSetTerminalState = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: constants.JobSetSubsystemName,
+			Name:      "terminal_state",
+			Help:      `The current number of JobSets in terminal state (e.g. Completed, Failed)`,
+		}, []string{"jobset_name", "terminal_state"},
+	)
 )
 
 // JobSetFailed records the failed case
@@ -53,9 +61,20 @@ func JobSetCompleted(namespaceName string) {
 	CompletedTotal.WithLabelValues(namespaceName).Inc()
 }
 
+// RecordJobSetTerminalState records the terminal state of a JobSet.
+// It sets the value of the "terminal_state" gauge metric for the given jobSet, namespace, and phase.
+// label values:
+// - namespaceName: The namespace/name of the JobSet.
+// - phase: The terminal state of the JobSet (e.g., "Completed" or "Failed").
+// - value: The value to set for the gauge metric (typically 1.0 for active or 0.0 for inactive).
+func RecordJobSetTerminalState(namespaceName, phase string, value float64) {
+	JobSetTerminalState.WithLabelValues(namespaceName, phase).Set(value)
+}
+
 func Register() {
 	metrics.Registry.MustRegister(
 		FailedTotal,
 		CompletedTotal,
+		JobSetTerminalState,
 	)
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metrics
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -61,4 +62,24 @@ func TestJobSetCompleted(t *testing.T) {
 	if count := testutil.ToFloat64(CompletedTotal.WithLabelValues("default/jobset-test2")); count != float64(1) {
 		t.Errorf("Expecting %s to have value %d, but got %f", "default/jobset-test2", 1, count)
 	}
+}
+
+func TestRecordJobSetTerminalState(t *testing.T) {
+	prometheus.MustRegister(JobSetTerminalState)
+
+	jobSetName := "jobset-test"
+	namespace := "default"
+	completedPhase := "Completed"
+	failedPhase := "Failed"
+
+	RecordJobSetTerminalState(fmt.Sprintf("%s/%s", jobSetName, namespace), completedPhase, 1.0)
+	if value := testutil.ToFloat64(JobSetTerminalState.WithLabelValues(fmt.Sprintf("%s/%s", jobSetName, namespace), completedPhase)); value != 1.0 {
+		t.Errorf("Expecting terminal state %s to have value %f, but got %f", completedPhase, 1.0, value)
+	}
+
+	RecordJobSetTerminalState(fmt.Sprintf("%s/%s", jobSetName, namespace), failedPhase, 1.0)
+	if value := testutil.ToFloat64(JobSetTerminalState.WithLabelValues(fmt.Sprintf("%s/%s", jobSetName, namespace), failedPhase)); value != 1.0 {
+		t.Errorf("Expecting terminal state %s to have value %f, but got %f", failedPhase, 1.0, value)
+	}
+
 }

--- a/site/content/en/docs/reference/metrics.md
+++ b/site/content/en/docs/reference/metrics.md
@@ -28,7 +28,8 @@ Use the following metrics to monitor the health of the jobset controller:
 
 Use the following metrics to monitor the health of the jobsets created by the jobset controller:
 
-| Metric name                                 | Type | Description                                                               | Labels                                                                                            |
-|---------------------------------------------| ---- |---------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
-| `jobset_failed_total`                       | Counter | The total number of failed JobSets. | `jobset_name`: name of jobset      |
-| `jobset_completed_total`                    | Counter | The total number of completed JobSets.                                    | `jobset_name`: name of jobset  |
+| Metric Name                                | Type    | Description                                                                                     | Labels                                                                                             |
+|--------------------------------------------|---------|-------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
+| `jobset_failed_total`                      | Counter | The total number of failed JobSets.                                                            | `jobset_name`: Identifier for the JobSet in the format `<namespace>/<name>`, where `<namespace>` is the namespace and `<name>` is the name of the JobSet. |
+| `jobset_completed_total`                   | Counter | The total number of completed JobSets.                                                         | `jobset_name`: Identifier for the JobSet in the format `<namespace>/<name>`, where `<namespace>` is the namespace and `<name>` is the name of the JobSet. |
+| `jobset_terminal_state`                    | Gauge   | The current number of JobSets in a terminal state (e.g., Completed, Failed).                   | `jobset_name`: Identifier for the JobSet in the format `<namespace>/<name>`, where `<namespace>` is the namespace and `<name>` is the name of the JobSet.<br>`terminal_state`: Terminal state of the JobSet (e.g., "Completed", "Failed"). |


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- I found that only counter seems to be insufficient info, we should add Gauge metrics for jobset. So that we can query for a single jobset terminal status
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
add jobset_terminal_state  metrics
```