### PR TITLE
cleanup: e2e tests: Don't sleep in trainer jobs

### DIFF
--- a/keps/262-ConfigurableFailurePolicy/README.md
+++ b/keps/262-ConfigurableFailurePolicy/README.md
@@ -26,10 +26,7 @@ tags, and then generate with `hack/update-toc.sh`.
     - [Story 2: RestartJobSet](#story-2-restartjobset)
     - [Story 3: RestartJobSetAndIgnoreMaxRestarts](#story-3-restartjobsetandignoremaxrestarts)
     - [Story 4: Different failure policies for different replicated jobs](#story-4-different-failure-policies-for-different-replicated-jobs)
-  - [Notes/Constraints/Caveats (Optional)](#notesconstraintscaveats-optional)
-  - [Risks and Mitigations](#risks-and-mitigations)
-- [Design Details](#design-details)
-  - [Proposed Failure Policy API](#proposed-failure-policy-api)
+    - [Story 5: Recreating individual jobs on failure rather than failing JobSet (<code>RecreateJob</code>)](#story-5-recreating-individual-jobs-on-failure-rather-than-failing-jobset-)
   - [Constraints](#constraints)
   - [Implementation](#implementation)
   - [Test Plan](#test-plan)
@@ -41,8 +38,6 @@ tags, and then generate with `hack/update-toc.sh`.
 - [Drawbacks](#drawbacks)
 - [Alternatives](#alternatives)
 - [Future Work](#future-work)
-  - [Story 1: RestartReplicatedJob](#story-1-restartreplicatedjob)
-  - [Story 2: FailJob and RestartJob](#story-2-failjob-and-restartjob)
 <!-- /toc -->
 
 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -53,6 +53,7 @@ func getNamespace() string {
 	}
 	return namespace
 }
+
 func TestAPIs(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

When testing `dependsOn`, it's not necessary to `sleep 10` in the trainer jobs as that is only postponing the jobset to be complete. Good 30 seconds saved, perhaps 🙂 

#### Which issue(s) this PR fixes:

None, but I improved things a little bit when I was checking out #786 

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

N/A