### PR TITLE
[release-0.8] fix: handle nil Completions in coordinator validation

### DIFF
--- a/pkg/webhooks/jobset_webhook.go
+++ b/pkg/webhooks/jobset_webhook.go
@@ -381,7 +381,7 @@ func validateCoordinator(js *jobset.JobSet) error {
 	}
 
 	// Validate Pod index.
-	if js.Spec.Coordinator.PodIndex < 0 || js.Spec.Coordinator.PodIndex >= int(*replicatedJob.Template.Spec.Completions) {
+	if js.Spec.Coordinator.PodIndex < 0 || replicatedJob.Template.Spec.Completions == nil || js.Spec.Coordinator.PodIndex >= int(*replicatedJob.Template.Spec.Completions) {
 		return fmt.Errorf("coordinator pod index %d is invalid for replicatedJob %s job index %d", js.Spec.Coordinator.PodIndex, js.Spec.Coordinator.ReplicatedJob, js.Spec.Coordinator.JobIndex)
 	}
 	return nil

--- a/pkg/webhooks/jobset_webhook.go
+++ b/pkg/webhooks/jobset_webhook.go
@@ -375,13 +375,13 @@ func validateCoordinator(js *jobset.JobSet) error {
 		return fmt.Errorf("coordinator job index %d is invalid for replicatedJob %s", js.Spec.Coordinator.JobIndex, replicatedJob.Name)
 	}
 
-	// Validate job is using indexed completion mode.
-	if replicatedJob.Template.Spec.CompletionMode == nil || *replicatedJob.Template.Spec.CompletionMode != batchv1.IndexedCompletion {
-		return fmt.Errorf("job for coordinator pod must be indexed completion mode")
+	// Validate job is using indexed completion mode and completions number is set.
+	if replicatedJob.Template.Spec.CompletionMode == nil || replicatedJob.Template.Spec.Completions == nil || *replicatedJob.Template.Spec.CompletionMode != batchv1.IndexedCompletion {
+		return fmt.Errorf("job for coordinator pod must be indexed completion mode, and completions number must be set")
 	}
 
 	// Validate Pod index.
-	if js.Spec.Coordinator.PodIndex < 0 || replicatedJob.Template.Spec.Completions == nil || js.Spec.Coordinator.PodIndex >= int(*replicatedJob.Template.Spec.Completions) {
+	if js.Spec.Coordinator.PodIndex < 0 || js.Spec.Coordinator.PodIndex >= int(*replicatedJob.Template.Spec.Completions) {
 		return fmt.Errorf("coordinator pod index %d is invalid for replicatedJob %s job index %d", js.Spec.Coordinator.PodIndex, js.Spec.Coordinator.ReplicatedJob, js.Spec.Coordinator.JobIndex)
 	}
 	return nil

--- a/pkg/webhooks/jobset_webhook_test.go
+++ b/pkg/webhooks/jobset_webhook_test.go
@@ -1415,9 +1415,8 @@ func TestValidateCreate(t *testing.T) {
 					},
 					ReplicatedJobs: []jobset.ReplicatedJob{
 						{
-							Name:      "replicatedjob-a",
-							GroupName: "default",
-							Replicas:  2,
+							Name:     "replicatedjob-a",
+							Replicas: 2,
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
 									CompletionMode: ptr.To(batchv1.IndexedCompletion),
@@ -1426,9 +1425,8 @@ func TestValidateCreate(t *testing.T) {
 							},
 						},
 						{
-							Name:      "replicatedjob-b",
-							GroupName: "default",
-							Replicas:  2,
+							Name:     "replicatedjob-b",
+							Replicas: 2,
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
 									CompletionMode: ptr.To(batchv1.IndexedCompletion),

--- a/pkg/webhooks/jobset_webhook_test.go
+++ b/pkg/webhooks/jobset_webhook_test.go
@@ -1404,6 +1404,48 @@ func TestValidateCreate(t *testing.T) {
 			),
 		},
 		{
+			name: "coordinator replicated job missing completions",
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					Coordinator: &jobset.Coordinator{
+						ReplicatedJob: "replicatedjob-a",
+						JobIndex:      0,
+						PodIndex:      0,
+					},
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:      "replicatedjob-a",
+							GroupName: "default",
+							Replicas:  2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
+									Parallelism:    ptr.To(int32(2)),
+								},
+							},
+						},
+						{
+							Name:      "replicatedjob-b",
+							GroupName: "default",
+							Replicas:  2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
+									Completions:    ptr.To(int32(2)),
+									Parallelism:    ptr.To(int32(2)),
+								},
+							},
+						},
+					},
+					SuccessPolicy: &jobset.SuccessPolicy{},
+				},
+			},
+			want: errors.Join(
+				fmt.Errorf("job for coordinator pod must be indexed completion mode, and completions number must be set"),
+			),
+		},
+		{
 			name: "coordinator job index invalid",
 			js: &jobset.JobSet{
 				ObjectMeta: validObjectMeta,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR fixed the automated cherry-pick in https://github.com/kubernetes-sigs/jobset/pull/934.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```