### PR TITLE
Add onJobFailureMessagePatterns to distinguish retriable from non retriable Pod failure policies

### DIFF
--- a/api/jobset/v1alpha2/jobset_types.go
+++ b/api/jobset/v1alpha2/jobset_types.go
@@ -355,6 +355,8 @@ type FailurePolicyRule struct {
 	// An empty list applies the rule to any job failure reason.
 	// +kubebuilder:validation:UniqueItems:true
 	OnJobFailureReasons []string `json:"onJobFailureReasons,omitempty"`
+	// TODO: Add description
+	OnJobFailureMessagePatterns []string `json:"onJobFailureMessagePatterns,omitempty"`
 	// TargetReplicatedJobs are the names of the replicated jobs the operator applies to.
 	// An empty list will apply to all replicatedJobs.
 	// +optional

--- a/api/jobset/v1alpha2/jobset_types.go
+++ b/api/jobset/v1alpha2/jobset_types.go
@@ -339,7 +339,10 @@ const (
 )
 
 // FailurePolicyRule defines a FailurePolicyAction to be executed if a child job
-// fails due to a reason listed in OnJobFailureReasons.
+// fails due to a reason listed in OnJobFailureReasons and a message pattern
+// listed in OnJobFailureMessagePatterns. The rule must match both the job
+// failure reason and the job failure message. The rules are evaluated in
+// order and the first matching rule is executed.
 type FailurePolicyRule struct {
 	// The name of the failure policy rule.
 	// The name is defaulted to 'failurePolicyRuleN' where N is the index of the failure policy rule.
@@ -348,17 +351,20 @@ type FailurePolicyRule struct {
 	// The action to take if the rule is matched.
 	// +kubebuilder:validation:Enum:=FailJobSet;RestartJobSet;RestartJobSetAndIgnoreMaxRestarts
 	Action FailurePolicyAction `json:"action"`
-	// The requirement on the job failure reasons. The requirement
-	// is satisfied if at least one reason matches the list.
-	// The rules are evaluated in order, and the first matching
-	// rule is executed.
-	// An empty list applies the rule to any job failure reason.
+	// The requirement on the job failure reasons. The requirement is satisfied
+	// if at least one reason matches the list. An empty list matches any job
+	// failure reason.
 	// +kubebuilder:validation:UniqueItems:true
 	OnJobFailureReasons []string `json:"onJobFailureReasons,omitempty"`
-	// The requirement on the job failure message. The requirement
-	// is satisfied if at least one pattern matches the job failure message.
-	// The rules are evaluated in order, and the first matching
-	// rule is executed.
+	// The requirement on the job failure message. The requirement is satisfied
+	// if at least one pattern (regex) matches the job failure message. An
+	// empty list matches any job failure message.
+	// The syntax of the regular expressions accepted is the same general
+	// syntax used by Perl, Python, and other languages. More precisely, it is
+	// the syntax accepted by RE2 and described at https://golang.org/s/re2syntax,
+	// except for \C. For an overview of the syntax, see
+	// https://pkg.go.dev/regexp/syntax.
+	// +kubebuilder:validation:UniqueItems:true
 	OnJobFailureMessagePatterns []string `json:"onJobFailureMessagePatterns,omitempty"`
 	// TargetReplicatedJobs are the names of the replicated jobs the operator applies to.
 	// An empty list will apply to all replicatedJobs.

--- a/api/jobset/v1alpha2/jobset_types.go
+++ b/api/jobset/v1alpha2/jobset_types.go
@@ -355,7 +355,10 @@ type FailurePolicyRule struct {
 	// An empty list applies the rule to any job failure reason.
 	// +kubebuilder:validation:UniqueItems:true
 	OnJobFailureReasons []string `json:"onJobFailureReasons,omitempty"`
-	// TODO: Add description
+	// The requirement on the job failure message. The requirement
+	// is satisfied if at least one pattern matches the job failure message.
+	// The rules are evaluated in order, and the first matching
+	// rule is executed.
 	OnJobFailureMessagePatterns []string `json:"onJobFailureMessagePatterns,omitempty"`
 	// TargetReplicatedJobs are the names of the replicated jobs the operator applies to.
 	// An empty list will apply to all replicatedJobs.

--- a/api/jobset/v1alpha2/openapi_generated.go
+++ b/api/jobset/v1alpha2/openapi_generated.go
@@ -152,7 +152,7 @@ func schema_jobset_api_jobset_v1alpha2_FailurePolicyRule(ref common.ReferenceCal
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "FailurePolicyRule defines a FailurePolicyAction to be executed if a child job fails due to a reason listed in OnJobFailureReasons.",
+				Description: "FailurePolicyRule defines a FailurePolicyAction to be executed if a child job fails due to a reason listed in OnJobFailureReasons and a message pattern listed in OnJobFailureMessagePatterns. The rule must match both the job failure reason and the job failure message. The rules are evaluated in order and the first matching rule is executed.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
@@ -173,7 +173,7 @@ func schema_jobset_api_jobset_v1alpha2_FailurePolicyRule(ref common.ReferenceCal
 					},
 					"onJobFailureReasons": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The requirement on the job failure reasons. The requirement is satisfied if at least one reason matches the list. The rules are evaluated in order, and the first matching rule is executed. An empty list applies the rule to any job failure reason.",
+							Description: "The requirement on the job failure reasons. The requirement is satisfied if at least one reason matches the list. An empty list matches any job failure reason.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -188,7 +188,7 @@ func schema_jobset_api_jobset_v1alpha2_FailurePolicyRule(ref common.ReferenceCal
 					},
 					"onJobFailureMessagePatterns": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The requirement on the job failure message. The requirement is satisfied if at least one pattern matches the job failure message. The rules are evaluated in order, and the first matching rule is executed.",
+							Description: "The requirement on the job failure message. The requirement is satisfied if at least one pattern (regex) matches the job failure message. An empty list matches any job failure message. The syntax of the regular expressions accepted is the same general syntax used by Perl, Python, and other languages. More precisely, it is the syntax accepted by RE2 and described at https://golang.org/s/re2syntax, except for \\C. For an overview of the syntax, see https://pkg.go.dev/regexp/syntax.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/api/jobset/v1alpha2/openapi_generated.go
+++ b/api/jobset/v1alpha2/openapi_generated.go
@@ -186,6 +186,21 @@ func schema_jobset_api_jobset_v1alpha2_FailurePolicyRule(ref common.ReferenceCal
 							},
 						},
 					},
+					"onJobFailureMessagePatterns": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The requirement on the job failure message. The requirement is satisfied if at least one pattern matches the job failure message. The rules are evaluated in order, and the first matching rule is executed.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 					"targetReplicatedJobs": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{

--- a/api/jobset/v1alpha2/zz_generated.deepcopy.go
+++ b/api/jobset/v1alpha2/zz_generated.deepcopy.go
@@ -82,6 +82,11 @@ func (in *FailurePolicyRule) DeepCopyInto(out *FailurePolicyRule) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.OnJobFailureMessagePatterns != nil {
+		in, out := &in.OnJobFailureMessagePatterns, &out.OnJobFailureMessagePatterns
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.TargetReplicatedJobs != nil {
 		in, out := &in.TargetReplicatedJobs, &out.TargetReplicatedJobs
 		*out = make([]string, len(*in))

--- a/client-go/applyconfiguration/jobset/v1alpha2/failurepolicyrule.go
+++ b/client-go/applyconfiguration/jobset/v1alpha2/failurepolicyrule.go
@@ -21,10 +21,11 @@ import (
 // FailurePolicyRuleApplyConfiguration represents a declarative configuration of the FailurePolicyRule type for use
 // with apply.
 type FailurePolicyRuleApplyConfiguration struct {
-	Name                 *string                             `json:"name,omitempty"`
-	Action               *jobsetv1alpha2.FailurePolicyAction `json:"action,omitempty"`
-	OnJobFailureReasons  []string                            `json:"onJobFailureReasons,omitempty"`
-	TargetReplicatedJobs []string                            `json:"targetReplicatedJobs,omitempty"`
+	Name                        *string                             `json:"name,omitempty"`
+	Action                      *jobsetv1alpha2.FailurePolicyAction `json:"action,omitempty"`
+	OnJobFailureReasons         []string                            `json:"onJobFailureReasons,omitempty"`
+	OnJobFailureMessagePatterns []string                            `json:"onJobFailureMessagePatterns,omitempty"`
+	TargetReplicatedJobs        []string                            `json:"targetReplicatedJobs,omitempty"`
 }
 
 // FailurePolicyRuleApplyConfiguration constructs a declarative configuration of the FailurePolicyRule type for use with
@@ -55,6 +56,16 @@ func (b *FailurePolicyRuleApplyConfiguration) WithAction(value jobsetv1alpha2.Fa
 func (b *FailurePolicyRuleApplyConfiguration) WithOnJobFailureReasons(values ...string) *FailurePolicyRuleApplyConfiguration {
 	for i := range values {
 		b.OnJobFailureReasons = append(b.OnJobFailureReasons, values[i])
+	}
+	return b
+}
+
+// WithOnJobFailureMessagePatterns adds the given value to the OnJobFailureMessagePatterns field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the OnJobFailureMessagePatterns field.
+func (b *FailurePolicyRuleApplyConfiguration) WithOnJobFailureMessagePatterns(values ...string) *FailurePolicyRuleApplyConfiguration {
+	for i := range values {
+		b.OnJobFailureMessagePatterns = append(b.OnJobFailureMessagePatterns, values[i])
 	}
 	return b
 }

--- a/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
+++ b/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
@@ -130,6 +130,15 @@ spec:
                             The name is defaulted to 'failurePolicyRuleN' where N is the index of the failure policy rule.
                             The name must match the regular expression "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$".
                           type: string
+                        onJobFailureMessagePatterns:
+                          description: |-
+                            The requirement on the job failure message. The requirement
+                            is satisfied if at least one pattern matches the job failure message.
+                            The rules are evaluated in order, and the first matching
+                            rule is executed.
+                          items:
+                            type: string
+                          type: array
                         onJobFailureReasons:
                           description: |-
                             The requirement on the job failure reasons. The requirement

--- a/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
+++ b/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
@@ -115,7 +115,10 @@ spec:
                     items:
                       description: |-
                         FailurePolicyRule defines a FailurePolicyAction to be executed if a child job
-                        fails due to a reason listed in OnJobFailureReasons.
+                        fails due to a reason listed in OnJobFailureReasons and a message pattern
+                        listed in OnJobFailureMessagePatterns. The rule must match both the job
+                        failure reason and the job failure message. The rules are evaluated in
+                        order and the first matching rule is executed.
                       properties:
                         action:
                           description: The action to take if the rule is matched.
@@ -132,20 +135,22 @@ spec:
                           type: string
                         onJobFailureMessagePatterns:
                           description: |-
-                            The requirement on the job failure message. The requirement
-                            is satisfied if at least one pattern matches the job failure message.
-                            The rules are evaluated in order, and the first matching
-                            rule is executed.
+                            The requirement on the job failure message. The requirement is satisfied
+                            if at least one pattern (regex) matches the job failure message. An
+                            empty list matches any job failure message.
+                            The syntax of the regular expressions accepted is the same general
+                            syntax used by Perl, Python, and other languages. More precisely, it is
+                            the syntax accepted by RE2 and described at https://golang.org/s/re2syntax,
+                            except for \C. For an overview of the syntax, see
+                            https://pkg.go.dev/regexp/syntax.
                           items:
                             type: string
                           type: array
                         onJobFailureReasons:
                           description: |-
-                            The requirement on the job failure reasons. The requirement
-                            is satisfied if at least one reason matches the list.
-                            The rules are evaluated in order, and the first matching
-                            rule is executed.
-                            An empty list applies the rule to any job failure reason.
+                            The requirement on the job failure reasons. The requirement is satisfied
+                            if at least one reason matches the list. An empty list matches any job
+                            failure reason.
                           items:
                             type: string
                           type: array

--- a/hack/python-sdk/swagger.json
+++ b/hack/python-sdk/swagger.json
@@ -91,6 +91,14 @@
           "type": "string",
           "default": ""
         },
+        "onJobFailureMessagePatterns": {
+          "description": "The requirement on the job failure message. The requirement is satisfied if at least one pattern matches the job failure message. The rules are evaluated in order, and the first matching rule is executed.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "default": ""
+          }
+        },
         "onJobFailureReasons": {
           "description": "The requirement on the job failure reasons. The requirement is satisfied if at least one reason matches the list. The rules are evaluated in order, and the first matching rule is executed. An empty list applies the rule to any job failure reason.",
           "type": "array",
@@ -124,7 +132,7 @@
         },
         "metadata": {
           "default": {},
-          "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.34.0/api/openapi-spec/swagger.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+          "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.34.1/api/openapi-spec/swagger.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
         },
         "spec": {
           "default": {},
@@ -160,7 +168,7 @@
         },
         "metadata": {
           "default": {},
-          "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.34.0/api/openapi-spec/swagger.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+          "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.34.1/api/openapi-spec/swagger.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
         }
       }
     },
@@ -223,7 +231,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.34.0/api/openapi-spec/swagger.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
+            "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.34.1/api/openapi-spec/swagger.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
           },
           "x-kubernetes-list-map-keys": [
             "type"
@@ -312,7 +320,7 @@
         "template": {
           "description": "Template defines the template of the Job that will be created.",
           "default": {},
-          "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.34.0/api/openapi-spec/swagger.json#/definitions/io.k8s.api.batch.v1.JobTemplateSpec"
+          "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.34.1/api/openapi-spec/swagger.json#/definitions/io.k8s.api.batch.v1.JobTemplateSpec"
         }
       }
     },

--- a/hack/python-sdk/swagger.json
+++ b/hack/python-sdk/swagger.json
@@ -74,7 +74,7 @@
       }
     },
     "jobset.v1alpha2.FailurePolicyRule": {
-      "description": "FailurePolicyRule defines a FailurePolicyAction to be executed if a child job fails due to a reason listed in OnJobFailureReasons.",
+      "description": "FailurePolicyRule defines a FailurePolicyAction to be executed if a child job fails due to a reason listed in OnJobFailureReasons and a message pattern listed in OnJobFailureMessagePatterns. The rule must match both the job failure reason and the job failure message. The rules are evaluated in order and the first matching rule is executed.",
       "type": "object",
       "required": [
         "name",
@@ -92,7 +92,7 @@
           "default": ""
         },
         "onJobFailureMessagePatterns": {
-          "description": "The requirement on the job failure message. The requirement is satisfied if at least one pattern matches the job failure message. The rules are evaluated in order, and the first matching rule is executed.",
+          "description": "The requirement on the job failure message. The requirement is satisfied if at least one pattern (regex) matches the job failure message. An empty list matches any job failure message. The syntax of the regular expressions accepted is the same general syntax used by Perl, Python, and other languages. More precisely, it is the syntax accepted by RE2 and described at https://golang.org/s/re2syntax, except for \\C. For an overview of the syntax, see https://pkg.go.dev/regexp/syntax.",
           "type": "array",
           "items": {
             "type": "string",
@@ -100,7 +100,7 @@
           }
         },
         "onJobFailureReasons": {
-          "description": "The requirement on the job failure reasons. The requirement is satisfied if at least one reason matches the list. The rules are evaluated in order, and the first matching rule is executed. An empty list applies the rule to any job failure reason.",
+          "description": "The requirement on the job failure reasons. The requirement is satisfied if at least one reason matches the list. An empty list matches any job failure reason.",
           "type": "array",
           "items": {
             "type": "string",

--- a/pkg/controllers/failure_policy.go
+++ b/pkg/controllers/failure_policy.go
@@ -93,7 +93,9 @@ func findFirstFailedPolicyRuleAndJob(ctx context.Context, rules []jobset.Failure
 				continue
 			}
 
-			jobFailureTime, jobFailureReason, jobFailureMessage := ptr.To(jobFailureCondition.LastTransitionTime), jobFailureCondition.Reason, jobFailureCondition.Message
+			jobFailureTime := ptr.To(jobFailureCondition.LastTransitionTime)
+			jobFailureReason := jobFailureCondition.Reason
+			jobFailureMessage := jobFailureCondition.Message
 			jobFailedEarlier := matchedFailedJob == nil || jobFailureTime.Before(matchedFailureTime)
 			if ruleIsApplicable(ctx, rule, failedJob, jobFailureReason, jobFailureMessage) && jobFailedEarlier {
 				matchedFailedJob = failedJob

--- a/pkg/controllers/failure_policy.go
+++ b/pkg/controllers/failure_policy.go
@@ -131,7 +131,7 @@ func applyFailurePolicyRuleAction(ctx context.Context, js *jobset.JobSet, matchi
 	return nil
 }
 
-// ruleIsApplicable returns true if the failed job and job failure reason match the failure policy rule.
+// ruleIsApplicable returns true if the failed job, job failure reason and job failure message match the failure policy rule.
 // The function returns false otherwise.
 func ruleIsApplicable(ctx context.Context, rule jobset.FailurePolicyRule, failedJob *batchv1.Job, jobFailureReason string, jobFailureMessage string) bool {
 	log := ctrl.LoggerFrom(ctx)

--- a/pkg/controllers/failure_policy.go
+++ b/pkg/controllers/failure_policy.go
@@ -157,7 +157,8 @@ func ruleIsApplicable(ctx context.Context, rule jobset.FailurePolicyRule, failed
 	return ruleAppliesToParentReplicatedJob
 }
 
-// TODO: Description
+// anyMatchFound returns true if any of the provided regex patterns matches the message.
+// The function returns false otherwise.
 func anyMatchFound(ctx context.Context, patterns []string, message string) bool {
 	log := ctrl.LoggerFrom(ctx)
 

--- a/pkg/controllers/failure_policy_test.go
+++ b/pkg/controllers/failure_policy_test.go
@@ -79,6 +79,7 @@ func TestFindFirstFailedJob(t *testing.T) {
 	}
 }
 
+// TODO: Update test
 func TestFailurePolicyRuleIsApplicable(t *testing.T) {
 	var (
 		replicatedJobName1 = "test-replicated-job-1"
@@ -92,11 +93,12 @@ func TestFailurePolicyRuleIsApplicable(t *testing.T) {
 	)
 
 	tests := []struct {
-		name             string
-		rule             jobset.FailurePolicyRule
-		failedJob        *batchv1.Job
-		jobFailureReason string
-		expected         bool
+		name              string
+		rule              jobset.FailurePolicyRule
+		failedJob         *batchv1.Job
+		jobFailureReason  string
+		jobFailureMessage string
+		expected          bool
 	}{
 		{
 			name: "a job has failed and the failure policy rule matches all possible parent replicated jobs and matches all possible job failure reasons",
@@ -210,7 +212,7 @@ func TestFailurePolicyRuleIsApplicable(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := ruleIsApplicable(context.TODO(), tc.rule, tc.failedJob, tc.jobFailureReason)
+			actual := ruleIsApplicable(context.TODO(), tc.rule, tc.failedJob, tc.jobFailureReason, tc.jobFailureMessage)
 			if diff := cmp.Diff(tc.expected, actual); diff != "" {
 				t.Errorf("unexpected finished value (+got/-want): %s", diff)
 			}

--- a/sdk/python/jobset/models/jobset_v1alpha2_failure_policy_rule.py
+++ b/sdk/python/jobset/models/jobset_v1alpha2_failure_policy_rule.py
@@ -28,9 +28,10 @@ class JobsetV1alpha2FailurePolicyRule(BaseModel):
     """ # noqa: E501
     action: StrictStr = Field(description="The action to take if the rule is matched.")
     name: StrictStr = Field(description="The name of the failure policy rule. The name is defaulted to 'failurePolicyRuleN' where N is the index of the failure policy rule. The name must match the regular expression \"^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$\".")
+    on_job_failure_message_patterns: Optional[List[StrictStr]] = Field(default=None, description="The requirement on the job failure message. The requirement is satisfied if at least one pattern matches the job failure message. The rules are evaluated in order, and the first matching rule is executed.", alias="onJobFailureMessagePatterns")
     on_job_failure_reasons: Optional[List[StrictStr]] = Field(default=None, description="The requirement on the job failure reasons. The requirement is satisfied if at least one reason matches the list. The rules are evaluated in order, and the first matching rule is executed. An empty list applies the rule to any job failure reason.", alias="onJobFailureReasons")
     target_replicated_jobs: Optional[List[StrictStr]] = Field(default=None, description="TargetReplicatedJobs are the names of the replicated jobs the operator applies to. An empty list will apply to all replicatedJobs.", alias="targetReplicatedJobs")
-    __properties: ClassVar[List[str]] = ["action", "name", "onJobFailureReasons", "targetReplicatedJobs"]
+    __properties: ClassVar[List[str]] = ["action", "name", "onJobFailureMessagePatterns", "onJobFailureReasons", "targetReplicatedJobs"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -85,6 +86,7 @@ class JobsetV1alpha2FailurePolicyRule(BaseModel):
         _obj = cls.model_validate({
             "action": obj.get("action") if obj.get("action") is not None else '',
             "name": obj.get("name") if obj.get("name") is not None else '',
+            "onJobFailureMessagePatterns": obj.get("onJobFailureMessagePatterns"),
             "onJobFailureReasons": obj.get("onJobFailureReasons"),
             "targetReplicatedJobs": obj.get("targetReplicatedJobs")
         })

--- a/sdk/python/jobset/models/jobset_v1alpha2_failure_policy_rule.py
+++ b/sdk/python/jobset/models/jobset_v1alpha2_failure_policy_rule.py
@@ -24,12 +24,12 @@ from typing_extensions import Self
 
 class JobsetV1alpha2FailurePolicyRule(BaseModel):
     """
-    FailurePolicyRule defines a FailurePolicyAction to be executed if a child job fails due to a reason listed in OnJobFailureReasons.
+    FailurePolicyRule defines a FailurePolicyAction to be executed if a child job fails due to a reason listed in OnJobFailureReasons and a message pattern listed in OnJobFailureMessagePatterns. The rule must match both the job failure reason and the job failure message. The rules are evaluated in order and the first matching rule is executed.
     """ # noqa: E501
     action: StrictStr = Field(description="The action to take if the rule is matched.")
     name: StrictStr = Field(description="The name of the failure policy rule. The name is defaulted to 'failurePolicyRuleN' where N is the index of the failure policy rule. The name must match the regular expression \"^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$\".")
-    on_job_failure_message_patterns: Optional[List[StrictStr]] = Field(default=None, description="The requirement on the job failure message. The requirement is satisfied if at least one pattern matches the job failure message. The rules are evaluated in order, and the first matching rule is executed.", alias="onJobFailureMessagePatterns")
-    on_job_failure_reasons: Optional[List[StrictStr]] = Field(default=None, description="The requirement on the job failure reasons. The requirement is satisfied if at least one reason matches the list. The rules are evaluated in order, and the first matching rule is executed. An empty list applies the rule to any job failure reason.", alias="onJobFailureReasons")
+    on_job_failure_message_patterns: Optional[List[StrictStr]] = Field(default=None, description="The requirement on the job failure message. The requirement is satisfied if at least one pattern (regex) matches the job failure message. An empty list matches any job failure message. The syntax of the regular expressions accepted is the same general syntax used by Perl, Python, and other languages. More precisely, it is the syntax accepted by RE2 and described at https://golang.org/s/re2syntax, except for \\C. For an overview of the syntax, see https://pkg.go.dev/regexp/syntax.", alias="onJobFailureMessagePatterns")
+    on_job_failure_reasons: Optional[List[StrictStr]] = Field(default=None, description="The requirement on the job failure reasons. The requirement is satisfied if at least one reason matches the list. An empty list matches any job failure reason.", alias="onJobFailureReasons")
     target_replicated_jobs: Optional[List[StrictStr]] = Field(default=None, description="TargetReplicatedJobs are the names of the replicated jobs the operator applies to. An empty list will apply to all replicatedJobs.", alias="targetReplicatedJobs")
     __properties: ClassVar[List[str]] = ["action", "name", "onJobFailureMessagePatterns", "onJobFailureReasons", "targetReplicatedJobs"]
 

--- a/sdk/python/test/test_jobset_v1alpha2_failure_policy.py
+++ b/sdk/python/test/test_jobset_v1alpha2_failure_policy.py
@@ -41,6 +41,9 @@ class TestJobsetV1alpha2FailurePolicy(unittest.TestCase):
                     jobset.models.jobset_v1alpha2_failure_policy_rule.JobsetV1alpha2FailurePolicyRule(
                         action = '', 
                         name = '', 
+                        on_job_failure_message_patterns = [
+                            ''
+                            ], 
                         on_job_failure_reasons = [
                             ''
                             ], 

--- a/sdk/python/test/test_jobset_v1alpha2_failure_policy_rule.py
+++ b/sdk/python/test/test_jobset_v1alpha2_failure_policy_rule.py
@@ -37,6 +37,9 @@ class TestJobsetV1alpha2FailurePolicyRule(unittest.TestCase):
             return JobsetV1alpha2FailurePolicyRule(
                 action = '',
                 name = '',
+                on_job_failure_message_patterns = [
+                    ''
+                    ],
                 on_job_failure_reasons = [
                     ''
                     ],

--- a/sdk/python/test/test_jobset_v1alpha2_job_set.py
+++ b/sdk/python/test/test_jobset_v1alpha2_job_set.py
@@ -88,6 +88,9 @@ class TestJobsetV1alpha2JobSet(unittest.TestCase):
                             jobset.models.jobset_v1alpha2_failure_policy_rule.JobsetV1alpha2FailurePolicyRule(
                                 action = '', 
                                 name = '', 
+                                on_job_failure_message_patterns = [
+                                    ''
+                                    ], 
                                 on_job_failure_reasons = [
                                     ''
                                     ], 

--- a/sdk/python/test/test_jobset_v1alpha2_job_set_list.py
+++ b/sdk/python/test/test_jobset_v1alpha2_job_set_list.py
@@ -91,6 +91,9 @@ class TestJobsetV1alpha2JobSetList(unittest.TestCase):
                                     jobset.models.jobset_v1alpha2_failure_policy_rule.JobsetV1alpha2FailurePolicyRule(
                                         action = '', 
                                         name = '', 
+                                        on_job_failure_message_patterns = [
+                                            ''
+                                            ], 
                                         on_job_failure_reasons = [
                                             ''
                                             ], 
@@ -208,6 +211,9 @@ class TestJobsetV1alpha2JobSetList(unittest.TestCase):
                                     jobset.models.jobset_v1alpha2_failure_policy_rule.JobsetV1alpha2FailurePolicyRule(
                                         action = '', 
                                         name = '', 
+                                        on_job_failure_message_patterns = [
+                                            ''
+                                            ], 
                                         on_job_failure_reasons = [
                                             ''
                                             ], 

--- a/sdk/python/test/test_jobset_v1alpha2_job_set_spec.py
+++ b/sdk/python/test/test_jobset_v1alpha2_job_set_spec.py
@@ -46,6 +46,9 @@ class TestJobsetV1alpha2JobSetSpec(unittest.TestCase):
                         jobset.models.jobset_v1alpha2_failure_policy_rule.JobsetV1alpha2FailurePolicyRule(
                             action = '', 
                             name = '', 
+                            on_job_failure_message_patterns = [
+                                ''
+                                ], 
                             on_job_failure_reasons = [
                                 ''
                                 ], 

--- a/site/content/en/docs/reference/jobset.v1alpha2.md
+++ b/site/content/en/docs/reference/jobset.v1alpha2.md
@@ -235,6 +235,16 @@ rule is executed.
 An empty list applies the rule to any job failure reason.</p>
 </td>
 </tr>
+<tr><td><code>onJobFailureMessagePatterns</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   <p>The requirement on the job failure message. The requirement
+is satisfied if at least one pattern matches the job failure message.
+The rules are evaluated in order, and the first matching
+rule is executed.</p>
+</td>
+</tr>
 <tr><td><code>targetReplicatedJobs</code><br/>
 <code>[]string</code>
 </td>

--- a/site/content/en/docs/reference/jobset.v1alpha2.md
+++ b/site/content/en/docs/reference/jobset.v1alpha2.md
@@ -200,7 +200,10 @@ a given FailurePolicyRule.</p>
 
 
 <p>FailurePolicyRule defines a FailurePolicyAction to be executed if a child job
-fails due to a reason listed in OnJobFailureReasons.</p>
+fails due to a reason listed in OnJobFailureReasons and a message pattern
+listed in OnJobFailureMessagePatterns. The rule must match both the job
+failure reason and the job failure message. The rules are evaluated in
+order and the first matching rule is executed.</p>
 
 
 <table class="table">
@@ -228,21 +231,23 @@ The name must match the regular expression &quot;^<a href="%5BA-Za-z0-9_,:%5D*%5
 <code>[]string</code>
 </td>
 <td>
-   <p>The requirement on the job failure reasons. The requirement
-is satisfied if at least one reason matches the list.
-The rules are evaluated in order, and the first matching
-rule is executed.
-An empty list applies the rule to any job failure reason.</p>
+   <p>The requirement on the job failure reasons. The requirement is satisfied
+if at least one reason matches the list. An empty list matches any job
+failure reason.</p>
 </td>
 </tr>
 <tr><td><code>onJobFailureMessagePatterns</code> <B>[Required]</B><br/>
 <code>[]string</code>
 </td>
 <td>
-   <p>The requirement on the job failure message. The requirement
-is satisfied if at least one pattern matches the job failure message.
-The rules are evaluated in order, and the first matching
-rule is executed.</p>
+   <p>The requirement on the job failure message. The requirement is satisfied
+if at least one pattern (regex) matches the job failure message. An
+empty list matches any job failure message.
+The syntax of the regular expressions accepted is the same general
+syntax used by Perl, Python, and other languages. More precisely, it is
+the syntax accepted by RE2 and described at https://golang.org/s/re2syntax,
+except for \C. For an overview of the syntax, see
+https://pkg.go.dev/regexp/syntax.</p>
 </td>
 </tr>
 <tr><td><code>targetReplicatedJobs</code><br/>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
/kind api-change

#### What this PR does / why we need it:

Add the new field `spec.failurePolicy.rules[].onJobFailureMessagePatterns` described in #1027. This will allow to distinguish retriable from non retriable Pod failure policies while [KEP-4443](https://github.com/kubernetes/enhancements/pull/4479) is not fully released (ETA September 2026). See #987 for more context.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #987

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add onJobFailureMessagePatterns to distinguish retriable from non retriable Pod failure policies
```