### PR TITLE
chore: Replace completionModePtr with ptr.To()

### DIFF
--- a/pkg/webhooks/jobset_webhook.go
+++ b/pkg/webhooks/jobset_webhook.go
@@ -121,7 +121,7 @@ func (j *jobSetWebhook) Default(ctx context.Context, obj runtime.Object) error {
 	for i := range js.Spec.ReplicatedJobs {
 		// Default job completion mode to indexed.
 		if js.Spec.ReplicatedJobs[i].Template.Spec.CompletionMode == nil {
-			js.Spec.ReplicatedJobs[i].Template.Spec.CompletionMode = completionModePtr(batchv1.IndexedCompletion)
+			js.Spec.ReplicatedJobs[i].Template.Spec.CompletionMode = ptr.To(batchv1.IndexedCompletion)
 		}
 		// Default pod restart policy to OnFailure.
 		if js.Spec.ReplicatedJobs[i].Template.Spec.Template.Spec.RestartPolicy == "" {
@@ -419,8 +419,4 @@ func replicatedJobNamesFromSpec(js *jobset.JobSet) []string {
 		names = append(names, rjob.Name)
 	}
 	return names
-}
-
-func completionModePtr(mode batchv1.CompletionMode) *batchv1.CompletionMode {
-	return &mode
 }

--- a/pkg/webhooks/jobset_webhook_test.go
+++ b/pkg/webhooks/jobset_webhook_test.go
@@ -77,7 +77,7 @@ func TestJobSetDefaulting(t *testing.T) {
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
 									Template:       TestPodTemplate,
-									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
 								},
 							},
 						},
@@ -97,7 +97,7 @@ func TestJobSetDefaulting(t *testing.T) {
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
 									Template:       TestPodTemplate,
-									CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
+									CompletionMode: ptr.To(batchv1.NonIndexedCompletion),
 								},
 							},
 						},
@@ -115,7 +115,7 @@ func TestJobSetDefaulting(t *testing.T) {
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
 									Template:       TestPodTemplate,
-									CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
+									CompletionMode: ptr.To(batchv1.NonIndexedCompletion),
 								},
 							},
 						},
@@ -138,7 +138,7 @@ func TestJobSetDefaulting(t *testing.T) {
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
 									Template:       TestPodTemplate,
-									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
 								},
 							},
 						},
@@ -156,7 +156,7 @@ func TestJobSetDefaulting(t *testing.T) {
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
 									Template:       TestPodTemplate,
-									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
 								},
 							},
 						},
@@ -177,7 +177,7 @@ func TestJobSetDefaulting(t *testing.T) {
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
 									Template:       TestPodTemplate,
-									CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
+									CompletionMode: ptr.To(batchv1.NonIndexedCompletion),
 								},
 							},
 						},
@@ -195,7 +195,7 @@ func TestJobSetDefaulting(t *testing.T) {
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
 									Template:       TestPodTemplate,
-									CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
+									CompletionMode: ptr.To(batchv1.NonIndexedCompletion),
 								},
 							},
 						},
@@ -219,7 +219,7 @@ func TestJobSetDefaulting(t *testing.T) {
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
 									Template:       TestPodTemplate,
-									CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
+									CompletionMode: ptr.To(batchv1.NonIndexedCompletion),
 								},
 							},
 						},
@@ -237,7 +237,7 @@ func TestJobSetDefaulting(t *testing.T) {
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
 									Template:       TestPodTemplate,
-									CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
+									CompletionMode: ptr.To(batchv1.NonIndexedCompletion),
 								},
 							},
 						},
@@ -258,7 +258,7 @@ func TestJobSetDefaulting(t *testing.T) {
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
 									Template:       TestPodTemplate,
-									CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
+									CompletionMode: ptr.To(batchv1.NonIndexedCompletion),
 								},
 							},
 						},
@@ -276,7 +276,7 @@ func TestJobSetDefaulting(t *testing.T) {
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
 									Template:       TestPodTemplate,
-									CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
+									CompletionMode: ptr.To(batchv1.NonIndexedCompletion),
 								},
 							},
 						},
