### PR TITLE
enable nobools for future api calls. ignore current violations though.

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -17,11 +17,10 @@ linters:
               - "conditions" # Ensure conditions have the correct json tags and markers.
               - "conflictingmarkers"
               - "duplicatemarkers" # Ensure there are no exact duplicate markers. for types and fields.
-              #- "forbiddenmarkers" # Ensure that types and fields do not contain any markers that are forbidden.
               # - "integers" # Ensure only int32 and int64 are used for integers.
               - "jsontags" # Ensure every field has a json tag.
               # - "maxlength" # Ensure all strings and arrays have maximum lengths/maximum items.
-              # - "nobools" # Bools do not evolve over time, should use enums instead.
+              - "nobools" # Bools do not evolve over time, should use enums instead.
               - "nodurations" # Prevents usage of `Duration` types.
               - "nofloats" # Ensure floats are not used.
               # - "nomaps" # Ensure maps are not used.

--- a/api/jobset/v1alpha2/jobset_types.go
+++ b/api/jobset/v1alpha2/jobset_types.go
@@ -125,7 +125,7 @@ type JobSetSpec struct {
 	StartupPolicy *StartupPolicy `json:"startupPolicy,omitempty"`
 
 	// suspend suspends all running child Jobs when set to true.
-	Suspend *bool `json:"suspend,omitempty"`
+	Suspend *bool `json:"suspend,omitempty"` //nolint
 
 	// coordinator can be used to assign a specific pod as the coordinator for
 	// the JobSet. If defined, an annotation will be added to all Jobs and pods with
@@ -303,7 +303,7 @@ type Network struct {
 	// Pods will be reachable using the fully qualified pod hostname:
 	// <jobSet.name>-<spec.replicatedJob.name>-<job-index>-<pod-index>.<subdomain>
 	// +optional
-	EnableDNSHostnames *bool `json:"enableDNSHostnames,omitempty"`
+	EnableDNSHostnames *bool `json:"enableDNSHostnames,omitempty"` //nolint
 
 	// subdomain is an explicit choice for a network subdomain name
 	// When set, any replicated job in the set is added to this network.
@@ -314,7 +314,7 @@ type Network struct {
 	// publishNotReadyAddresses indicates if DNS records of pods should be published before the pods are ready.
 	// Defaults to True.
 	// +optional
-	PublishNotReadyAddresses *bool `json:"publishNotReadyAddresses,omitempty"`
+	PublishNotReadyAddresses *bool `json:"publishNotReadyAddresses,omitempty"` //nolint
 }
 
 // Operator defines the target of a SuccessPolicy or FailurePolicy.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add more kube-api-linter fixes
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

For API promotion we should probably apply this rule but this would be a breaking change for v1alpha2.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```