### PR TITLE
Updated Makefile for s390x support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GO_VERSION := $(shell awk '/^go /{print $$2}' go.mod|head -n1)
 
 GIT_TAG ?= $(shell git describe --tags --dirty --always)
 # Image URL to use all building/pushing image targets
-PLATFORMS ?= linux/amd64,linux/arm64
+PLATFORMS ?= linux/amd64,linux/arm64,linux/s390x
 DOCKER_BUILDX_CMD ?= docker buildx
 IMAGE_BUILD_CMD ?= $(DOCKER_BUILDX_CMD) build
 IMAGE_BUILD_EXTRA_OPTS ?=


### PR DESCRIPTION
Signed-off-by: Jathavedhan M <jadu20xx@gmail.com>

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds support for building and running the JobSet controller on the s390x architecture, enabling multi-arch compatibility and expanding platform support for the Kubernetes JobSet project.

#### Special notes for your reviewer:

- This is part of the ongoing effort to enable multiarch support in Kueue and its components.
- Verified image builds on s390x using Docker buildx.
- Please validate multiarch support strategy and Makefile changes.

#### Does this PR introduce a user-facing change?

```release-note
Added support for building and running the JobSet controller on s390x architecture.
