### PR TITLE
add test-infra requirement for release

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -52,6 +52,9 @@ Please do not remove items from the checklist
        branch has been created (presumably the README update commit above), and, push the tag:
       `DEVEL=v0.$(($MAJ+1)).0-devel; git tag $DEVEL main && git push $DEVEL`
       This ensures that the devel builds on the `main` branch will have a meaningful version number.
+- [ ] For a major release, Submit a PR against [test-infra](https://github.com/kubernetes/test-infra),
+      updating `config/jobs/kubernetes-sigs/jobset` periodics to drop n - 1 release and add a periodic
+      covering the new release branch. <!-- example kubernetes/test-infra#35420-->
 - [ ] Close this issue
 
 

--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -52,7 +52,7 @@ Please do not remove items from the checklist
        branch has been created (presumably the README update commit above), and, push the tag:
       `DEVEL=v0.$(($MAJ+1)).0-devel; git tag $DEVEL main && git push $DEVEL`
       This ensures that the devel builds on the `main` branch will have a meaningful version number.
-- [ ] For a major release, Submit a PR against [test-infra](https://github.com/kubernetes/test-infra),
+- [ ] For a major or minor release, submit a PR against [test-infra](https://github.com/kubernetes/test-infra),
       updating `config/jobs/kubernetes-sigs/jobset` periodics to drop n - 1 release and add a periodic
       covering the new release branch. <!-- example kubernetes/test-infra#35420-->
 - [ ] Close this issue


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add step to add a new periodic job for a new minor release of JobSet.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
cc @andreyvelich 

https://github.com/kubernetes/test-infra/pull/35420#pullrequestreview-3166460363
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```