### PR TITLE
feat: support multiple items in DependsOn API

### DIFF
--- a/api/jobset/v1alpha2/jobset_types.go
+++ b/api/jobset/v1alpha2/jobset_types.go
@@ -262,6 +262,7 @@ type ReplicatedJob struct {
 	// resumed the Job sequence starts again.
 	// This API is mutually exclusive with the StartupPolicy API.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
+	// +kubebuilder:validation:MaxItems=16
 	// +optional
 	// +listType=map
 	// +listMapKey=name

--- a/api/jobset/v1alpha2/jobset_types.go
+++ b/api/jobset/v1alpha2/jobset_types.go
@@ -261,8 +261,7 @@ type ReplicatedJob struct {
 	// If JobSet is suspended the all active ReplicatedJobs will be suspended. When JobSet is
 	// resumed the Job sequence starts again.
 	// This API is mutually exclusive with the StartupPolicy API.
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:Immutable
 	// +optional
 	// +listType=map
 	// +listMapKey=name

--- a/api/jobset/v1alpha2/jobset_types.go
+++ b/api/jobset/v1alpha2/jobset_types.go
@@ -261,7 +261,8 @@ type ReplicatedJob struct {
 	// If JobSet is suspended the all active ReplicatedJobs will be suspended. When JobSet is
 	// resumed the Job sequence starts again.
 	// This API is mutually exclusive with the StartupPolicy API.
-	// +kubebuilder:validation:Immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
+	// +kubebuilder:validation:MaxItems=5
 	// +optional
 	// +listType=map
 	// +listMapKey=name

--- a/api/jobset/v1alpha2/jobset_types.go
+++ b/api/jobset/v1alpha2/jobset_types.go
@@ -262,7 +262,6 @@ type ReplicatedJob struct {
 	// resumed the Job sequence starts again.
 	// This API is mutually exclusive with the StartupPolicy API.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
-	// +kubebuilder:validation:MaxItems=1
 	// +optional
 	// +listType=map
 	// +listMapKey=name

--- a/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
+++ b/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
@@ -229,14 +229,10 @@ spec:
                         - name
                         - status
                         type: object
-                      maxItems: 16
                       type: array
                       x-kubernetes-list-map-keys:
                       - name
                       x-kubernetes-list-type: map
-                      x-kubernetes-validations:
-                      - message: Value is immutable
-                        rule: self == oldSelf
                     groupName:
                       default: default
                       description: GroupName defines the name of the group this ReplicatedJob

--- a/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
+++ b/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
@@ -229,10 +229,14 @@ spec:
                         - name
                         - status
                         type: object
+                      maxItems: 5
                       type: array
                       x-kubernetes-list-map-keys:
                       - name
                       x-kubernetes-list-type: map
+                      x-kubernetes-validations:
+                      - message: Value is immutable
+                        rule: self == oldSelf
                     groupName:
                       default: default
                       description: GroupName defines the name of the group this ReplicatedJob

--- a/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
+++ b/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
@@ -229,7 +229,6 @@ spec:
                         - name
                         - status
                         type: object
-                      maxItems: 1
                       type: array
                       x-kubernetes-list-map-keys:
                       - name

--- a/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
+++ b/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
@@ -229,6 +229,7 @@ spec:
                         - name
                         - status
                         type: object
+                      maxItems: 16
                       type: array
                       x-kubernetes-list-map-keys:
                       - name

--- a/hack/python-sdk/swagger.json
+++ b/hack/python-sdk/swagger.json
@@ -124,7 +124,7 @@
         },
         "metadata": {
           "default": {},
-          "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.32.2/api/openapi-spec/swagger.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+          "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.32.3/api/openapi-spec/swagger.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
         },
         "spec": {
           "default": {},
@@ -160,7 +160,7 @@
         },
         "metadata": {
           "default": {},
-          "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.32.2/api/openapi-spec/swagger.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+          "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.32.3/api/openapi-spec/swagger.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
         }
       }
     },
@@ -223,7 +223,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.32.2/api/openapi-spec/swagger.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
+            "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.32.3/api/openapi-spec/swagger.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
           },
           "x-kubernetes-list-map-keys": [
             "type"
@@ -253,7 +253,7 @@
           "format": "int32"
         },
         "terminalState": {
-          "description": "TerminalState the state of the JobSet when it finishes execution. It can be either Complete or Failed. Otherwise, it is empty by default.",
+          "description": "TerminalState the state of the JobSet when it finishes execution. It can be either Completed or Failed. Otherwise, it is empty by default.",
           "type": "string"
         }
       }
@@ -311,7 +311,7 @@
         "template": {
           "description": "Template defines the template of the Job that will be created.",
           "default": {},
-          "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.32.2/api/openapi-spec/swagger.json#/definitions/io.k8s.api.batch.v1.JobTemplateSpec"
+          "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.32.3/api/openapi-spec/swagger.json#/definitions/io.k8s.api.batch.v1.JobTemplateSpec"
         }
       }
     },

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -23,7 +23,7 @@ GO_CMD=${1:-go}
 CODEGEN_PKG=${2:-bin}
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-echo "GOPATH=$GOPATH"
+echo "GOPATH=$(go env GOPATH)"
 
 source "${CODEGEN_PKG}/kube_codegen.sh"
 

--- a/keps/672-serial-job-execution/README.md
+++ b/keps/672-serial-job-execution/README.md
@@ -17,7 +17,6 @@ tags, and then generate with `hack/update-toc.sh`.
 -->
 
 <!-- toc -->
