### PR TITLE
Update failure policy KEP with proposed RecreateJob behavior

### DIFF
--- a/keps/262-ConfigurableFailurePolicy/README.md
+++ b/keps/262-ConfigurableFailurePolicy/README.md
@@ -278,11 +278,11 @@ spec:
                 python3 train.py
 ```
 
-#### Story 5: Recreating replicated jobs on failure rather than failing JobSet
+#### Story 5: Recreating individual jobs on failure rather than failing JobSet (`RecreateJob`)
 
-As a user, I have a JobSet with 2 replicated jobs: one which runs distributed training processes across a pool of GPU
-nodes, and one which runs the driver/coordinator on a CPU pool. If a child job of the GPU worker ReplicatedJob crashes, I just want to recreate the GPU workers and not the driver, then resume training from the latest checkpoint. However, if
-the driver crashes, I want to restart the entire JobSet, then resume training from the latest checkpoint.
+If it is possible for individual worker Jobs within a ReplicatedJob to be restarted independently on failure
+without requiring a full restart of their parent ReplicatedJob or the entire JobSet, the `RecreateJob`
+failure policy can be used.
 
 **Example Failure Policy configuration for this use case**:
 
@@ -290,20 +290,18 @@ the driver crashes, I want to restart the entire JobSet, then resume training fr
 apiVersion: jobset.x-k8s.io/v1alpha2
 kind: JobSet
 metadata:
-  name: recreate-replicated-job-example
-  annotations:
-    alpha.jobset.sigs.k8s.io/exclusive-topology: {{topologyDomain}} # 1:1 job replica to topology domain assignment
+  name: recreate-job-example
 spec:
-  # Failure Policy to restart the child jobs of the target ReplicatedJob (gpu-workers) if any fail, but fall
-  # back to the default behavior of restarting the entire JobSet if the driver fails.
+  # Failure Policy to restart individual jobs of the target ReplicatedJob (recoverable-workers) if they fail,
+  # without restarting the entire JobSet or other jobs in recoverable-workers.
   failurePolicy:
     rules:
-    - action: RecreateReplicatedJob
+    - action: RecreateJob
       targetReplicatedJobs:
-      - gpu-workers
+      - recoverable-workers
     maxRestarts: 10
   replicatedJobs:
-  - name: driver
+  - name: recoverable-workers
     replicas: 1
     template:
       spec:
@@ -317,24 +315,7 @@ spec:
             - name: main
               image: python:3.10
               command: ["..."]
-  - name: gpu-workers
-    replicas: 4 # number of node pools
-    template:
-      spec:
-        parallelism: 2
-        completions: 2
-        backoffLimit: 0
-        template:
-          spec:
-            containers:
-            - name: main
-              image: pytorch:latest
-              command: ["..."]
-            resources:
-              limits:
-                nvidia.com/gpu: 1
-```
-
+``
 
 ### Notes/Constraints/Caveats (Optional)
 
@@ -543,6 +524,10 @@ be available to use for some time.
 
 Additional actions we want to support in the future include:
 
-1) `FailJob`: To leave a particular child job in a failed state without restarting it or restarting the JobSet, the
+1) `RestartReplicatedJob`: To restart the child jobs of a specific replicated job, the controller will delete the child
+jobs of the target replicated job, **without incrementing the restart attempt annotation**. The jobs will then be 
+recreated via the normal reconciliation process.
+
+2) `FailJob`: To leave a particular child job in a failed state without restarting it or restarting the JobSet, the
 controller will simply do nothing, taking no action on this job.
 

--- a/keps/262-ConfigurableFailurePolicy/README.md
+++ b/keps/262-ConfigurableFailurePolicy/README.md
@@ -302,7 +302,7 @@ spec:
     maxRestarts: 10
   replicatedJobs:
   - name: recoverable-workers
-    replicas: 1
+    replicas: 2
     template:
       spec:
         parallelism: 1
@@ -363,17 +363,13 @@ const (
 
   // Recreate the failed Job without restarting the entire JobSet.
   RecreateJob FailurePolicyAction = "RecreateJob"
-
-  // Recreate all Jobs in a ReplicatedJob if any of them fail, without
-  // restarting the entire JobSet.
-  RecreateReplicatedJob FailurePolicyAction = "RecreateReplicatedJob"
 )
 
 // FailurePolicyRule defines a FailurePolicyAction to be executed if a child job
 // fails due to a reason listed in OnJobFailureReasons.
 type FailurePolicyRule struct {
   // The action to take if the rule is matched.
-  // +kubebuilder:validation:Enum:=FailJobSet;RestartJobSetAndIgnoreMaxRestarts;FailJob;RecreateJob;RecreateReplicatedJob
+  // +kubebuilder:validation:Enum:=FailJobSet;RestartJobSetAndIgnoreMaxRestarts;FailJob;RecreateJob
   Action FailurePolicyAction `json:"action"`
   // The requirement on the job failure reasons. The requirement
   // is satisfied if at least one reason matches the list.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind documentation
/kind api-change

#### What this PR does / why we need it:
KEP proposing addition of new RecreateJob and RecreateReplicatedJob failure policies, see #918 and #920 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #918

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```