### PR TITLE
Filter out terminating leader Pods

### DIFF
--- a/pkg/webhooks/pod_admission_webhook_test.go
+++ b/pkg/webhooks/pod_admission_webhook_test.go
@@ -2,15 +2,19 @@ package webhooks
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+	"sigs.k8s.io/jobset/pkg/controllers"
 )
 
 func TestLeaderPodName(t *testing.T) {
@@ -121,6 +125,109 @@ func TestPodsOwnedBySameJob(t *testing.T) {
 	}
 }
 
+func TestLeaderPodForFollower(t *testing.T) {
+	// Common owner reference for pods in the same job.
+	ownerRef := metav1.OwnerReference{UID: types.UID("job-uid-1"), Kind: "Job", Controller: ptr.To(true)}
+	annotations := map[string]string{jobset.ExclusiveKey: "topology.kubernetes.io/zone"}
+	leaderPod := makeTestPod("js-rjob-0-0-xyz", &ownerRef, annotations)
+	followerPod := makeTestPod("js-rjob-0-1-abc", &ownerRef, annotations)
+
+	testCases := []struct {
+		name          string
+		followerPod   *corev1.Pod
+		existingPods  []runtime.Object
+		wantLeaderPod *corev1.Pod
+		wantErr       string
+	}{
+		{
+			name:          "valid leader pod exists",
+			followerPod:   followerPod,
+			existingPods:  []runtime.Object{leaderPod},
+			wantLeaderPod: leaderPod,
+		},
+		{
+			name: "follower pod missing labels",
+			followerPod: func() *corev1.Pod {
+				p := followerPod.DeepCopy()
+				delete(p.Labels, jobset.JobIndexKey)
+				return p
+			}(),
+			wantErr: "pod missing label: jobset.sigs.k8s.io/job-index",
+		},
+		{
+			name:         "no leader pod found",
+			followerPod:  followerPod,
+			existingPods: []runtime.Object{},
+			wantErr:      "expected 1 leader pod (js-rjob-0-0), but got 0",
+		},
+		{
+			name:        "multiple leader pods found",
+			followerPod: followerPod,
+			existingPods: []runtime.Object{
+				leaderPod,
+				makeTestPod("js-rjob-0-0-uvw", &ownerRef, annotations),
+			},
+			wantErr: "expected 1 leader pod (js-rjob-0-0), but got 2",
+		},
+		{
+			name:        "leader pod is terminating",
+			followerPod: followerPod,
+			existingPods: []runtime.Object{
+				func() *corev1.Pod {
+					p := leaderPod.DeepCopy()
+					p.DeletionTimestamp = ptr.To(metav1.Now())
+					p.Finalizers = []string{"batch.kubernetes.io/job-tracking"}
+					return p
+				}(),
+			},
+			wantErr: "expected 1 leader pod (js-rjob-0-0), but got 0",
+		},
+		{
+			name:        "leader and follower owned by different jobs",
+			followerPod: followerPod,
+			existingPods: []runtime.Object{
+				makeTestPod("js-rjob-0-0-xyz", &metav1.OwnerReference{UID: types.UID("job-uid-2"), Kind: "Job", Controller: ptr.To(true)}, annotations),
+			},
+			wantErr: "follower pod owner UID (job-uid-1) != leader pod owner UID (job-uid-2)",
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add corev1 to scheme: %v", err)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tc.existingPods...).
+				WithIndex(&corev1.Pod{}, controllers.PodNameKey, controllers.IndexPodName).
+				Build()
+			p := &podWebhook{client: fakeClient}
+
+			got, err := p.leaderPodForFollower(t.Context(), tc.followerPod)
+
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Errorf("expected error %q, got nil", tc.wantErr)
+					return
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("expected error to contain %q, got %q", tc.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.wantLeaderPod, got); diff != "" {
+				t.Errorf("unexpected diff (-want/+got): %s", diff)
+			}
+		})
+	}
+}
+
 func createPodWithOwner(name string, ownerUID string) *corev1.Pod {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -131,6 +238,25 @@ func createPodWithOwner(name string, ownerUID string) *corev1.Pod {
 		pod.OwnerReferences = []metav1.OwnerReference{
 			{UID: types.UID(ownerUID), Kind: "Job", Controller: ptr.To(true)},
 		}
+	}
+	return pod
+}
+
+func makeTestPod(name string, owner *metav1.OwnerReference, annotations map[string]string) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels: map[string]string{
+				jobset.JobSetNameKey:        "js",
+				jobset.ReplicatedJobNameKey: "rjob",
+				jobset.JobIndexKey:          "0",
+			},
+			Annotations: annotations,
+		},
+	}
+	if owner != nil {
+		pod.OwnerReferences = []metav1.OwnerReference{*owner}
 	}
 	return pod
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- Filter outs terminating leader Pods
- Add unit tests for `leaderPodForFollower` function
- Small refactor of indexes so they can be used in unit tests

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1021

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
JobSet pod webhook validates if leader Pods are terminating before copying metadate from them  
```