### PR TITLE
Use explicit bash image path instead of ambiguous shortname

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -630,7 +630,7 @@ func pingTestJobSet(ns *corev1.Namespace) *testing.JobSetWrapper {
 					Containers: []corev1.Container{
 						{
 							Name:    "ping-test-container",
-							Image:   "bash:latest",
+							Image:   "docker.io/library/bash:latest",
 							Command: []string{"bash", "-c"},
 							Args:    []string{cmd},
 						},
@@ -665,7 +665,7 @@ func pingTestJobSetSubdomain(ns *corev1.Namespace) *testing.JobSetWrapper {
 					Containers: []corev1.Container{
 						{
 							Name:    "ping-test-container",
-							Image:   "bash:latest",
+							Image:   "docker.io/library/bash:latest",
 							Command: []string{"bash", "-c"},
 							Args:    []string{cmd},
 						},
@@ -687,7 +687,7 @@ func sleepTestJobSet(ns *corev1.Namespace, durationSeconds int32) *testing.JobSe
 					Containers: []corev1.Container{
 						{
 							Name:    "sleep-test-container",
-							Image:   "bash:latest",
+							Image:   "docker.io/library/bash:latest",
 							Command: []string{"bash", "-c"},
 							Args:    []string{fmt.Sprintf("sleep %d", durationSeconds)},
 						},
@@ -712,7 +712,7 @@ func dependsOnTestReplicatedJob(ns *corev1.Namespace, jobName string, numReplica
 				Containers: []corev1.Container{
 					{
 						Name:         "sleep-test-container",
-						Image:        "bash:latest",
+						Image:        "docker.io/library/bash:latest",
 						Command:      []string{"bash", "-c"},
 						Args:         []string{"sleep " + strconv.Itoa(sleepSeconds)},
 						StartupProbe: startupProbe,
@@ -738,7 +738,7 @@ func serverSideApplyTestJobSet(ns *corev1.Namespace, name string) *jobsetv1alpha
 								WithRestartPolicy(corev1.RestartPolicyNever).
 								WithContainers(corev1ac.Container().
 									WithName("test-container").
-									WithImage("bash:latest").
+									WithImage("docker.io/library/bash:latest").
 									WithCommand("bash", "-c").
 									WithArgs("echo 'Hello from server-side apply test'; sleep 5"),
 								),


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
`bash:latest` image is used in e2e tests heavily. However, these tests do not reliably work on the environments that do not allow ambiguous image registries (i.e. due to the enforced policy). For example, if `bash:latest` is hosted in multiple registries, node simply errors out without pulling the image. 

In order to fix this issue and make e2e tests working on all environment, this PR uses explicit image path.

#### Does this PR introduce a user-facing change?
```release-note
None
```