### PR TITLE
e2e tests: Improve a flaky DependsOn test

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -517,12 +517,12 @@ var _ = ginkgo.Describe("JobSet", func() {
 					Should(gomega.Equal(numReplicasLauncher))
 			})
 
-			ginkgo.By("Wait for Launcher to be in Ready status", func() {
+			ginkgo.By("Wait for Launcher to be in Ready/Succeeded status", func() {
 				gomega.Eventually(func() int32 {
 					gomega.Expect(k8sClient.Get(ctx, jobSetKey, jobSet)).Should(gomega.Succeed())
 					for _, rJobStatus := range jobSet.Status.ReplicatedJobsStatus {
 						if rJobStatus.Name == launcherJob {
-							return rJobStatus.Ready
+							return max(rJobStatus.Ready, rJobStatus.Succeeded)
 						}
 					}
 					return 0


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind flake

#### What this PR does / why we need it:

In DependsOn tests, we wait for the launcher replicated job to be Ready before proceeding. This breaks in case the job manages to succeed before reaching the check. So the condition is improved to wait for Ready/Succeeded.

As much as this seems improbable, it may be causing [failures](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_jobset/944/pull-jobset-test-e2e-main-1-33/1947787367217631232) and I don't have any other theory why the check would fail when the job is clearly Complete at the end of the test, as visible from the namespace dump.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

I am actually not sure whether it's significant that we wait for Ready in particular. We may want to check that the waiting jobs are actually started on Ready already. But that is inevitably making the test more flaky, it seems.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```