### PR TITLE
Filter out Pods that do not have the same owner reference

### DIFF
--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -140,9 +140,6 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{}, fmt.Errorf("job key label not found on leader pod: %q", leaderPod.Name)
 	}
 
-	// For security, only reconcile pods that have the same controller owner as the leader pod.
-	// This prevents an attacker with 'create pods' permission from injecting a pod with a
-	// forged job-key label into the JobSet.
 	owner := metav1.GetControllerOf(&leaderPod)
 	if owner == nil {
 		return ctrl.Result{}, fmt.Errorf("leader pod %q has no controller owner", leaderPod.Name)
@@ -169,9 +166,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 }
 
 // listPodsForJob returns a list of pods owned by a specific job, using the
-// jobKey (SHA1 hash of the namespaced job name) label selector.
-// For security, we filter the pods to only include those that have the same
-// controller owner UID as the leader pod.
+// jobKey (SHA1 hash of the namespaced job name) label selector and the owner UID
 func (r *PodReconciler) listPodsForJob(ctx context.Context, ns, jobKey string, ownerUID types.UID) (*corev1.PodList, error) {
 	log := ctrl.LoggerFrom(ctx)
 	var podList corev1.PodList

--- a/pkg/controllers/pod_controller_test.go
+++ b/pkg/controllers/pod_controller_test.go
@@ -426,15 +426,15 @@ func TestListPodsForJob(t *testing.T) {
 		},
 	}
 
-	maliciousPod := makePod(&makePodArgs{
+	inconsistentPod := makePod(&makePodArgs{
 		jobSetName:        jobSetName,
 		replicatedJobName: "replicated-job-1",
 		jobName:           jobName,
-		podName:           "malicious-pod",
+		podName:           "inconsistent-pod",
 		ns:                ns,
 		jobIdx:            0,
 	}).AddAnnotation(jobset.ExclusiveKey, "topologyKey").Obj()
-	maliciousPod.OwnerReferences = []metav1.OwnerReference{
+	inconsistentPod.OwnerReferences = []metav1.OwnerReference{
 		{
 			APIVersion: "batch/v1",
 			Kind:       "Job",
@@ -467,11 +467,11 @@ func TestListPodsForJob(t *testing.T) {
 			expectedCount: 2,
 		},
 		{
-			name: "with malicious and unowned pods",
+			name: "with inconsistent and unowned pods",
 			pods: []corev1.Pod{
 				leaderPod,
 				followerPod,
-				maliciousPod,
+				inconsistentPod,
 				unownedPod,
 			},
 			expectedCount: 2,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

Fix vulnerability in the Pod controller. See #1153 for context.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1153

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix vulnerability in the Pod controller.
```