-
 - [Summary](#summary)
 - [Motivation](#motivation)
   - [Goals](#goals)
@@ -28,6 +27,7 @@ tags, and then generate with `hack/update-toc.sh`.
     - [Story 2](#story-2)
     - [Story 3](#story-3)
     - [Story 4](#story-4)
+    - [Story 5](#story-5)
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
   - [API Details](#api-details)
@@ -46,7 +46,7 @@ tags, and then generate with `hack/update-toc.sh`.
 - [Alternatives](#alternatives)
   - [Using workflow engine to execute sequence of jobs](#using-workflow-engine-to-execute-sequence-of-jobs)
   - [Add the WaitForStatus API under ReplicatedJob](#add-the-waitforstatus-api-under-replicatedjob)
-  <!-- /toc -->
+<!-- /toc -->
 
 ## Summary
 

--- a/pkg/controllers/depends_on.go
+++ b/pkg/controllers/depends_on.go
@@ -7,11 +7,6 @@ import (
 // dependencyReachedStatus checks if dependant ReplicatedJob reaches Ready or Complete status.
 // func dependencyReachedStatus(dependsOnJob jobset.DependsOn, dependsOnJobReplicas int32, rJobsStatuses []jobset.ReplicatedJobStatus) bool {
 func dependencyReachedStatus(rJob jobset.ReplicatedJob, rJobReplicas map[string]int32, rJobsStatuses []jobset.ReplicatedJobStatus) bool {
-	// Check is ReplicatedJob has any dependencies.
-	if rJob.DependsOn == nil {
-		return true
-	}
-
 	for _, dependsOnJob := range rJob.DependsOn {
 		// If the actual status of dependant ReplicatedJob is empty, return false.
 		actualStatus := findReplicatedJobStatus(rJobsStatuses, dependsOnJob.Name)

--- a/pkg/controllers/depends_on.go
+++ b/pkg/controllers/depends_on.go
@@ -12,24 +12,23 @@ func dependencyReachedStatus(rJob jobset.ReplicatedJob, rJobReplicas map[string]
 		return true
 	}
 
-	// Get the dependant ReplicatedJob. Currently, the ReplicatedJob supports only a single dependency.
-	dependsOnJob := rJob.DependsOn[0]
+	for _, dependsOnJob := range rJob.DependsOn {
+		// If the actual status of dependant ReplicatedJob is empty, return false.
+		actualStatus := findReplicatedJobStatus(rJobsStatuses, dependsOnJob.Name)
+		if actualStatus == nil {
+			return false
+		}
 
-	// If the actual status of dependant ReplicatedJob is empty, return false.
-	actualStatus := findReplicatedJobStatus(rJobsStatuses, dependsOnJob.Name)
-	if actualStatus == nil {
-		return false
+		// For Complete status, number of replicas must be equal to number of succeeded Jobs.
+		if dependsOnJob.Status == jobset.DependencyComplete && rJobReplicas[dependsOnJob.Name] != actualStatus.Succeeded {
+			return false
+		}
+
+		// For Ready status, number of replicas must be equal to sum of ready, failed, and succeeded Jobs.
+		if dependsOnJob.Status == jobset.DependencyReady && rJobReplicas[dependsOnJob.Name] != actualStatus.Failed+actualStatus.Ready+actualStatus.Succeeded {
+			return false
+		}
 	}
 
-	// For Complete status, number of replicas must be equal to number of succeeded Jobs.
-	if dependsOnJob.Status == jobset.DependencyComplete && rJobReplicas[dependsOnJob.Name] == actualStatus.Succeeded {
-		return true
-	}
-
-	// For Ready status, number of replicas must be equal to sum of ready, failed, and succeeded Jobs.
-	if dependsOnJob.Status == jobset.DependencyReady && rJobReplicas[dependsOnJob.Name] == actualStatus.Failed+actualStatus.Ready+actualStatus.Succeeded {
-		return true
-	}
-
-	return false
+	return true
 }

--- a/pkg/controllers/depends_on_test.go
+++ b/pkg/controllers/depends_on_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 func TestDependencyReachedStatus(t *testing.T) {
-	rJobInitializer := "initializer"
+	rJobModelInitializer := "model-initializer"
+	rJobDatasetInitializer := "dataset-initializer"
 	rJobTrainer := "trainer-node"
 
 	tests := []struct {
@@ -22,10 +23,10 @@ func TestDependencyReachedStatus(t *testing.T) {
 	}{
 		{
 			name: "ReplicatedJob doesn't have any dependencies",
-			rJob: testutils.MakeReplicatedJob(rJobInitializer).
+			rJob: testutils.MakeReplicatedJob(rJobModelInitializer).
 				Obj(),
 			rJobReplicas: map[string]int32{
-				rJobInitializer: 1,
+				rJobModelInitializer: 1,
 			},
 			rJobsStatuses: []jobset.ReplicatedJobStatus{},
 			expected:      true,
@@ -36,15 +37,15 @@ func TestDependencyReachedStatus(t *testing.T) {
 				DependsOn(
 					[]jobset.DependsOn{
 						{
-							Name:   rJobInitializer,
+							Name:   rJobModelInitializer,
 							Status: jobset.DependencyComplete,
 						},
 					},
 				).
 				Obj(),
 			rJobReplicas: map[string]int32{
-				rJobInitializer: 1,
-				rJobTrainer:     1,
+				rJobModelInitializer: 1,
+				rJobTrainer:          1,
 			},
 			rJobsStatuses: []jobset.ReplicatedJobStatus{
 				{
@@ -64,19 +65,32 @@ func TestDependencyReachedStatus(t *testing.T) {
 				DependsOn(
 					[]jobset.DependsOn{
 						{
-							Name:   rJobInitializer,
+							Name:   rJobModelInitializer,
+							Status: jobset.DependencyComplete,
+						},
+						{
+							Name:   rJobDatasetInitializer,
 							Status: jobset.DependencyComplete,
 						},
 					},
 				).
 				Obj(),
 			rJobReplicas: map[string]int32{
-				rJobInitializer: 2,
-				rJobTrainer:     1,
+				rJobModelInitializer:   2,
+				rJobDatasetInitializer: 2,
+				rJobTrainer:            1,
 			},
 			rJobsStatuses: []jobset.ReplicatedJobStatus{
 				{
-					Name:      rJobInitializer,
+					Name:      rJobModelInitializer,
+					Ready:     0,
+					Succeeded: 2,
+					Failed:    0,
+					Suspended: 0,
+					Active:    0,
+				},
+				{
+					Name:      rJobDatasetInitializer,
 					Ready:     0,
 					Succeeded: 2,
 					Failed:    0,
@@ -87,24 +101,78 @@ func TestDependencyReachedStatus(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "depends on ReplicatedJob doesn't reach complete status",
+			name: "one depends on ReplicatedJob doesn't reach complete status",
 			rJob: testutils.MakeReplicatedJob(rJobTrainer).
 				DependsOn(
 					[]jobset.DependsOn{
 						{
-							Name:   rJobInitializer,
+							Name:   rJobModelInitializer,
+							Status: jobset.DependencyComplete,
+						},
+						{
+							Name:   rJobDatasetInitializer,
 							Status: jobset.DependencyComplete,
 						},
 					},
 				).
 				Obj(),
 			rJobReplicas: map[string]int32{
-				rJobInitializer: 2,
-				rJobTrainer:     1,
+				rJobModelInitializer:   2,
+				rJobDatasetInitializer: 2,
+				rJobTrainer:            1,
 			},
 			rJobsStatuses: []jobset.ReplicatedJobStatus{
 				{
-					Name:      rJobInitializer,
+					Name:      rJobModelInitializer,
+					Ready:     1,
+					Succeeded: 1,
+					Failed:    0,
+					Suspended: 0,
+					Active:    0,
+				},
+				{
+					Name:      rJobDatasetInitializer,
+					Ready:     0,
+					Succeeded: 2,
+					Failed:    0,
+					Suspended: 0,
+					Active:    0,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "two depends on ReplicatedJob doesn't reach complete status",
+			rJob: testutils.MakeReplicatedJob(rJobTrainer).
+				DependsOn(
+					[]jobset.DependsOn{
+						{
+							Name:   rJobModelInitializer,
+							Status: jobset.DependencyComplete,
+						},
+						{
+							Name:   rJobDatasetInitializer,
+							Status: jobset.DependencyComplete,
+						},
+					},
+				).
+				Obj(),
+			rJobReplicas: map[string]int32{
+				rJobModelInitializer:   2,
+				rJobDatasetInitializer: 2,
+				rJobTrainer:            1,
+			},
+			rJobsStatuses: []jobset.ReplicatedJobStatus{
+				{
+					Name:      rJobModelInitializer,
+					Ready:     1,
+					Succeeded: 1,
+					Failed:    0,
+					Suspended: 0,
+					Active:    0,
+				},
+				{
+					Name:      rJobDatasetInitializer,
 					Ready:     1,
 					Succeeded: 1,
 					Failed:    0,
@@ -120,19 +188,32 @@ func TestDependencyReachedStatus(t *testing.T) {
 				DependsOn(
 					[]jobset.DependsOn{
 						{
-							Name:   rJobInitializer,
+							Name:   rJobModelInitializer,
+							Status: jobset.DependencyReady,
+						},
+						{
+							Name:   rJobDatasetInitializer,
 							Status: jobset.DependencyReady,
 						},
 					},
 				).
 				Obj(),
 			rJobReplicas: map[string]int32{
-				rJobInitializer: 3,
-				rJobTrainer:     1,
+				rJobModelInitializer:   3,
+				rJobDatasetInitializer: 3,
+				rJobTrainer:            1,
 			},
 			rJobsStatuses: []jobset.ReplicatedJobStatus{
 				{
-					Name:      rJobInitializer,
+					Name:      rJobModelInitializer,
+					Ready:     1,
+					Succeeded: 1,
+					Failed:    1,
+					Suspended: 0,
+					Active:    0,
+				},
+				{
+					Name:      rJobDatasetInitializer,
 					Ready:     1,
 					Succeeded: 1,
 					Failed:    1,
@@ -143,24 +224,78 @@ func TestDependencyReachedStatus(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "depends on ReplicatedJob doesn't reach ready status",
+			name: "one depends on ReplicatedJob doesn't reach ready status",
 			rJob: testutils.MakeReplicatedJob(rJobTrainer).
 				DependsOn(
 					[]jobset.DependsOn{
 						{
-							Name:   rJobInitializer,
+							Name:   rJobModelInitializer,
+							Status: jobset.DependencyReady,
+						},
+						{
+							Name:   rJobDatasetInitializer,
 							Status: jobset.DependencyReady,
 						},
 					},
 				).
 				Obj(),
 			rJobReplicas: map[string]int32{
-				rJobInitializer: 3,
-				rJobTrainer:     1,
+				rJobModelInitializer:   3,
+				rJobDatasetInitializer: 3,
+				rJobTrainer:            1,
 			},
 			rJobsStatuses: []jobset.ReplicatedJobStatus{
 				{
-					Name:      rJobInitializer,
+					Name:      rJobModelInitializer,
+					Ready:     2,
+					Succeeded: 0,
+					Failed:    0,
+					Suspended: 0,
+					Active:    1,
+				},
+				{
+					Name:      rJobDatasetInitializer,
+					Ready:     1,
+					Succeeded: 1,
+					Failed:    1,
+					Suspended: 0,
+					Active:    0,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "two depends on ReplicatedJobs doesn't reach ready status",
+			rJob: testutils.MakeReplicatedJob(rJobTrainer).
+				DependsOn(
+					[]jobset.DependsOn{
+						{
+							Name:   rJobModelInitializer,
+							Status: jobset.DependencyReady,
+						},
+						{
+							Name:   rJobDatasetInitializer,
+							Status: jobset.DependencyReady,
+						},
+					},
+				).
+				Obj(),
+			rJobReplicas: map[string]int32{
+				rJobModelInitializer:   3,
+				rJobDatasetInitializer: 3,
+				rJobTrainer:            1,
+			},
+			rJobsStatuses: []jobset.ReplicatedJobStatus{
+				{
+					Name:      rJobModelInitializer,
+					Ready:     2,
+					Succeeded: 0,
+					Failed:    0,
+					Suspended: 0,
+					Active:    1,
+				},
+				{
+					Name:      rJobDatasetInitializer,
 					Ready:     2,
 					Succeeded: 0,
 					Failed:    0,

--- a/pkg/controllers/depends_on_test.go
+++ b/pkg/controllers/depends_on_test.go
@@ -60,6 +60,25 @@ func TestDependencyReachedStatus(t *testing.T) {
 			expected: false,
 		},
 		{
+			name: "rJobStatuses is nil",
+			rJob: testutils.MakeReplicatedJob(rJobTrainer).
+				DependsOn(
+					[]jobset.DependsOn{
+						{
+							Name:   rJobModelInitializer,
+							Status: jobset.DependencyComplete,
+						},
+					},
+				).
+				Obj(),
+			rJobReplicas: map[string]int32{
+				rJobModelInitializer: 1,
+				rJobTrainer:          1,
+			},
+			rJobsStatuses: nil,
+			expected:      false,
+		},
+		{
 			name: "depends on ReplicatedJob reaches complete status",
 			rJob: testutils.MakeReplicatedJob(rJobTrainer).
 				DependsOn(

--- a/pkg/webhooks/jobset_webhook.go
+++ b/pkg/webhooks/jobset_webhook.go
@@ -242,8 +242,13 @@ func (j *jobSetWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) 
 			}
 		}
 		// Check that DependsOn references the previous ReplicatedJob.
-		if rJob.DependsOn != nil && !rJobNames.Has(rJob.DependsOn[0].Name) {
-			allErrs = append(allErrs, fmt.Errorf("replicatedJob: %s cannot depend on replicatedJob: %s", rJob.Name, rJob.DependsOn[0].Name))
+		if rJob.DependsOn != nil {
+			for _, dependOnItem := range rJob.DependsOn {
+				_, ok := replicatedJobNames[dependOnItem.Name]
+				if !ok {
+					allErrs = append(allErrs, fmt.Errorf("replicatedJob: %s cannot depend on replicatedJob: %s", rJob.Name, dependOnItem.Name))
+				}
+			}
 		}
 	}
 

--- a/pkg/webhooks/jobset_webhook.go
+++ b/pkg/webhooks/jobset_webhook.go
@@ -243,11 +243,9 @@ func (j *jobSetWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) 
 		}
 
 		// Check that DependsOn references the previous ReplicatedJob.
-		if rJob.DependsOn != nil {
-			for _, dependOnItem := range rJob.DependsOn {
-				if !rJobNames.Has(dependOnItem.Name) {
-					allErrs = append(allErrs, fmt.Errorf("replicatedJob: %s cannot depend on replicatedJob: %s", rJob.Name, dependOnItem.Name))
-				}
+		for _, dependOnItem := range rJob.DependsOn {
+			if !rJobNames.Has(dependOnItem.Name) {
+				allErrs = append(allErrs, fmt.Errorf("replicatedJob: %s cannot depend on replicatedJob: %s", rJob.Name, dependOnItem.Name))
 			}
 		}
 	}

--- a/pkg/webhooks/jobset_webhook.go
+++ b/pkg/webhooks/jobset_webhook.go
@@ -241,11 +241,11 @@ func (j *jobSetWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) 
 				allErrs = append(allErrs, field.Invalid(fieldPath.Child("name"), longestJobName, errMessage))
 			}
 		}
+
 		// Check that DependsOn references the previous ReplicatedJob.
 		if rJob.DependsOn != nil {
 			for _, dependOnItem := range rJob.DependsOn {
-				_, ok := replicatedJobNames[dependOnItem.Name]
-				if !ok {
+				if !rJobNames.Has(dependOnItem.Name) {
 					allErrs = append(allErrs, fmt.Errorf("replicatedJob: %s cannot depend on replicatedJob: %s", rJob.Name, dependOnItem.Name))
 				}
 			}

--- a/pkg/webhooks/jobset_webhook_test.go
+++ b/pkg/webhooks/jobset_webhook_test.go
@@ -1759,6 +1759,64 @@ func TestValidateCreate(t *testing.T) {
 			want: errors.Join(fmt.Errorf("replicatedJob: job-2 cannot depend on replicatedJob: job-3")),
 		},
 		{
+			name: "DependsOn is invalid since job-2 depends on job-3 and job-1",
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					SuccessPolicy: &jobset.SuccessPolicy{},
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:      "job-1",
+							GroupName: "default",
+							Replicas:  1,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Template: validPodTemplateSpec,
+								},
+							},
+						},
+						{
+							Name: "job-2",
+							DependsOn: []jobset.DependsOn{
+								{
+									Name:   "job-1",
+									Status: "Complete",
+								},
+								{
+									Name:   "job-3",
+									Status: "Complete",
+								},
+							},
+							GroupName: "default",
+							Replicas:  1,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Template: validPodTemplateSpec,
+								},
+							},
+						},
+						{
+							Name: "job-3",
+							DependsOn: []jobset.DependsOn{
+								{
+									Name:   "job-1",
+									Status: "Complete",
+								},
+							},
+							GroupName: "default",
+							Replicas:  1,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Template: validPodTemplateSpec,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: errors.Join(fmt.Errorf("replicatedJob: job-2 cannot depend on replicatedJob: job-3")),
+		},
+		{
 			name: "job-2 depends on invalid ReplicatedJob",
 			js: &jobset.JobSet{
 				ObjectMeta: validObjectMeta,

--- a/pkg/webhooks/jobset_webhook_test.go
+++ b/pkg/webhooks/jobset_webhook_test.go
@@ -1653,6 +1653,58 @@ func TestValidateCreate(t *testing.T) {
 			want: errors.Join(),
 		},
 		{
+			name: "DependsOn is valid since job-3 depends on job-1 and job-2",
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					SuccessPolicy: &jobset.SuccessPolicy{},
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:      "job-1",
+							GroupName: "default",
+							Replicas:  1,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Template: validPodTemplateSpec,
+								},
+							},
+						},
+						{
+							Name:      "job-2",
+							GroupName: "default",
+							Replicas:  1,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Template: validPodTemplateSpec,
+								},
+							},
+						},
+						{
+							Name: "job-3",
+							DependsOn: []jobset.DependsOn{
+								{
+									Name:   "job-1",
+									Status: "Complete",
+								},
+								{
+									Name:   "job-2",
+									Status: "Complete",
+								},
+							},
+							GroupName: "default",
+							Replicas:  1,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Template: validPodTemplateSpec,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: errors.Join(),
+		},
+		{
 			name: "DependsOn is invalid since job-2 depends on job-3",
 			js: &jobset.JobSet{
 				ObjectMeta: validObjectMeta,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -330,7 +330,7 @@ var _ = ginkgo.Describe("JobSet", func() {
 			// Otherwise, it will cause this check to fail.
 			ginkgo.By("Verify that only Initializer is created", func() {
 				gomega.Eventually(util.NumJobs, timeout, interval).WithArguments(ctx, k8sClient, jobSet).
-					Should(gomega.Equal(numReplicas))
+					Should(gomega.Equal(numReplicas * 2))
 			})
 
 			ginkgo.By("Wait for Initializer to be in Completed status", func() {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -273,36 +273,51 @@ var _ = ginkgo.Describe("JobSet", func() {
 	// This test runs JobSet with the DependsOn API.
 	ginkgo.When("DependsOn is enabled on JobSet", func() {
 		// This test shows that when a JobSet is used with the Kubeflow Trainer LLM Runtime.
-		// The initializer Job should be completed before trainer node Job is started.
+		// The model-initializer and dataset-intializer Job should be completed before trainer node Job is started.
 		ginkgo.It("trainer-node Job depends on initializer Job completion", func() {
 			ctx := context.Background()
 
 			numReplicas := 1
-			initializerJob := "initializer"
+			modelInitializerJob := "model-initializer"
+			datasetInitializerJob := "dataset-initializer"
 			trainerJob := "trainer-node"
 
 			// Every ReplicatedJob runs 1 container to sleep for 10 seconds.
-			rJobInitializer := dependsOnTestReplicatedJob(ns, initializerJob, numReplicas, nil, nil)
+			rJobModelInitializer := dependsOnTestReplicatedJob(ns, modelInitializerJob, numReplicas, nil, nil)
+			rJobDatasetInitializer := dependsOnTestReplicatedJob(ns, datasetInitializerJob, numReplicas, nil, nil)
 			rJobTrainer := dependsOnTestReplicatedJob(ns, trainerJob, numReplicas, nil,
 				[]jobset.DependsOn{
 					{
-						Name:   initializerJob,
+						Name:   modelInitializerJob,
+						Status: jobset.DependencyComplete,
+					},
+					{
+						Name:   datasetInitializerJob,
 						Status: jobset.DependencyComplete,
 					},
 				})
 
-			jobSet := dependsOnTestJobSet(ns, []jobset.ReplicatedJob{rJobInitializer, rJobTrainer})
+			jobSet := dependsOnTestJobSet(ns, []jobset.ReplicatedJob{rJobModelInitializer, rJobDatasetInitializer, rJobTrainer})
 			jobSetKey := types.NamespacedName{Name: jobSet.Name, Namespace: jobSet.Namespace}
 
 			ginkgo.By("Create a JobSet with DependsOn", func() {
 				gomega.Expect(k8sClient.Create(ctx, jobSet)).Should(gomega.Succeed())
 			})
 
-			ginkgo.By("Wait for Initializer to be in Ready status", func() {
+			ginkgo.By("Wait for Model Initializer and Dataset Initializer to be in Ready status", func() {
 				gomega.Eventually(func() int32 {
 					gomega.Expect(k8sClient.Get(ctx, jobSetKey, jobSet)).Should(gomega.Succeed())
 					for _, rJobStatus := range jobSet.Status.ReplicatedJobsStatus {
-						if rJobStatus.Name == initializerJob {
+						if rJobStatus.Name == modelInitializerJob {
+							return rJobStatus.Ready
+						}
+					}
+					return 0
+				}, timeout, interval).Should(gomega.Equal(int32(numReplicas)))
+				gomega.Eventually(func() int32 {
+					gomega.Expect(k8sClient.Get(ctx, jobSetKey, jobSet)).Should(gomega.Succeed())
+					for _, rJobStatus := range jobSet.Status.ReplicatedJobsStatus {
+						if rJobStatus.Name == datasetInitializerJob {
 							return rJobStatus.Ready
 						}
 					}
@@ -323,7 +338,16 @@ var _ = ginkgo.Describe("JobSet", func() {
 				gomega.Eventually(func() int32 {
 					gomega.Expect(k8sClient.Get(ctx, jobSetKey, jobSet)).Should(gomega.Succeed())
 					for _, rJobStatus := range jobSet.Status.ReplicatedJobsStatus {
-						if rJobStatus.Name == initializerJob {
+						if rJobStatus.Name == modelInitializerJob {
+							return rJobStatus.Succeeded
+						}
+					}
+					return 0
+				}, timeout, interval).Should(gomega.Equal(int32(numReplicas)))
+				gomega.Eventually(func() int32 {
+					gomega.Expect(k8sClient.Get(ctx, jobSetKey, jobSet)).Should(gomega.Succeed())
+					for _, rJobStatus := range jobSet.Status.ReplicatedJobsStatus {
+						if rJobStatus.Name == datasetInitializerJob {
 							return rJobStatus.Succeeded
 						}
 					}
@@ -331,7 +355,7 @@ var _ = ginkgo.Describe("JobSet", func() {
 				}, timeout, interval).Should(gomega.Equal(int32(numReplicas)))
 			})
 
-			ginkgo.By("Verify that Initializer and Trainer Job is created", func() {
+			ginkgo.By("Verify that Model Initializer, Dataset Initializer, and Trainer Job is created", func() {
 				gomega.Eventually(util.NumJobs, timeout, interval).WithArguments(ctx, k8sClient, jobSet).
 					Should(gomega.Equal(util.NumExpectedJobs(jobSet)))
 			})

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -384,7 +384,7 @@ var _ = ginkgo.Describe("JobSet", func() {
 					InitialDelaySeconds: 5,
 				},
 				nil)
-			
+
 			rJobTrainer := dependsOnTestReplicatedJob(ns, trainerJob, numReplicas, nil,
 				[]jobset.DependsOn{
 					{

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -328,12 +328,12 @@ var _ = ginkgo.Describe("JobSet", func() {
 			// We need to ensure that the E2E test reaches this check within 10 seconds of
 			// the JobSet being created, as the Initializer has a 10-second sleep timer.
 			// Otherwise, it will cause this check to fail.
-			ginkgo.By("Verify that only Initializer is created", func() {
+			ginkgo.By("Verify that only Model Initializer and Dataset Initializer are created", func() {
 				gomega.Eventually(util.NumJobs, timeout, interval).WithArguments(ctx, k8sClient, jobSet).
 					Should(gomega.Equal(numReplicas * 2))
 			})
 
-			ginkgo.By("Wait for Initializer to be in Completed status", func() {
+			ginkgo.By("Wait for Model Initializer and Dataset Initializer to be in Completed status", func() {
 				gomega.Expect(k8sClient.Get(ctx, jobSetKey, jobSet)).Should(gomega.Succeed())
 				gomega.Eventually(func() int32 {
 					gomega.Expect(k8sClient.Get(ctx, jobSetKey, jobSet)).Should(gomega.Succeed())
@@ -356,6 +356,61 @@ var _ = ginkgo.Describe("JobSet", func() {
 			})
 
 			ginkgo.By("Verify that Model Initializer, Dataset Initializer, and Trainer Job is created", func() {
+				gomega.Eventually(util.NumJobs, timeout, interval).WithArguments(ctx, k8sClient, jobSet).
+					Should(gomega.Equal(util.NumExpectedJobs(jobSet)))
+			})
+
+			ginkgo.By("Wait for JobSet to be Completed", func() {
+				util.JobSetCompleted(ctx, k8sClient, jobSet, timeout)
+			})
+		})
+		// This test shows that when a JobSet is used for the Kubeflow Trainer with coordinator.
+		// The coordinator Job should be ready before trainer node Job is started.
+		ginkgo.It("trainer-node Job depends on coordinator Job ready status", func() {
+			ctx := context.Background()
+
+			numReplicas := 1
+			coordinatorJob := "coordinator"
+			trainerJob := "trainer-node"
+
+			// Every ReplicatedJob runs 1 container to sleep for 10 seconds.
+			rJobCoordinator := dependsOnTestReplicatedJob(ns, coordinatorJob, numReplicas, nil, nil)
+			rJobTrainer := dependsOnTestReplicatedJob(ns, trainerJob, numReplicas, nil,
+				[]jobset.DependsOn{
+					{
+						Name:   coordinatorJob,
+						Status: jobset.DependencyReady,
+					},
+				})
+
+			jobSet := dependsOnTestJobSet(ns, []jobset.ReplicatedJob{rJobCoordinator, rJobTrainer})
+			jobSetKey := types.NamespacedName{Name: jobSet.Name, Namespace: jobSet.Namespace}
+
+			ginkgo.By("Create a JobSet with DependsOn", func() {
+				gomega.Expect(k8sClient.Create(ctx, jobSet)).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Wait for Coordinator Job to be in Ready status", func() {
+				gomega.Eventually(func() int32 {
+					gomega.Expect(k8sClient.Get(ctx, jobSetKey, jobSet)).Should(gomega.Succeed())
+					for _, rJobStatus := range jobSet.Status.ReplicatedJobsStatus {
+						if rJobStatus.Name == coordinatorJob {
+							return rJobStatus.Ready
+						}
+					}
+					return 0
+				}, timeout, interval).Should(gomega.Equal(int32(numReplicas)))
+			})
+
+			// We need to ensure that the E2E test reaches this check within 10 seconds of
+			// the JobSet being created, as the Initializer has a 10-second sleep timer.
+			// Otherwise, it will cause this check to fail.
+			ginkgo.By("Verify that only Coordinator is created", func() {
+				gomega.Eventually(util.NumJobs, timeout, interval).WithArguments(ctx, k8sClient, jobSet).
+					Should(gomega.Equal(numReplicas))
+			})
+
+			ginkgo.By("Verify that Coordinator Job and Trainer Job is created", func() {
 				gomega.Eventually(util.NumJobs, timeout, interval).WithArguments(ctx, k8sClient, jobSet).
 					Should(gomega.Equal(util.NumExpectedJobs(jobSet)))
 			})

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -274,7 +274,7 @@ var _ = ginkgo.Describe("JobSet", func() {
 	ginkgo.When("DependsOn is enabled on JobSet", func() {
 		// This test shows that when a JobSet is used with the Kubeflow Trainer LLM Runtime.
 		// The model-initializer and dataset-intializer Job should be completed before trainer node Job is started.
-		ginkgo.It("trainer-node Job depends on initializer Job completion", func() {
+		ginkgo.It("trainer-node Job depends on dataset initializer and model initializer Jobs completion", func() {
 			ctx := context.Background()
 
 			numReplicas := 1

--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -2040,8 +2040,9 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 								Succeeded: 1,
 							},
 							{
-								Name:  "rjob-a",
-								Ready: 1,
+								Name:   "rjob-a",
+								Ready:  1,
+								Active: 1,
 							},
 						})
 					},
@@ -2063,8 +2064,9 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 								Succeeded: 1,
 							},
 							{
-								Name:  "rjob-a",
-								Ready: 1,
+								Name:   "rjob-a",
+								Ready:  1,
+								Active: 1,
 							},
 						})
 					},

--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -1883,6 +1883,111 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 				},
 			},
 		}),
+		ginkgo.Entry("DependsOn: rjob-c depends on complete status of rjob-a and rjob-b", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("depends-on", ns.Name).
+					SuccessPolicy(&jobset.SuccessPolicy{Operator: jobset.OperatorAll, TargetReplicatedJobs: []string{}}).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob-a").
+						Job(testing.MakeJobTemplate("job", ns.Name).PodSpec(testing.TestPodSpec).Obj()).
+						Replicas(1).
+						Obj()).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob-b").
+						Job(testing.MakeJobTemplate("job", ns.Name).PodSpec(testing.TestPodSpec).Obj()).
+						Replicas(1).
+						Obj()).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob-c").
+						Job(testing.MakeJobTemplate("job", ns.Name).PodSpec(testing.TestPodSpec).Obj()).
+						Replicas(3).
+						DependsOn([]jobset.DependsOn{
+							{
+								Name:   "rjob-a",
+								Status: jobset.DependencyComplete,
+							},
+							{
+								Name:   "rjob-b",
+								Status: jobset.DependencyComplete,
+							},
+						}).
+						Obj())
+			},
+			skipCreationCheck: true,
+			steps: []*step{
+				{
+					// First check.
+					// Replicated-Job-A and Replicated-Job-B must be created.
+					checkJobCreation: func(js *jobset.JobSet) {
+						expectedStarts := 2
+						gomega.Eventually(testutil.NumJobs, timeout, interval).WithArguments(ctx, k8sClient, js).Should(gomega.Equal(expectedStarts))
+					},
+					// Set the Replicated-Job-A and Replicated-Job-B status to complete.
+					// Replicated-Job-C depends on complete status of Replicated-Job-A and Replicated-Job-B
+					jobUpdateFn: func(jobList *batchv1.JobList) {
+						completeJob(&jobList.Items[0])
+						completeJob(&jobList.Items[1])
+					},
+					checkJobSetState: func(js *jobset.JobSet) {
+						matchJobSetReplicatedStatus(js, []jobset.ReplicatedJobStatus{
+							{
+								Name: "rjob-c",
+							},
+							{
+								Name:      "rjob-a",
+								Succeeded: 1,
+							},
+							{
+								Name:      "rjob-b",
+								Succeeded: 1,
+							},
+						})
+					},
+				},
+				{
+					// Second check.
+					// Replicated-Job-A, Replicated-Job-B, and Replicated-Job-C must be created.
+					checkJobCreation: func(js *jobset.JobSet) {
+						expectedStarts := 5
+						gomega.Eventually(testutil.NumJobs, timeout, interval).WithArguments(ctx, k8sClient, js).Should(gomega.Equal(expectedStarts))
+					},
+					checkJobSetState: func(js *jobset.JobSet) {
+						matchJobSetReplicatedStatus(js, []jobset.ReplicatedJobStatus{
+							{
+								Name: "rjob-c",
+							},
+							{
+								Name:      "rjob-a",
+								Succeeded: 1,
+							},
+							{
+								Name:      "rjob-b",
+								Succeeded: 1,
+							},
+						})
+					},
+				},
+				{
+					// Final check.
+					// Complete all Jobs.
+					jobUpdateFn: completeAllJobs,
+					// All Jobs must be in the succeeded status.
+					checkJobSetState: func(js *jobset.JobSet) {
+						matchJobSetReplicatedStatus(js, []jobset.ReplicatedJobStatus{
+							{
+								Name:      "rjob-c",
+								Succeeded: 3,
+							},
+							{
+								Name:      "rjob-b",
+								Succeeded: 1,
+							},
+							{
+								Name:      "rjob-a",
+								Succeeded: 1,
+							},
+						})
+					},
+				},
+			},
+		}),
 		ginkgo.Entry("DependsOn: resume suspended JobSet when rjob-b depends on ready status of rjob-a", &testCase{
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
 				return testing.MakeJobSet("depends-on", ns.Name).

--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -1988,6 +1988,111 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 				},
 			},
 		}),
+		ginkgo.Entry("DependsOn: rjob-c depends on ready status of rjob-a and complete status of rjob-b", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("depends-on", ns.Name).
+					SuccessPolicy(&jobset.SuccessPolicy{Operator: jobset.OperatorAll, TargetReplicatedJobs: []string{}}).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob-a").
+						Job(testing.MakeJobTemplate("job", ns.Name).PodSpec(testing.TestPodSpec).Obj()).
+						Replicas(1).
+						Obj()).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob-b").
+						Job(testing.MakeJobTemplate("job", ns.Name).PodSpec(testing.TestPodSpec).Obj()).
+						Replicas(1).
+						Obj()).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob-c").
+						Job(testing.MakeJobTemplate("job", ns.Name).PodSpec(testing.TestPodSpec).Obj()).
+						Replicas(3).
+						DependsOn([]jobset.DependsOn{
+							{
+								Name:   "rjob-a",
+								Status: jobset.DependencyReady,
+							},
+							{
+								Name:   "rjob-b",
+								Status: jobset.DependencyComplete,
+							},
+						}).
+						Obj())
+			},
+			skipCreationCheck: true,
+			steps: []*step{
+				{
+					// First check.
+					// Replicated-Job-A and Replicated-Job-B must be created.
+					checkJobCreation: func(js *jobset.JobSet) {
+						expectedStarts := 2
+						gomega.Eventually(testutil.NumJobs, timeout, interval).WithArguments(ctx, k8sClient, js).Should(gomega.Equal(expectedStarts))
+					},
+					// Set the Replicated-Job-A status to ready and Replicated-Job-B status to complete.
+					// Replicated-Job-C depends on ready status of Replicated-Job-A and complete status of Replicated-Job-B
+					jobUpdateFn: func(jobList *batchv1.JobList) {
+						readyReplicatedJob(jobList, "rjob-a")
+						completeJob(&jobList.Items[1])
+					},
+					checkJobSetState: func(js *jobset.JobSet) {
+						matchJobSetReplicatedStatus(js, []jobset.ReplicatedJobStatus{
+							{
+								Name: "rjob-c",
+							},
+							{
+								Name:      "rjob-b",
+								Succeeded: 1,
+							},
+							{
+								Name:  "rjob-a",
+								Ready: 1,
+							},
+						})
+					},
+				},
+				{
+					// Second check.
+					// Replicated-Job-A, Replicated-Job-B, and Replicated-Job-C must be created.
+					checkJobCreation: func(js *jobset.JobSet) {
+						expectedStarts := 5
+						gomega.Eventually(testutil.NumJobs, timeout, interval).WithArguments(ctx, k8sClient, js).Should(gomega.Equal(expectedStarts))
+					},
+					checkJobSetState: func(js *jobset.JobSet) {
+						matchJobSetReplicatedStatus(js, []jobset.ReplicatedJobStatus{
+							{
+								Name: "rjob-c",
+							},
+							{
+								Name:      "rjob-b",
+								Succeeded: 1,
+							},
+							{
+								Name:  "rjob-a",
+								Ready: 1,
+							},
+						})
+					},
+				},
+				{
+					// Final check.
+					// Complete all Jobs.
+					jobUpdateFn: completeAllJobs,
+					// All Jobs must be in the succeeded status.
+					checkJobSetState: func(js *jobset.JobSet) {
+						matchJobSetReplicatedStatus(js, []jobset.ReplicatedJobStatus{
+							{
+								Name:      "rjob-c",
+								Succeeded: 3,
+							},
+							{
+								Name:      "rjob-b",
+								Succeeded: 1,
+							},
+							{
+								Name:      "rjob-a",
+								Succeeded: 1,
+							},
+						})
+					},
+				},
+			},
+		}),
 		ginkgo.Entry("DependsOn: resume suspended JobSet when rjob-b depends on ready status of rjob-a", &testCase{
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
 				return testing.MakeJobSet("depends-on", ns.Name).

--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -1931,11 +1931,11 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 								Name: "rjob-c",
 							},
 							{
-								Name:      "rjob-a",
+								Name:      "rjob-b",
 								Succeeded: 1,
 							},
 							{
-								Name:      "rjob-b",
+								Name:      "rjob-a",
 								Succeeded: 1,
 							},
 						})
@@ -1954,11 +1954,11 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 								Name: "rjob-c",
 							},
 							{
-								Name:      "rjob-a",
+								Name:      "rjob-b",
 								Succeeded: 1,
 							},
 							{
-								Name:      "rjob-b",
+								Name:      "rjob-a",
 								Succeeded: 1,
 							},
 						})

--- a/test/integration/webhook/jobset_webhook_test.go
+++ b/test/integration/webhook/jobset_webhook_test.go
@@ -484,37 +484,6 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 			},
 			jobSetCreationShouldFail: true,
 		}),
-		ginkgo.Entry("DependsOn list can't contain more than one element", &testCase{
-			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
-				return testing.MakeJobSet("depends-on", ns.Name).
-					ReplicatedJob(testing.MakeReplicatedJob("rjob-1").
-						Job(testing.MakeJobTemplate("job", ns.Name).
-							PodSpec(testing.TestPodSpec).
-							Obj()).
-						Obj()).
-					ReplicatedJob(testing.MakeReplicatedJob("rjob-2").
-						Job(testing.MakeJobTemplate("job", ns.Name).
-							PodSpec(testing.TestPodSpec).
-							Obj()).
-						Obj()).
-					ReplicatedJob(testing.MakeReplicatedJob("rjob-3").
-						Job(testing.MakeJobTemplate("job", ns.Name).
-							PodSpec(testing.TestPodSpec).
-							Obj()).
-						DependsOn([]jobset.DependsOn{
-							{
-								Name:   "rjob-1",
-								Status: jobset.DependencyComplete,
-							},
-							{
-								Name:   "rjob-2",
-								Status: jobset.DependencyComplete,
-							},
-						}).
-						Obj())
-			},
-			jobSetCreationShouldFail: true,
-		}),
 		ginkgo.Entry("DependsOn list must contain valid ReplicatedJob status", &testCase{
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
 				return testing.MakeJobSet("depends-on", ns.Name).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR adds the support for multiple items in DependsOn API, so that we can unblock the implementation of Kubeflow LLM Trainer V2.

/cc @andreyvelich @tenzen-y @kannon92 @ahg-g 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #874

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```