### PR TITLE
restrict controller-manager Secrets access to jobset install namespace

### DIFF
--- a/charts/jobset/templates/controller/cluster_role.yaml
+++ b/charts/jobset/templates/controller/cluster_role.yaml
@@ -53,15 +53,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - services
   verbs:
   - create

--- a/charts/jobset/templates/controller/role.yaml
+++ b/charts/jobset/templates/controller/role.yaml
@@ -34,6 +34,15 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - update
+  - watch
 {{- if .Values.controller.leaderElection.enable }}
 - apiGroups:
   - coordination.k8s.io

--- a/config/components/rbac/kustomization.yaml
+++ b/config/components/rbac/kustomization.yaml
@@ -9,6 +9,8 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+- manager_secrets_role.yaml
+- manager_secrets_role_binding.yaml
 # Comment the following 4 lines if you want to disable
 # protecting your /metrics endpoint.
 - auth_proxy_role.yaml

--- a/config/components/rbac/manager_secrets_role.yaml
+++ b/config/components/rbac/manager_secrets_role.yaml
@@ -1,0 +1,22 @@
+# permissions for the manager to access secrets.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: role
+    app.kubernetes.io/instance: manager-secrets-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: jobset
+    app.kubernetes.io/part-of: jobset
+    app.kubernetes.io/managed-by: kustomize
+  name: manager-secrets-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - update
+  - watch

--- a/config/components/rbac/manager_secrets_role_binding.yaml
+++ b/config/components/rbac/manager_secrets_role_binding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/instance: manager-secrets-rolebinding
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: jobset
+    app.kubernetes.io/part-of: jobset
+    app.kubernetes.io/managed-by: kustomize
+  name: manager-secrets-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: manager-secrets-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/config/components/rbac/role.yaml
+++ b/config/components/rbac/role.yaml
@@ -35,15 +35,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
   - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations

--- a/pkg/util/cert/cert.go
+++ b/pkg/util/cert/cert.go
@@ -43,7 +43,6 @@ func getOperatorNamespace() string {
 	return defaultNamespace
 }
 
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;update
 //+kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=mutatingwebhookconfigurations,verbs=get;list;watch;update
 //+kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=validatingwebhookconfigurations,verbs=get;list;watch;update
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Currently, the JobSet controller only uses Secrets when updating self‑signed certificates.
A single shared Secret object is mounted onto all JobSet controller pods and used as the webhook server certificate.
In this scenario, the Secret and the controller are deployed in the same namespace ({{ .Release.Namespace }}), so namespace‑scoped Secret update permissions should be sufficient.

A similar approach is taken to the existing **leader-election-role** Role and RoleBinding. Specifically:
- Remove Secrets RBAC marker from pkg/util/cert/cert.go, in turn removing Secrets permissions from the generated ClusterRole.
- Add Role manager-secrets-role and RoleBinding manager-secrets-rolebinding to config/components/rbac.
- Update Helm chart templates for the above.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1061

#### Special notes for your reviewer:
Reference related PR: https://github.com/kubernetes-sigs/kueue/pull/7188

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```