### PR TITLE
test/e2e: Remove extra Eventually call

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -194,7 +194,7 @@ var _ = ginkgo.Describe("JobSet", func() {
 
 			// Ensure the child jobs are deleted.
 			ginkgo.By("checking that all child jobs are deleted")
-			gomega.Eventually(util.NumJobs, timeout, interval).WithArguments(ctx, k8sClient, js).Should(gomega.Equal(0))
+			gomega.Expect(util.NumJobs(ctx, k8sClient, js)).To(gomega.Equal(0))
 		})
 	})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Attending to a post-merge review [comment](https://github.com/kubernetes-sigs/jobset/pull/960#discussion_r2243725745),
removing an extra `Eventually` call.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```