### PR TITLE
add timeout for waiting for PVC to fight flakes

### DIFF
--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -3213,7 +3213,7 @@ func checkExpectedPVCs(js *jobset.JobSet) {
 			return -1, err
 		}
 		return len(pvcList.Items), nil
-	}).Should(gomega.Equal(numExpectedPVCs(js)))
+	}, timeout, interval).Should(gomega.Equal(numExpectedPVCs(js)))
 }
 
 // Check that there are no active jobs owned by jobset, and the


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1133 

#### Special notes for your reviewer:

Claude research:

**Summary of the Flake**

  The test "jobset with VolumeClaimPolicies should create two PVC with Delete and Retain policies" is flaking with a timeout on util.go:101, which is the JobSetCompleted check that waits for the JobSet to have the Completed condition.

  Root Causes

  1. Missing timeout/interval in checkExpectedPVCs:

     Looking at test/integration/controller/jobset_controller_test.go:3209-3217:
```
  func checkExpectedPVCs(js *jobset.JobSet) {
      gomega.Eventually(func() (int, error) {
          // ...
      }).Should(gomega.Equal(numExpectedPVCs(js)))  // No timeout specified!
  }
```

This uses Gomega's default timeout of 1 second, which is very short. If PVCs take close to 1 second to be created, the controller may still be busy when step 2 begins.

Seems like a good theory.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```