@@ -302,7 +302,7 @@ func TestJobSetDefaulting(t *testing.T) {
 									Template: corev1.PodTemplateSpec{
 										Spec: corev1.PodSpec{},
 									},
-									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
 								},
 							},
 						},
@@ -324,7 +324,7 @@ func TestJobSetDefaulting(t *testing.T) {
 											RestartPolicy: corev1.RestartPolicyOnFailure,
 										},
 									},
-									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
 								},
 							},
 						},
@@ -349,7 +349,7 @@ func TestJobSetDefaulting(t *testing.T) {
 											RestartPolicy: corev1.RestartPolicyAlways,
 										},
 									},
-									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
 								},
 							},
 						},
@@ -371,7 +371,7 @@ func TestJobSetDefaulting(t *testing.T) {
 											RestartPolicy: corev1.RestartPolicyAlways,
 										},
 									},
-									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
 								},
 							},
 						},
@@ -398,7 +398,7 @@ func TestJobSetDefaulting(t *testing.T) {
 											RestartPolicy: corev1.RestartPolicyAlways,
 										},
 									},
-									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
 								},
 							},
 						},
@@ -420,7 +420,7 @@ func TestJobSetDefaulting(t *testing.T) {
 											RestartPolicy: corev1.RestartPolicyAlways,
 										},
 									},
-									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
 								},
 							},
 						},
@@ -447,7 +447,7 @@ func TestJobSetDefaulting(t *testing.T) {
 											RestartPolicy: corev1.RestartPolicyAlways,
 										},
 									},
-									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
 								},
 							},
 						},
@@ -471,7 +471,7 @@ func TestJobSetDefaulting(t *testing.T) {
 											RestartPolicy: corev1.RestartPolicyAlways,
 										},
 									},
-									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
 								},
 							},
 						},
@@ -503,7 +503,7 @@ func TestJobSetDefaulting(t *testing.T) {
 											RestartPolicy: corev1.RestartPolicyAlways,
 										},
 									},
-									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
 								},
 							},
 						},
@@ -529,7 +529,7 @@ func TestJobSetDefaulting(t *testing.T) {
 											RestartPolicy: corev1.RestartPolicyAlways,
 										},
 									},
-									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
 								},
 							},
 						},
@@ -552,7 +552,7 @@ func TestJobSetDefaulting(t *testing.T) {
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
 									Template:       TestPodTemplate,
-									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
 								},
 							},
 						},
@@ -569,7 +569,7 @@ func TestJobSetDefaulting(t *testing.T) {
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
 									Template:       TestPodTemplate,
-									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
 								},
 							},
 						},
@@ -588,7 +588,7 @@ func TestJobSetDefaulting(t *testing.T) {
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
 									Template:       TestPodTemplate,
-									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
 								},
 							},
 						},
@@ -606,7 +606,7 @@ func TestJobSetDefaulting(t *testing.T) {
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
 									Template:       TestPodTemplate,
-									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
 								},
 							},
 						},
@@ -629,7 +629,7 @@ func TestJobSetDefaulting(t *testing.T) {
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
 									Template:       TestPodTemplate,
-									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
 								},
 							},
 						},
@@ -649,7 +649,7 @@ func TestJobSetDefaulting(t *testing.T) {
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
 									Template:       TestPodTemplate,
-									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
 								},
 							},
 						},
@@ -673,7 +673,7 @@ func TestJobSetDefaulting(t *testing.T) {
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
 									Template:       TestPodTemplate,
-									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
 								},
 							},
 						},
@@ -696,7 +696,7 @@ func TestJobSetDefaulting(t *testing.T) {
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
 									Template:       TestPodTemplate,
-									CompletionMode: completionModePtr(batchv1.IndexedCompletion),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
 								},
 							},
 						},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Replace `completionModePtr()` with `ptr.To()` to reduce management codes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```