### PR TITLE
Update failure policy KEP: distinguish retriable from non retriable Pod failure policies

### DIFF
--- a/keps/262-ConfigurableFailurePolicy/README.md
+++ b/keps/262-ConfigurableFailurePolicy/README.md
@@ -26,6 +26,7 @@ tags, and then generate with `hack/update-toc.sh`.
     - [Story 2: RestartJobSet](#story-2-restartjobset)
     - [Story 3: RestartJobSetAndIgnoreMaxRestarts](#story-3-restartjobsetandignoremaxrestarts)
     - [Story 4: Different failure policies for different replicated jobs](#story-4-different-failure-policies-for-different-replicated-jobs)
+    - [Story 5: Distinguishing retriable from non retriable Pod failure policies](#story-5-distinguishing-retriable-from-non-retriable-pod-failure-policies)
   - [Notes/Constraints/Caveats (Optional)](#notesconstraintscaveats-optional)
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)

--- a/keps/262-ConfigurableFailurePolicy/README.md
+++ b/keps/262-ConfigurableFailurePolicy/README.md
@@ -392,8 +392,8 @@ spec:
 ```
 
 While welcome, the upstream change will take time to be delivered. In the best 
-case scenario, the change will be included in Kubernetes 1.34 as alpha (ETA 
-January 2026) and become stable in 1.36 (ETA September 2026). A short-term 
+case scenario, the change will be included in Kubernetes 1.35 as alpha (ETA 
+January 2026) and become stable in 1.37 (ETA September 2026). A short-term 
 solution is to add the new field `spec.failurePolicy.rules[].onJobFailureMessagePatterns`, 
 which will allow the value of the `message` field in the Job failure condition 
 to be matched against a pattern. Although not designed to be machine-readable, 

--- a/keps/262-ConfigurableFailurePolicy/README.md
+++ b/keps/262-ConfigurableFailurePolicy/README.md
@@ -346,7 +346,7 @@ will allow me to support my use case. This will be possible because the new
 field `podFailurePolicy.rules[].name` will allow the value of the `reason` 
 field of the Job failure condition to be customized as `PodFailurePolicy_{name}`.
 
-**Long-Term: Example Failure Policy Configuration for this use case**:
+**Long-Term solution: Example Failure Policy Configuration for this use case**:
 
 ```yaml
 apiVersion: jobset.x-k8s.io/v1alpha2
@@ -398,11 +398,11 @@ solution is to add the new field `spec.failurePolicy.rules[].onJobFailureMessage
 which will allow the value of the `message` field in the Job failure condition 
 to be matched against a pattern. Although not designed to be machine-readable, 
 the message field is stable enough (no changes since its addition 2 years ago) 
-to serve as a short-term workaround. Once the upstream solution is fully 
+to serve as a short-term solution. Once the upstream solution is fully 
 delivered, the documentation and validation webhook of JobSet can be updated 
 to encourage new JobSet YAML files to use the long-term solution.
 
-**Short-Term: Example Failure Policy Configuration for this use case**:
+**Short-Term solution: Example Failure Policy Configuration for this use case**:
 
 ```yaml
 apiVersion: jobset.x-k8s.io/v1alpha2
@@ -417,12 +417,12 @@ spec:
       onJobFailureReasons:
       - PodFailurePolicy
       onJobFailureMessagePatterns: # New field
-      - ".*DisruptionTarget.*"
+      - ".*DisruptionTarget.*" # Failure message: Pod <pod namespace>/<pod name> has condition DisruptionTarget matching FailJob rule at index <index>
     - action: FailJobSet
       onJobFailureReasons:
       - PodFailurePolicy
       onJobFailureMessagePatterns: # New field
-      - ".*exit code 42.*"
+      - ".*exit code 42.*" # Failure message: Container <container name> for pod <pod namespace>/<pod name> failed with exit code 42 matching FailJob rule at index <index>
   replicatedJobs:
   - name: leader
     replicas: 1

--- a/keps/262-ConfigurableFailurePolicy/README.md
+++ b/keps/262-ConfigurableFailurePolicy/README.md
@@ -501,33 +501,33 @@ const (
 // failure reason and the job failure message. The rules are evaluated in
 // order and the first matching rule is executed.
 type FailurePolicyRule struct {
-	// The name of the failure policy rule.
-	// The name is defaulted to 'failurePolicyRuleN' where N is the index of the failure policy rule.
-	// The name must match the regular expression "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$".
-	Name string `json:"name"`
-	// The action to take if the rule is matched.
-	// +kubebuilder:validation:Enum:=FailJobSet;RestartJobSet;RestartJobSetAndIgnoreMaxRestarts
-	Action FailurePolicyAction `json:"action"`
-	// The requirement on the job failure reasons. The requirement is satisfied
-	// if at least one reason matches the list. An empty list matches any job
-	// failure reason.
-	// +kubebuilder:validation:UniqueItems:true
-	OnJobFailureReasons []string `json:"onJobFailureReasons,omitempty"`
-	// The requirement on the job failure message. The requirement is satisfied
-	// if at least one pattern (regex) matches the job failure message. An
-	// empty list matches any job failure message.
-	// The syntax of the regular expressions accepted is the same general
-	// syntax used by Perl, Python, and other languages. More precisely, it is
-	// the syntax accepted by RE2 and described at https://golang.org/s/re2syntax,
-	// except for \C. For an overview of the syntax, see
-	// https://pkg.go.dev/regexp/syntax.
-	// +kubebuilder:validation:UniqueItems:true
-	OnJobFailureMessagePatterns []string `json:"onJobFailureMessagePatterns,omitempty"`
-	// TargetReplicatedJobs are the names of the replicated jobs the operator applies to.
-	// An empty list will apply to all replicatedJobs.
-	// +optional
-	// +listType=atomic
-	TargetReplicatedJobs []string `json:"targetReplicatedJobs,omitempty"`
+  // The name of the failure policy rule.
+  // The name is defaulted to 'failurePolicyRuleN' where N is the index of the failure policy rule.
+  // The name must match the regular expression "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$".
+  Name string `json:"name"`
+  // The action to take if the rule is matched.
+  // +kubebuilder:validation:Enum:=FailJobSet;RestartJobSet;RestartJobSetAndIgnoreMaxRestarts
+  Action FailurePolicyAction `json:"action"`
+  // The requirement on the job failure reasons. The requirement is satisfied
+  // if at least one reason matches the list. An empty list matches any job
+  // failure reason.
+  // +kubebuilder:validation:UniqueItems:true
+  OnJobFailureReasons []string `json:"onJobFailureReasons,omitempty"`
+  // The requirement on the job failure message. The requirement is satisfied
+  // if at least one pattern (regex) matches the job failure message. An
+  // empty list matches any job failure message.
+  // The syntax of the regular expressions accepted is the same general
+  // syntax used by Perl, Python, and other languages. More precisely, it is
+  // the syntax accepted by RE2 and described at https://golang.org/s/re2syntax,
+  // except for \C. For an overview of the syntax, see
+  // https://pkg.go.dev/regexp/syntax.
+  // +kubebuilder:validation:UniqueItems:true
+  OnJobFailureMessagePatterns []string `json:"onJobFailureMessagePatterns,omitempty"`
+  // TargetReplicatedJobs are the names of the replicated jobs the operator applies to.
+  // An empty list will apply to all replicatedJobs.
+  // +optional
+  // +listType=atomic
+  TargetReplicatedJobs []string `json:"targetReplicatedJobs,omitempty"`
 }
 
 type FailurePolicy struct {

--- a/keps/262-ConfigurableFailurePolicy/README.md
+++ b/keps/262-ConfigurableFailurePolicy/README.md
@@ -280,11 +280,22 @@ spec:
 
 As a user, I have a workload that can fail for three different reasons:
 
-1. The main container exits with exit code `1`. This is a case that is worth retrying, so I want my JobSet workload to be restarted and count towards `maxRestarts`.
-2. The main container exits with the special exit code `42`. This is a case that is not retriable. If the workload is restarted, it will exit again with exit code `42`. Therefore, I want my JobSet to ignore `maxRestarts` and fail immediately.
-3. The Pod is evicted due to maintenance on the VM. This is a case that is well worth retrying, so I want my JobSet workload to be restarted, but do not count towards `maxRestarts`.
+1. The main container exits with exit code `1`. This is a case that is worth 
+retrying, so I want my JobSet workload to be restarted and count towards 
+`maxRestarts`.
+2. The main container exits with the special exit code `42`. This is a case 
+that is not retriable. If the workload is restarted, it will exit again with 
+exit code `42`. Therefore, I want my JobSet to ignore `maxRestarts` and fail 
+immediately.
+3. The Pod is evicted due to maintenance on the VM. This is a case that is 
+well worth retrying, so I want my JobSet workload to be restarted, but do not 
+count towards `maxRestarts`.
 
-Currently, there is no way to distinguish failure (2) from failure (3). This is because a Job that has failed due to a matching rule in `podFailurePolicy.rules[]` will always have the reason `PodFailurePolicy` in its failure condition. Consequently, the JobSet controller has no way to determine which rule in `podFailurePolicy.rules[]` caused the Job to fail.
+Currently, there is no way to distinguish failure (2) from failure (3). This 
+is because a Job that has failed due to a matching rule in 
+`podFailurePolicy.rules[]` will always have the reason `PodFailurePolicy` in 
+its failure condition. Consequently, the JobSet controller has no way to 
+determine which rule in `podFailurePolicy.rules[]` caused the Job to fail.
 
 **Current implementation of JobSet: Example Failure Policy Configuration for this use case**:
 
@@ -330,7 +341,10 @@ spec:
               values: [42]
 ```
 
-The upstream change to the Job API described in [KEP-4443](https://github.com/kubernetes/enhancements/pull/4479) will allow me to support my use case. This will be possible because the new field `podFailurePolicy.rules[].name` will allow the value of the `reason` field of the Job failure condition to be customized as `PodFailurePolicy_{name}`.
+The upstream change to the Job API described in [KEP-4443](https://github.com/kubernetes/enhancements/pull/4479) 
+will allow me to support my use case. This will be possible because the new 
+field `podFailurePolicy.rules[].name` will allow the value of the `reason` 
+field of the Job failure condition to be customized as `PodFailurePolicy_{name}`.
 
 **Long-Term: Example Failure Policy Configuration for this use case**:
 
@@ -377,7 +391,16 @@ spec:
               values: [42]
 ```
 
-While welcome, the upstream change will take time to be delivered. In the best case scenario, the change will be included in Kubernetes 1.34 as alpha (ETA January 2026) and become stable in 1.36 (ETA September 2026). A short-term solution is to add the new field `spec.failurePolicy.rules[].onJobFailureMessagePatterns`, which will allow the value of the `message` field in the Job failure condition to be matched against a pattern. Although not designed to be machine-readable, the message field is stable enough (no changes since its addition 2 years ago) to serve as a short-term workaround. Once the upstream solution is fully delivered, the documentation and validation webhook of JobSet can be updated to encourage new JobSet YAML files to use the long-term solution.
+While welcome, the upstream change will take time to be delivered. In the best 
+case scenario, the change will be included in Kubernetes 1.34 as alpha (ETA 
+January 2026) and become stable in 1.36 (ETA September 2026). A short-term 
+solution is to add the new field `spec.failurePolicy.rules[].onJobFailureMessagePatterns`, 
+which will allow the value of the `message` field in the Job failure condition 
+to be matched against a pattern. Although not designed to be machine-readable, 
+the message field is stable enough (no changes since its addition 2 years ago) 
+to serve as a short-term workaround. Once the upstream solution is fully 
+delivered, the documentation and validation webhook of JobSet can be updated 
+to encourage new JobSet YAML files to use the long-term solution.
 
 **Short-Term: Example Failure Policy Configuration for this use case**:
 

--- a/keps/262-ConfigurableFailurePolicy/README.md
+++ b/keps/262-ConfigurableFailurePolicy/README.md
@@ -495,24 +495,38 @@ const (
 )
 
 // FailurePolicyRule defines a FailurePolicyAction to be executed if a child job
-// fails due to a reason listed in OnJobFailureReasons.
+// fails due to a reason listed in OnJobFailureReasons and a message pattern
+// listed in OnJobFailureMessagePatterns. The rule must match both the job
+// failure reason and the job failure message. The rules are evaluated in
+// order and the first matching rule is executed.
 type FailurePolicyRule struct {
-  // The action to take if the rule is matched.
-  // +kubebuilder:validation:Enum:=FailJobSet;RestartJobSetAndIgnoreMaxRestarts;FailJob
-  Action FailurePolicyAction `json:"action"`
-  // The requirement on the job failure reasons. The requirement
-  // is satisfied if at least one reason matches the list.
-  // The rules are evaluated in order, and the first matching
-  // rule is executed.
-  // An empty list applies the rule to any job failure reason.
-  // +kubebuilder:validation:UniqueItems:true
-  OnJobFailureReasons []string `json:"onJobFailureReasons"`
-  // TargetReplicatedJobs are the names of the replicated jobs the operator applies to.
-  // An empty list will apply to all replicatedJobs.
-  // +optional
-  // +listType=atomic
-  // +kubebuilder:validation:UniqueItems
-  TargetReplicatedJobs []string `json:"targetReplicatedJobs,omitempty"`
+	// The name of the failure policy rule.
+	// The name is defaulted to 'failurePolicyRuleN' where N is the index of the failure policy rule.
+	// The name must match the regular expression "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$".
+	Name string `json:"name"`
+	// The action to take if the rule is matched.
+	// +kubebuilder:validation:Enum:=FailJobSet;RestartJobSet;RestartJobSetAndIgnoreMaxRestarts
+	Action FailurePolicyAction `json:"action"`
+	// The requirement on the job failure reasons. The requirement is satisfied
+	// if at least one reason matches the list. An empty list matches any job
+	// failure reason.
+	// +kubebuilder:validation:UniqueItems:true
+	OnJobFailureReasons []string `json:"onJobFailureReasons,omitempty"`
+	// The requirement on the job failure message. The requirement is satisfied
+	// if at least one pattern (regex) matches the job failure message. An
+	// empty list matches any job failure message.
+	// The syntax of the regular expressions accepted is the same general
+	// syntax used by Perl, Python, and other languages. More precisely, it is
+	// the syntax accepted by RE2 and described at https://golang.org/s/re2syntax,
+	// except for \C. For an overview of the syntax, see
+	// https://pkg.go.dev/regexp/syntax.
+	// +kubebuilder:validation:UniqueItems:true
+	OnJobFailureMessagePatterns []string `json:"onJobFailureMessagePatterns,omitempty"`
+	// TargetReplicatedJobs are the names of the replicated jobs the operator applies to.
+	// An empty list will apply to all replicatedJobs.
+	// +optional
+	// +listType=atomic
+	TargetReplicatedJobs []string `json:"targetReplicatedJobs,omitempty"`
 }
 
 type FailurePolicy struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
/kind api-change

#### What this PR does / why we need it:

This PR updates the failure policy KEP.

As discussed in #987, this update explains how the upstream [KEP-4443](https://github.com/kubernetes/enhancements/pull/4479) will allow to distinguish retriable from non retriable Pod failure policies in the long term. This update also explains how the new JobSet field `spec.failurePolicy.rules[].onJobFailureMessagePatterns` will allow the use case to be supported in the short term.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None.

#### Special notes for your reviewer:

I'll create a following PR with the implementation.

cc @kannon92 @andreyvelich @mimowo 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE

I'll add the user facing changes in the implementation PR.