### PR TITLE
fix: handle nil Completions in coordinator validation

### DIFF
--- a/pkg/webhooks/jobset_webhook.go
+++ b/pkg/webhooks/jobset_webhook.go
@@ -384,13 +384,13 @@ func validateCoordinator(js *jobset.JobSet) error {
 		return fmt.Errorf("coordinator job index %d is invalid for replicatedJob %s", js.Spec.Coordinator.JobIndex, replicatedJob.Name)
 	}
 
-	// Validate job is using indexed completion mode.
-	if replicatedJob.Template.Spec.CompletionMode == nil || *replicatedJob.Template.Spec.CompletionMode != batchv1.IndexedCompletion {
-		return fmt.Errorf("job for coordinator pod must be indexed completion mode")
+	// Validate job is using indexed completion mode and completions number is set.
+	if replicatedJob.Template.Spec.CompletionMode == nil || replicatedJob.Template.Spec.Completions == nil || *replicatedJob.Template.Spec.CompletionMode != batchv1.IndexedCompletion {
+		return fmt.Errorf("job for coordinator pod must be indexed completion mode, and completions number must be set")
 	}
 
 	// Validate Pod index.
-	if js.Spec.Coordinator.PodIndex < 0 || replicatedJob.Template.Spec.Completions == nil || js.Spec.Coordinator.PodIndex >= int(*replicatedJob.Template.Spec.Completions) {
+	if js.Spec.Coordinator.PodIndex < 0 || js.Spec.Coordinator.PodIndex >= int(*replicatedJob.Template.Spec.Completions) {
 		return fmt.Errorf("coordinator pod index %d is invalid for replicatedJob %s job index %d", js.Spec.Coordinator.PodIndex, js.Spec.Coordinator.ReplicatedJob, js.Spec.Coordinator.JobIndex)
 	}
 	return nil

--- a/pkg/webhooks/jobset_webhook.go
+++ b/pkg/webhooks/jobset_webhook.go
@@ -390,7 +390,7 @@ func validateCoordinator(js *jobset.JobSet) error {
 	}
 
 	// Validate Pod index.
-	if js.Spec.Coordinator.PodIndex < 0 || js.Spec.Coordinator.PodIndex >= int(*replicatedJob.Template.Spec.Completions) {
+	if js.Spec.Coordinator.PodIndex < 0 || replicatedJob.Template.Spec.Completions == nil || js.Spec.Coordinator.PodIndex >= int(*replicatedJob.Template.Spec.Completions) {
 		return fmt.Errorf("coordinator pod index %d is invalid for replicatedJob %s job index %d", js.Spec.Coordinator.PodIndex, js.Spec.Coordinator.ReplicatedJob, js.Spec.Coordinator.JobIndex)
 	}
 	return nil

--- a/pkg/webhooks/jobset_webhook_test.go
+++ b/pkg/webhooks/jobset_webhook_test.go
@@ -1456,6 +1456,48 @@ func TestValidateCreate(t *testing.T) {
 			),
 		},
 		{
+			name: "coordinator replicated job missing completions",
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					Coordinator: &jobset.Coordinator{
+						ReplicatedJob: "replicatedjob-a",
+						JobIndex:      0,
+						PodIndex:      0,
+					},
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:      "replicatedjob-a",
+							GroupName: "default",
+							Replicas:  2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
+									Parallelism:    ptr.To(int32(2)),
+								},
+							},
+						},
+						{
+							Name:      "replicatedjob-b",
+							GroupName: "default",
+							Replicas:  2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
+									Completions:    ptr.To(int32(2)),
+									Parallelism:    ptr.To(int32(2)),
+								},
+							},
+						},
+					},
+					SuccessPolicy: &jobset.SuccessPolicy{},
+				},
+			},
+			want: errors.Join(
+				fmt.Errorf("job for coordinator pod must be indexed completion mode, and completions number must be set"),
+			),
+		},
+		{
 			name: "coordinator job index invalid",
 			js: &jobset.JobSet{
 				ObjectMeta: validObjectMeta,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

`invalid memory address or nil pointer dereference` error happens when setting the `coordinator`, but forgetting to set `completions`.

Validator does not check that `completions` is nil, causing an error at L393.
https://github.com/Ladicle/jobset/blob/main/pkg/webhooks/jobset_webhook.go#L387-L395
Note: `IndexedCompletion` is set as the default value in the previous process.
https://github.com/Ladicle/jobset/blob/main/pkg/webhooks/jobset_webhook.go#L122


```yaml
apiVersion: jobset.x-k8s.io/v1alpha2
kind: JobSet
metadata:
  name: ray
spec:
  coordinator:
    replicatedJob: head
    jobIndex: 0
    podIndex: 0
  successPolicy:
    operator: All
    targetReplicatedJobs:
    - head
  replicatedJobs:
  - name: head
    replicas: 1
    template:
      spec:
        # completionMode: Indexed
        # completions: 1
        backoffLimit: 0
        template:
        ....
```

```console
jobset-controller-manager-694f54749-d4vx8 manager 2025-07-09T10:59:23Z  ERROR   admission       Observed a panic        {"webhookGroup": "jobset.x-k8s.io", "webhookKind": "JobSet", "JobSet": {"name":"ray","namespace":"default"}, "namespace": "default", "name": "ray", "resource": {"group":"jobset.x-k8s.io","version":"v1alpha2","resource":"jobsets"}, "user": "kubernetes-admin", "requestID": "e4e605f5-522b-41c9-a285-2f4c61d477c8", "panic": "runtime error: invalid memory address or nil pointer dereference", "panicGoValue": "\"invalid memory address or nil pointer dereference\"", "stacktrace": "goroutine 59448 [running]:\nk8s.io/apimachinery/pkg/util/runtime.logPanic({0x1e39370, 0x40010461b0}, {0x17f9b00, 0x2f0e820})\n\t/go/pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/util/runtime/runtime.go:107 +0x98\nsigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).Handle.func1()\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.2/pkg/webhook/admission/webhook.go:163 +0xe8\npanic({0x17f9b00?, 0x2f0e820?})\n\t/usr/local/go/src/runtime/panic.go:785 +0x124\nsigs.k8s.io/jobset/pkg/webhooks.validateCoordinator(0x400096da40)\n\t/workspace/pkg/webhooks/jobset_webhook.go:380 +0x1fc\nsigs.k8s.io/jobset/pkg/webhooks.(*jobSetWebhook).ValidateCreate(0x4000317fb0?, {0x24?, 0x4000fe1bd0?}, {0x1e1fe80?, 0x400096da40?})\n\t/workspace/pkg/webhooks/jobset_webhook.go:255 +0xc18\nsigs.k8s.io/controller-runtime/pkg/webhook/admission.(*validatorForType).Handle(_, {_, _}, {{{0x4000317fb0, 0x24}, {{0x4000fe1bd0, 0xf}, {0x4000fe1ba8, 0x8}, {0x4000fe1be0, ...}}, ...}})\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.2/pkg/webhook/admission/validator_custom.go:94 +0x25c\nsigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).Handle(_, {_, _}, {{{0x4000317fb0, 0x24}, {{0x4000fe1bd0, 0xf}, {0x4000fe1ba8, 0x8}, {0x4000fe1be0, ...}}, ...}})\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.2/pkg/webhook/admission/webhook.go:181 +0x194\nsigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).ServeHTTP(0x4000301950, {0xffff766b1920, 0x40006874f0}, 0x4000322500)\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.2/pkg/webhook/admission/http.go:119 +0x8dc\nsigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics.InstrumentedHook.InstrumentHandlerInFlight.func1({0xffff766b1920, 0x40006874f0}, 0x4000322500)\n\t/go/pkg/mod/github.com/prometheus/client_golang@v1.21.0/prometheus/promhttp/instrument_server.go:60 +0xa8\nnet/http.HandlerFunc.ServeHTTP(0x1e27e08?, {0xffff766b1920?, 0x40006874f0?}, 0x4000614fa5?)\n\t/usr/local/go/src/net/http/server.go:2220 +0x38\ngithub.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerCounter.func1({0x1e27e08?, 0x4000794b60?}, 0x4000322500)\n\t/go/pkg/mod/github.com/prometheus/client_golang@v1.21.0/prometheus/promhttp/instrument_server.go:147 +0xa8\nnet/http.HandlerFunc.ServeHTTP(0x40008979d8?, {0x1e27e08?, 0x4000794b60?}, 0x400106a200?)\n\t/usr/local/go/src/net/http/server.go:2220 +0x38\ngithub.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerDuration.func2({0x1e27e08, 0x4000794b60}, 0x4000322500)\n\t/go/pkg/mod/github.com/prometheus/client_golang@v1.21.0/prometheus/promhttp/instrument_server.go:109 +0x94\nnet/http.HandlerFunc.ServeHTTP(0x4000774460?, {0x1e27e08?, 0x4000794b60?}, 0x4000897b10?)\n\t/usr/local/go/src/net/http/server.go:2220 +0x38\nnet/http.(*ServeMux).ServeHTTP(0x10?, {0x1e27e08, 0x4000794b60}, 0x4000322500)\n\t/usr/local/go/src/net/http/server.go:2747 +0x1b4\nnet/http.serverHandler.ServeHTTP({0x1e1f308?}, {0x1e27e08?, 0x4000794b60?}, 0x6?)\n\t/usr/local/go/src/net/http/server.go:3210 +0xbc\nnet/http.(*conn).serve(0x4000d26090, {0x1e39370, 0x4000c01d40})\n\t/usr/local/go/src/net/http/server.go:2092 +0x4fc\ncreated by net/http.(*Server).Serve in goroutine 265\n\t/usr/local/go/src/net/http/server.go:3360 +0x3dc\n"}
jobset-controller-manager-694f54749-d4vx8 manager runtime.sigpanic
jobset-controller-manager-694f54749-d4vx8 manager       /usr/local/go/src/runtime/signal_unix.go:900
jobset-controller-manager-694f54749-d4vx8 manager sigs.k8s.io/jobset/pkg/webhooks.validateCoordinator
jobset-controller-manager-694f54749-d4vx8 manager       /workspace/pkg/webhooks/jobset_webhook.go:380
jobset-controller-manager-694f54749-d4vx8 manager sigs.k8s.io/jobset/pkg/webhooks.(*jobSetWebhook).ValidateCreate
jobset-controller-manager-694f54749-d4vx8 manager       /workspace/pkg/webhooks/jobset_webhook.go:255
jobset-controller-manager-694f54749-d4vx8 manager sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*validatorForType).Handle
jobset-controller-manager-694f54749-d4vx8 manager       /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.2/pkg/webhook/admission/validator_custom.go:94
jobset-controller-manager-694f54749-d4vx8 manager sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).Handle
jobset-controller-manager-694f54749-d4vx8 manager       /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.2/pkg/webhook/admission/webhook.go:181
jobset-controller-manager-694f54749-d4vx8 manager sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).ServeHTTP
jobset-controller-manager-694f54749-d4vx8 manager       /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.2/pkg/webhook/admission/http.go:119
jobset-controller-manager-694f54749-d4vx8 manager sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics.InstrumentedHook.InstrumentHandlerInFlight.func1
jobset-controller-manager-694f54749-d4vx8 manager       /go/pkg/mod/github.com/prometheus/client_golang@v1.21.0/prometheus/promhttp/instrument_server.go:60
jobset-controller-manager-694f54749-d4vx8 manager net/http.HandlerFunc.ServeHTTP
jobset-controller-manager-694f54749-d4vx8 manager       /usr/local/go/src/net/http/server.go:2220
jobset-controller-manager-694f54749-d4vx8 manager github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerCounter.func1
jobset-controller-manager-694f54749-d4vx8 manager       /go/pkg/mod/github.com/prometheus/client_golang@v1.21.0/prometheus/promhttp/instrument_server.go:147
jobset-controller-manager-694f54749-d4vx8 manager net/http.HandlerFunc.ServeHTTP
jobset-controller-manager-694f54749-d4vx8 manager       /usr/local/go/src/net/http/server.go:2220
jobset-controller-manager-694f54749-d4vx8 manager github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerDuration.func2
jobset-controller-manager-694f54749-d4vx8 manager       /go/pkg/mod/github.com/prometheus/client_golang@v1.21.0/prometheus/promhttp/instrument_server.go:109
jobset-controller-manager-694f54749-d4vx8 manager net/http.HandlerFunc.ServeHTTP
jobset-controller-manager-694f54749-d4vx8 manager       /usr/local/go/src/net/http/server.go:2220
jobset-controller-manager-694f54749-d4vx8 manager net/http.(*ServeMux).ServeHTTP
jobset-controller-manager-694f54749-d4vx8 manager       /usr/local/go/src/net/http/server.go:2747
jobset-controller-manager-694f54749-d4vx8 manager net/http.serverHandler.ServeHTTP
jobset-controller-manager-694f54749-d4vx8 manager       /usr/local/go/src/net/http/server.go:3210
jobset-controller-manager-694f54749-d4vx8 manager net/http.(*conn).serve
jobset-controller-manager-694f54749-d4vx8 manager       /usr/local/go/src/net/http/server.go:2092
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```