### PR TITLE
Update helm chart URL

### DIFF
--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -55,7 +55,7 @@ kubectl apply --server-side -f https://github.com/kubernetes-sigs/jobset/release
 To install a released version of JobSet in your cluster using Helm, run the following command:
 
 ```shell
-helm install jobset oci://registry.k8s.io/charts/jobset --version=$VERSION --create-namespace --namespace=jobset-system
+helm install jobset oci://registry.k8s.io/jobset/charts/jobset --version=$VERSION --create-namespace --namespace=jobset-system
 
 ```
 


### PR DESCRIPTION
/kind documentation

#### What this PR does / why we need it:

The provided instruction produces an error:
```
$ helm install jobset oci://registry.k8s.io/charts/jobset --version=v0.8.1 --create-namespace --namespace=jobset-system
Error: INSTALLATION FAILED: registry.k8s.io/charts/jobset:v0.8.1: not found
```

