### PR TITLE
hack/e2e-test.sh: Use a temporary KUBECONFIG

### DIFF
--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -6,6 +6,9 @@ export KIND=$PWD/bin/kind
 export NAMESPACE="jobset-system"
 export JOBSET_E2E_TESTS_DUMP_NAMESPACE=true
 
+# Use a temporary KUBECONFIG so that the script does not mess with the current user's kubeconfig.
+KUBECONFIG=""
+
 function cleanup {
     if [ $USE_EXISTING_CLUSTER == 'false' ] 
     then
@@ -16,12 +19,19 @@ function cleanup {
         kubectl describe pods -n jobset-system > $ARTIFACTS/jobset-system-pods.log || true
         $KIND export logs $ARTIFACTS || true
         $KIND delete cluster --name $KIND_CLUSTER_NAME || { echo "You need to run make kind-image-build before this script"; exit -1; }
+        rm "$KUBECONFIG"
     fi
     (cd config/components/manager && $KUSTOMIZE edit set image controller=us-central1-docker.pkg.dev/k8s-staging-images/jobset/jobset:main)
 }
 function startup {
     if [ $USE_EXISTING_CLUSTER == 'false' ] 
-    then 
+    then
+        KUBECONFIG="$(mktemp)"
+        if [ -z "$KUBECONFIG" ]; then
+            echo "Failed to generate temporary KUBECONFIG" 1>&2
+            exit 1
+        fi
+        export KUBECONFIG
         $KIND create cluster --name $KIND_CLUSTER_NAME --image $E2E_KIND_VERSION --wait 1m
         kubectl get nodes > $ARTIFACTS/kind-nodes.log || true
         kubectl describe pods -n kube-system > $ARTIFACTS/kube-system-pods.log || true


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

When the kind cluster is deleted, the kubeconfig context is left empty. This can mess up the current user's kubeconfig, which I find tremendously annoying. So this patch uses a temporary kubeconfig file just for kind.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```