### PR TITLE
feat(controller,webhook): implement Elastic JobSets (Pod-level scaling)

### DIFF
--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -212,6 +212,12 @@ func (r *JobSetReconciler) reconcile(ctx context.Context, js *jobset.JobSet, upd
 		}
 	}
 
+	// Opportunistically patch existing active jobs for pod-level scaling
+	if err := r.syncJobScaling(ctx, js, ownedJobs.active); err != nil {
+		log.Error(err, "syncing job scaling")
+		return ctrl.Result{}, err
+	}
+
 	// If job has not failed or succeeded, reconcile the state of the replicatedJobs.
 	if err := r.reconcileReplicatedJobs(ctx, js, ownedJobs, rjobStatuses, updateStatusOpts); err != nil {
 		log.Error(err, "creating jobs")
@@ -818,6 +824,64 @@ func (r *JobSetReconciler) createHeadlessSvcIfNecessary(ctx context.Context, js 
 		log.V(2).Info("successfully created headless service", "service", klog.KObj(&headlessSvc))
 	}
 	return nil
+}
+
+// syncJobScaling applies in-place updates to the parallelism and completions of existing active child jobs
+// to match the desired state in the JobSet template (Elastic Indexed Jobs).
+func (r *JobSetReconciler) syncJobScaling(ctx context.Context, js *jobset.JobSet, activeJobs []*batchv1.Job) error {
+	log := ctrl.LoggerFrom(ctx)
+	var finalErrs []error
+
+	// Lookup map for the desired scaling configurations
+	type scalingConfig struct {
+		parallelism *int32
+		completions *int32
+	}
+	desiredScaling := make(map[string]scalingConfig)
+	for _, rjob := range js.Spec.ReplicatedJobs {
+		desiredScaling[rjob.Name] = scalingConfig{
+			parallelism: rjob.Template.Spec.Parallelism,
+			completions: rjob.Template.Spec.Completions,
+		}
+	}
+
+	// Iterate through active jobs and patch them if their scaling configuration is out of sync
+	for _, job := range activeJobs {
+		rjobName, ok := job.Labels[jobset.ReplicatedJobNameKey]
+		if !ok {
+			continue // Skip if label is missing
+		}
+
+		desired, exists := desiredScaling[rjobName]
+		if !exists {
+			continue
+		}
+
+		needsPatch := false
+		if !ptr.Equal(job.Spec.Parallelism, desired.parallelism) {
+			needsPatch = true
+		}
+		if !ptr.Equal(job.Spec.Completions, desired.completions) {
+			needsPatch = true
+		}
+
+		if needsPatch {
+			patch := client.MergeFrom(job.DeepCopy())
+			job.Spec.Parallelism = desired.parallelism
+			job.Spec.Completions = desired.completions
+
+			log.V(2).Info("Patching child Job for horizontal pod scaling",
+				"job", klog.KObj(job),
+				"parallelism", ptr.Deref(desired.parallelism, 0),
+				"completions", ptr.Deref(desired.completions, 0))
+
+			if err := r.Patch(ctx, job, patch); err != nil {
+				finalErrs = append(finalErrs, fmt.Errorf("failed to patch job %q for scaling: %w", job.Name, err))
+			}
+		}
+	}
+
+	return errors.Join(finalErrs...)
 }
 
 // executeSuccessPolicy checks the completed jobs against the jobset success policy

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -831,6 +831,11 @@ func (r *JobSetReconciler) createHeadlessSvcIfNecessary(ctx context.Context, js 
 // syncJobScaling applies in-place updates to the parallelism and completions of existing active child jobs
 // to match the desired state in the JobSet template (Elastic Indexed Jobs).
 func (r *JobSetReconciler) syncJobScaling(ctx context.Context, js *jobset.JobSet, activeJobs []*batchv1.Job) error {
+
+	if !features.Enabled(features.ElasticJobSet) {
+		return nil
+	}
+
 	log := ctrl.LoggerFrom(ctx)
 	var finalErrs []error
 
@@ -859,15 +864,7 @@ func (r *JobSetReconciler) syncJobScaling(ctx context.Context, js *jobset.JobSet
 			continue
 		}
 
-		needsPatch := false
-		if !ptr.Equal(job.Spec.Parallelism, desired.parallelism) {
-			needsPatch = true
-		}
-		if !ptr.Equal(job.Spec.Completions, desired.completions) {
-			needsPatch = true
-		}
-
-		if needsPatch {
+		if jobScalingNeedsPatch(job, desired.parallelism, desired.completions) {
 			patch := client.MergeFrom(job.DeepCopy())
 			job.Spec.Parallelism = desired.parallelism
 			job.Spec.Completions = desired.completions
@@ -884,6 +881,23 @@ func (r *JobSetReconciler) syncJobScaling(ctx context.Context, js *jobset.JobSet
 	}
 
 	return errors.Join(finalErrs...)
+}
+
+// jobScalingNeedsPatch evaluates whether a job's parallelism or completions
+// are out of sync with the desired state. It also guarantees we only trigger
+// a patch if the desired state is valid for Elastic Indexed Jobs (P == C).
+func jobScalingNeedsPatch(job *batchv1.Job, desiredParallelism, desiredCompletions *int32) bool {
+	// Parallelism and Completions should be equal for elastic scaling.
+	// If the desired state is out of sync with itself, it's an invalid configuration.
+	if !ptr.Equal(desiredParallelism, desiredCompletions) {
+		return false
+	}
+
+	// 2. Check if the Job has drifted from the desired state.
+	parallelismChanged := !ptr.Equal(job.Spec.Parallelism, desiredParallelism)
+	completionsChanged := !ptr.Equal(job.Spec.Completions, desiredCompletions)
+
+	return parallelismChanged || completionsChanged
 }
 
 // executeSuccessPolicy checks the completed jobs against the jobset success policy

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -213,9 +213,11 @@ func (r *JobSetReconciler) reconcile(ctx context.Context, js *jobset.JobSet, upd
 	}
 
 	// Opportunistically patch existing active jobs for pod-level scaling
-	if err := r.syncJobScaling(ctx, js, ownedJobs.active); err != nil {
-		log.Error(err, "syncing job scaling")
-		return ctrl.Result{}, err
+	if features.Enabled(features.ElasticJobSet) {
+		if err := r.syncJobScaling(ctx, js, ownedJobs.active); err != nil {
+			log.Error(err, "syncing job scaling")
+			return ctrl.Result{}, err
+		}
 	}
 
 	// If job has not failed or succeeded, reconcile the state of the replicatedJobs.

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -2102,3 +2102,93 @@ func TestGroupReplicas(t *testing.T) {
 		})
 	}
 }
+
+func TestSyncJobScaling(t *testing.T) {
+	var (
+		jobSetName        = "test-jobset"
+		replicatedJobName = "replicated-job"
+		jobName           = "test-job"
+		ns                = "default"
+	)
+
+	tests := []struct {
+		name        string
+		jobSet      *jobset.JobSet
+		activeJobs  []*batchv1.Job
+		expectPatch bool
+	}{
+		{
+			name: "jobs in sync, no patch needed",
+			jobSet: testutils.MakeJobSet(jobSetName, ns).
+				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName).
+					Job(testutils.MakeJobTemplate(jobName, ns).Parallelism(2).Completions(2).Obj()).
+					Replicas(1).
+					Obj()).Obj(),
+			activeJobs: []*batchv1.Job{
+				makeJob(&makeJobArgs{
+					jobSetName:        jobSetName,
+					replicatedJobName: replicatedJobName,
+					jobName:           "test-job-0",
+					ns:                ns,
+				}).Parallelism(2).Completions(2).Obj(),
+			},
+			expectPatch: false,
+		},
+		{
+			name: "jobs out of sync, patch needed",
+			jobSet: testutils.MakeJobSet(jobSetName, ns).
+				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName).
+					Job(testutils.MakeJobTemplate(jobName, ns).Parallelism(8).Completions(8).Obj()).
+					Replicas(1).
+					Obj()).Obj(),
+			activeJobs: []*batchv1.Job{
+				makeJob(&makeJobArgs{
+					jobSetName:        jobSetName,
+					replicatedJobName: replicatedJobName,
+					jobName:           "test-job-0",
+					ns:                ns,
+				}).Parallelism(2).Completions(2).Obj(),
+			},
+			expectPatch: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var patchesSent int
+			_, ctx := ktesting.NewTestContext(t)
+			scheme := runtime.NewScheme()
+			utilruntime.Must(jobset.AddToScheme(scheme))
+			utilruntime.Must(corev1.AddToScheme(scheme))
+			utilruntime.Must(batchv1.AddToScheme(scheme))
+
+			fakeClientBuilder := fake.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+				Patch: func(ctx context.Context, client client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					patchesSent++
+					patchedJob := obj.(*batchv1.Job)
+					if *patchedJob.Spec.Parallelism != 8 || *patchedJob.Spec.Completions != 8 {
+						t.Errorf("Expected job to be patched to Parallelism/Completions 8, got %d and %d", *patchedJob.Spec.Parallelism, *patchedJob.Spec.Completions)
+					}
+					return nil
+				},
+			})
+
+			r := &JobSetReconciler{
+				Client: fakeClientBuilder.Build(),
+				Scheme: scheme,
+				Record: events.NewFakeRecorder(32),
+			}
+
+			err := r.syncJobScaling(ctx, tc.jobSet, tc.activeJobs)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if tc.expectPatch && patchesSent == 0 {
+				t.Errorf("Expected patch to be sent, but none were")
+			}
+			if !tc.expectPatch && patchesSent > 0 {
+				t.Errorf("Expected no patches to be sent, but got %d", patchesSent)
+			}
+		})
+	}
+}

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -2112,10 +2112,11 @@ func TestSyncJobScaling(t *testing.T) {
 	)
 
 	tests := []struct {
-		name        string
-		jobSet      *jobset.JobSet
-		activeJobs  []*batchv1.Job
-		expectPatch bool
+		name                string
+		jobSet              *jobset.JobSet
+		activeJobs          []*batchv1.Job
+		expectPatch         bool
+		enableElasticJobSet bool
 	}{
 		{
 			name: "jobs in sync, no patch needed",
@@ -2132,7 +2133,8 @@ func TestSyncJobScaling(t *testing.T) {
 					ns:                ns,
 				}).Parallelism(2).Completions(2).Obj(),
 			},
-			expectPatch: false,
+			expectPatch:         false,
+			enableElasticJobSet: true,
 		},
 		{
 			name: "jobs out of sync, patch needed",
@@ -2149,7 +2151,62 @@ func TestSyncJobScaling(t *testing.T) {
 					ns:                ns,
 				}).Parallelism(2).Completions(2).Obj(),
 			},
-			expectPatch: true,
+			expectPatch:         true,
+			enableElasticJobSet: true,
+		},
+		{
+			name: "parallelism is changed, completions kept the same (invalid scaling, no patch)",
+			jobSet: testutils.MakeJobSet(jobSetName, ns).
+				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName).
+					Job(testutils.MakeJobTemplate(jobName, ns).Parallelism(8).Completions(2).Obj()). // Mismatched desired state
+					Replicas(1).
+					Obj()).Obj(),
+			activeJobs: []*batchv1.Job{
+				makeJob(&makeJobArgs{
+					jobSetName:        jobSetName,
+					replicatedJobName: replicatedJobName,
+					jobName:           "test-job-0",
+					ns:                ns,
+				}).Parallelism(2).Completions(2).Obj(),
+			},
+			expectPatch:         false,
+			enableElasticJobSet: true,
+		},
+		{
+			name: "parallelism kept the same, completions is changed (invalid scaling, no patch)",
+			jobSet: testutils.MakeJobSet(jobSetName, ns).
+				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName).
+					Job(testutils.MakeJobTemplate(jobName, ns).Parallelism(2).Completions(8).Obj()). // Mismatched desired state
+					Replicas(1).
+					Obj()).Obj(),
+			activeJobs: []*batchv1.Job{
+				makeJob(&makeJobArgs{
+					jobSetName:        jobSetName,
+					replicatedJobName: replicatedJobName,
+					jobName:           "test-job-0",
+					ns:                ns,
+				}).Parallelism(2).Completions(2).Obj(),
+			},
+			expectPatch:         false,
+			enableElasticJobSet: true,
+		},
+		{
+			name: "jobs out of sync, but feature gate disabled (no patch)",
+			jobSet: testutils.MakeJobSet(jobSetName, ns).
+				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName).
+					Job(testutils.MakeJobTemplate(jobName, ns).Parallelism(8).Completions(8).Obj()).
+					Replicas(1).
+					Obj()).Obj(),
+			activeJobs: []*batchv1.Job{
+				makeJob(&makeJobArgs{
+					jobSetName:        jobSetName,
+					replicatedJobName: replicatedJobName,
+					jobName:           "test-job-0",
+					ns:                ns,
+				}).Parallelism(2).Completions(2).Obj(),
+			},
+			expectPatch:         false,
+			enableElasticJobSet: false,
 		},
 	}
 
@@ -2179,7 +2236,8 @@ func TestSyncJobScaling(t *testing.T) {
 				Record: events.NewFakeRecorder(32),
 			}
 
-			features.SetFeatureGateDuringTest(t, features.ElasticJobSet, true)
+			features.SetFeatureGateDuringTest(t, features.ElasticJobSet, tc.enableElasticJobSet)
+
 			err := r.syncJobScaling(ctx, tc.jobSet, tc.activeJobs)
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -2179,6 +2179,7 @@ func TestSyncJobScaling(t *testing.T) {
 				Record: events.NewFakeRecorder(32),
 			}
 
+			features.SetFeatureGateDuringTest(t, features.ElasticJobSet, true)
 			err := r.syncJobScaling(ctx, tc.jobSet, tc.activeJobs)
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -46,6 +46,13 @@ const (
 	// recover from failures (i.e., failed Jobs) by recreating only the failed Job instead of all Jobs
 	// as in `RestartJobSet`.
 	RestartJob featuregate.Feature = "RestartJob"
+
+	// owner: @aniket2405
+	// kep: https://github.com/kubernetes-sigs/jobset/blob/main/keps/463-ElasticJobsets/README.md
+	//
+	// ElasticJobSet enables the mutation of parallelism and completions for ReplicatedJobs
+	// to support dynamic horizontal pod-level scaling.
+	ElasticJobSet featuregate.Feature = "ElasticJobSet"
 )
 
 func init() {
@@ -64,6 +71,8 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	TLSOptions: {Default: true, PreRelease: featuregate.Beta},
 
 	RestartJob: {Default: false, PreRelease: featuregate.Alpha},
+
+	ElasticJobSet: {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func SetFeatureGateDuringTest(tb testing.TB, f featuregate.Feature, value bool) {

--- a/pkg/webhooks/jobset_webhook.go
+++ b/pkg/webhooks/jobset_webhook.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -309,27 +310,76 @@ func (j *jobSetWebhook) ValidateCreate(ctx context.Context, js *jobset.JobSet) (
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (j *jobSetWebhook) ValidateUpdate(ctx context.Context, oldJs, newJs *jobset.JobSet) (admission.Warnings, error) {
+	mungedSpec := newJs.Spec.DeepCopy()
+	var errs field.ErrorList
+
+	// Elastic JobSet Validation
+	if features.Enabled(features.ElasticJobSet) {
+		// Check if the JobSet is in a terminal state (Completed or Failed)
+		isTerminal := false
+		for _, cond := range oldJs.Status.Conditions {
+			if (cond.Type == string(jobset.JobSetCompleted) || cond.Type == string(jobset.JobSetFailed)) && cond.Status == metav1.ConditionTrue {
+				isTerminal = true
+				break
+			}
+		}
+
+		for index := range newJs.Spec.ReplicatedJobs {
+			// Safe bounds check strictly for Elastic scaling evaluation
+			if index >= len(oldJs.Spec.ReplicatedJobs) {
+				continue
+			}
+
+			oldRJob := oldJs.Spec.ReplicatedJobs[index]
+			newRJob := newJs.Spec.ReplicatedJobs[index]
+			rJobPath := field.NewPath("spec", "replicatedJobs").Index(index).Child("template", "spec")
+
+			// Check if parallelism and completions have changed
+			parallelismChanged := !ptr.Equal(newRJob.Template.Spec.Parallelism, oldRJob.Template.Spec.Parallelism)
+			completionsChanged := !ptr.Equal(newRJob.Template.Spec.Completions, oldRJob.Template.Spec.Completions)
+
+			if parallelismChanged || completionsChanged {
+				if isTerminal {
+					errs = append(errs, field.Forbidden(rJobPath, "Cannot mutate parallelism or completions when JobSet is in a terminal state (Completed or Failed)"))
+				} else {
+					if parallelismChanged && newRJob.Template.Spec.Parallelism != nil && *newRJob.Template.Spec.Parallelism < 1 {
+						errs = append(errs, field.Invalid(rJobPath.Child("parallelism"), *newRJob.Template.Spec.Parallelism, "parallelism must be >= 1"))
+					}
+					if completionsChanged && newRJob.Template.Spec.Completions != nil && *newRJob.Template.Spec.Completions < 1 {
+						errs = append(errs, field.Invalid(rJobPath.Child("completions"), *newRJob.Template.Spec.Completions, "completions must be >= 1"))
+					}
+				}
+			}
+
+			// Mask parallelism and completions in mungedSpec to bypass the strict immutability check
+			mungedSpec.ReplicatedJobs[index].Template.Spec.Parallelism = oldRJob.Template.Spec.Parallelism
+			mungedSpec.ReplicatedJobs[index].Template.Spec.Completions = oldRJob.Template.Spec.Completions
+		}
+	}
+
 	// Allow pod template to be mutated for suspended JobSets, or JobSets getting suspended.
 	// This is needed for integration with Kueue/DWS.
 	if ptr.Deref(oldJs.Spec.Suspend, false) || ptr.Deref(newJs.Spec.Suspend, false) {
 		for index := range newJs.Spec.ReplicatedJobs {
 			// Pod values which must be mutable for Kueue are defined here: https://github.com/kubernetes-sigs/kueue/blob/a50d395c36a2cb3965be5232162cf1fded1bdb08/apis/kueue/v1beta1/workload_types.go#L256-L260
-			newJs.Spec.ReplicatedJobs[index].Template.Spec.Template.Annotations = oldJs.Spec.ReplicatedJobs[index].Template.Spec.Template.Annotations
-			newJs.Spec.ReplicatedJobs[index].Template.Spec.Template.Labels = oldJs.Spec.ReplicatedJobs[index].Template.Spec.Template.Labels
-			newJs.Spec.ReplicatedJobs[index].Template.Spec.Template.Spec.NodeSelector = oldJs.Spec.ReplicatedJobs[index].Template.Spec.Template.Spec.NodeSelector
-			newJs.Spec.ReplicatedJobs[index].Template.Spec.Template.Spec.Tolerations = oldJs.Spec.ReplicatedJobs[index].Template.Spec.Template.Spec.Tolerations
+			mungedSpec.ReplicatedJobs[index].Template.Spec.Template.Annotations = oldJs.Spec.ReplicatedJobs[index].Template.Spec.Template.Annotations
+			mungedSpec.ReplicatedJobs[index].Template.Spec.Template.Labels = oldJs.Spec.ReplicatedJobs[index].Template.Spec.Template.Labels
+			mungedSpec.ReplicatedJobs[index].Template.Spec.Template.Spec.NodeSelector = oldJs.Spec.ReplicatedJobs[index].Template.Spec.Template.Spec.NodeSelector
+			mungedSpec.ReplicatedJobs[index].Template.Spec.Template.Spec.Tolerations = oldJs.Spec.ReplicatedJobs[index].Template.Spec.Template.Spec.Tolerations
 
 			// Pod Scheduling Gates can be updated for batch/v1 Job: https://github.com/kubernetes/kubernetes/blob/ceb58a4dbc671b9d0a2de6d73a1616bc0c299863/pkg/apis/batch/validation/validation.go#L662
-			newJs.Spec.ReplicatedJobs[index].Template.Spec.Template.Spec.SchedulingGates = oldJs.Spec.ReplicatedJobs[index].Template.Spec.Template.Spec.SchedulingGates
+			mungedSpec.ReplicatedJobs[index].Template.Spec.Template.Spec.SchedulingGates = oldJs.Spec.ReplicatedJobs[index].Template.Spec.Template.Spec.SchedulingGates
 		}
 	}
 
 	// Note that SucccessPolicy and failurePolicy are made immutable via CEL.
-	errs := apivalidation.ValidateImmutableField(newJs.Spec.ReplicatedJobs, oldJs.Spec.ReplicatedJobs, field.NewPath("spec").Child("replicatedJobs"))
+	errs = append(errs, apivalidation.ValidateImmutableField(mungedSpec.ReplicatedJobs, oldJs.Spec.ReplicatedJobs, field.NewPath("spec").Child("replicatedJobs"))...)
 	errs = append(errs, apivalidation.ValidateImmutableField(newJs.Spec.ManagedBy, oldJs.Spec.ManagedBy, field.NewPath("spec").Child("managedBy"))...)
+
 	if len(errs) == 0 {
 		return nil, nil
 	}
+
 	return nil, apierrors.NewInvalid(
 		schema.GroupKind{Group: "jobset.x-k8s.io", Kind: "JobSet"},
 		newJs.Name,

--- a/pkg/webhooks/jobset_webhook.go
+++ b/pkg/webhooks/jobset_webhook.go
@@ -27,8 +27,8 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -313,50 +313,58 @@ func (j *jobSetWebhook) ValidateUpdate(ctx context.Context, oldJs, newJs *jobset
 	mungedSpec := newJs.Spec.DeepCopy()
 	var errs field.ErrorList
 
+	// Create a map of old ReplicatedJobs by name for safe lookup
+	oldJobsMap := make(map[string]*jobset.ReplicatedJob)
+	for i := range oldJs.Spec.ReplicatedJobs {
+		rjob := &oldJs.Spec.ReplicatedJobs[i]
+		oldJobsMap[rjob.Name] = rjob
+	}
+
 	// Elastic JobSet Validation
 	if features.Enabled(features.ElasticJobSet) {
 		// Check if the JobSet is in a terminal state (Completed or Failed)
-		isTerminal := false
-		for _, cond := range oldJs.Status.Conditions {
-			if (cond.Type == string(jobset.JobSetCompleted) || cond.Type == string(jobset.JobSetFailed)) && cond.Status == metav1.ConditionTrue {
-				isTerminal = true
-				break
-			}
-		}
+		isTerminal := meta.IsStatusConditionTrue(oldJs.Status.Conditions, string(jobset.JobSetCompleted)) ||
+			meta.IsStatusConditionTrue(oldJs.Status.Conditions, string(jobset.JobSetFailed))
 
 		for index := range newJs.Spec.ReplicatedJobs {
-			// Safe bounds check strictly for Elastic scaling evaluation
-			if index >= len(oldJs.Spec.ReplicatedJobs) {
-				continue
+			newRJob := &newJs.Spec.ReplicatedJobs[index]
+
+			// Safely grab the old replicated job by Name
+			oldRJob, exists := oldJobsMap[newRJob.Name]
+			if !exists {
+				continue // Skip if this is a new job
 			}
 
-			oldRJob := oldJs.Spec.ReplicatedJobs[index]
-			newRJob := newJs.Spec.ReplicatedJobs[index]
 			rJobPath := field.NewPath("spec", "replicatedJobs").Index(index).Child("template", "spec")
 
-			// Check if parallelism and completions have changed
-			parallelismChanged := !ptr.Equal(newRJob.Template.Spec.Parallelism, oldRJob.Template.Spec.Parallelism)
-			completionsChanged := !ptr.Equal(newRJob.Template.Spec.Completions, oldRJob.Template.Spec.Completions)
+			// Only allow elastic scaling for Indexed jobs.
+			isIndexedJob := newRJob.Template.Spec.CompletionMode != nil && *newRJob.Template.Spec.CompletionMode == batchv1.IndexedCompletion
 
-			if parallelismChanged || completionsChanged {
-				if isTerminal {
-					errs = append(errs, field.Forbidden(rJobPath, "Cannot mutate parallelism or completions when JobSet is in a terminal state (Completed or Failed)"))
-				} else {
-					if parallelismChanged && newRJob.Template.Spec.Parallelism != nil && *newRJob.Template.Spec.Parallelism < 1 {
-						errs = append(errs, field.Invalid(rJobPath.Child("parallelism"), *newRJob.Template.Spec.Parallelism, "parallelism must be >= 1"))
-					}
-					if completionsChanged && newRJob.Template.Spec.Completions != nil && *newRJob.Template.Spec.Completions < 1 {
-						errs = append(errs, field.Invalid(rJobPath.Child("completions"), *newRJob.Template.Spec.Completions, "completions must be >= 1"))
-					}
-					if newRJob.Template.Spec.Parallelism != nil && newRJob.Template.Spec.Completions != nil && *newRJob.Template.Spec.Parallelism != *newRJob.Template.Spec.Completions {
-						errs = append(errs, field.Invalid(rJobPath.Child("completions"), *newRJob.Template.Spec.Completions, "completions must be equal to parallelism for Elastic Indexed Jobs"))
+			if isIndexedJob {
+				// Check if parallelism and completions have changed
+				parallelismChanged := !ptr.Equal(newRJob.Template.Spec.Parallelism, oldRJob.Template.Spec.Parallelism)
+				completionsChanged := !ptr.Equal(newRJob.Template.Spec.Completions, oldRJob.Template.Spec.Completions)
+
+				if parallelismChanged || completionsChanged {
+					if isTerminal {
+						errs = append(errs, field.Forbidden(rJobPath, "Cannot mutate parallelism or completions when JobSet is in a terminal state (Completed or Failed)"))
+					} else {
+						if parallelismChanged && newRJob.Template.Spec.Parallelism != nil && *newRJob.Template.Spec.Parallelism < 1 {
+							errs = append(errs, field.Invalid(rJobPath.Child("parallelism"), *newRJob.Template.Spec.Parallelism, "parallelism must be >= 1"))
+						}
+						if completionsChanged && newRJob.Template.Spec.Completions != nil && *newRJob.Template.Spec.Completions < 1 {
+							errs = append(errs, field.Invalid(rJobPath.Child("completions"), *newRJob.Template.Spec.Completions, "completions must be >= 1"))
+						}
+						if newRJob.Template.Spec.Parallelism != nil && newRJob.Template.Spec.Completions != nil && *newRJob.Template.Spec.Parallelism != *newRJob.Template.Spec.Completions {
+							errs = append(errs, field.Invalid(rJobPath.Child("completions"), *newRJob.Template.Spec.Completions, "completions must be equal to parallelism for Elastic Indexed Jobs"))
+						}
 					}
 				}
-			}
 
-			// Mask parallelism and completions in mungedSpec to bypass the strict immutability check
-			mungedSpec.ReplicatedJobs[index].Template.Spec.Parallelism = oldRJob.Template.Spec.Parallelism
-			mungedSpec.ReplicatedJobs[index].Template.Spec.Completions = oldRJob.Template.Spec.Completions
+				// Mask parallelism and completions in mungedSpec to bypass the strict immutability check
+				mungedSpec.ReplicatedJobs[index].Template.Spec.Parallelism = oldRJob.Template.Spec.Parallelism
+				mungedSpec.ReplicatedJobs[index].Template.Spec.Completions = oldRJob.Template.Spec.Completions
+			}
 		}
 	}
 
@@ -364,14 +372,22 @@ func (j *jobSetWebhook) ValidateUpdate(ctx context.Context, oldJs, newJs *jobset
 	// This is needed for integration with Kueue/DWS.
 	if ptr.Deref(oldJs.Spec.Suspend, false) || ptr.Deref(newJs.Spec.Suspend, false) {
 		for index := range newJs.Spec.ReplicatedJobs {
+			newRJob := &newJs.Spec.ReplicatedJobs[index]
+
+			// Safely grab the old replicated job by Name to prevent panics on length mismatch
+			oldRJob, exists := oldJobsMap[newRJob.Name]
+			if !exists {
+				continue
+			}
+
 			// Pod values which must be mutable for Kueue are defined here: https://github.com/kubernetes-sigs/kueue/blob/a50d395c36a2cb3965be5232162cf1fded1bdb08/apis/kueue/v1beta1/workload_types.go#L256-L260
-			mungedSpec.ReplicatedJobs[index].Template.Spec.Template.Annotations = oldJs.Spec.ReplicatedJobs[index].Template.Spec.Template.Annotations
-			mungedSpec.ReplicatedJobs[index].Template.Spec.Template.Labels = oldJs.Spec.ReplicatedJobs[index].Template.Spec.Template.Labels
-			mungedSpec.ReplicatedJobs[index].Template.Spec.Template.Spec.NodeSelector = oldJs.Spec.ReplicatedJobs[index].Template.Spec.Template.Spec.NodeSelector
-			mungedSpec.ReplicatedJobs[index].Template.Spec.Template.Spec.Tolerations = oldJs.Spec.ReplicatedJobs[index].Template.Spec.Template.Spec.Tolerations
+			mungedSpec.ReplicatedJobs[index].Template.Spec.Template.Annotations = oldRJob.Template.Spec.Template.Annotations
+			mungedSpec.ReplicatedJobs[index].Template.Spec.Template.Labels = oldRJob.Template.Spec.Template.Labels
+			mungedSpec.ReplicatedJobs[index].Template.Spec.Template.Spec.NodeSelector = oldRJob.Template.Spec.Template.Spec.NodeSelector
+			mungedSpec.ReplicatedJobs[index].Template.Spec.Template.Spec.Tolerations = oldRJob.Template.Spec.Template.Spec.Tolerations
 
 			// Pod Scheduling Gates can be updated for batch/v1 Job: https://github.com/kubernetes/kubernetes/blob/ceb58a4dbc671b9d0a2de6d73a1616bc0c299863/pkg/apis/batch/validation/validation.go#L662
-			mungedSpec.ReplicatedJobs[index].Template.Spec.Template.Spec.SchedulingGates = oldJs.Spec.ReplicatedJobs[index].Template.Spec.Template.Spec.SchedulingGates
+			mungedSpec.ReplicatedJobs[index].Template.Spec.Template.Spec.SchedulingGates = oldRJob.Template.Spec.Template.Spec.SchedulingGates
 		}
 	}
 

--- a/pkg/webhooks/jobset_webhook.go
+++ b/pkg/webhooks/jobset_webhook.go
@@ -348,6 +348,9 @@ func (j *jobSetWebhook) ValidateUpdate(ctx context.Context, oldJs, newJs *jobset
 					if completionsChanged && newRJob.Template.Spec.Completions != nil && *newRJob.Template.Spec.Completions < 1 {
 						errs = append(errs, field.Invalid(rJobPath.Child("completions"), *newRJob.Template.Spec.Completions, "completions must be >= 1"))
 					}
+					if newRJob.Template.Spec.Parallelism != nil && newRJob.Template.Spec.Completions != nil && *newRJob.Template.Spec.Parallelism != *newRJob.Template.Spec.Completions {
+						errs = append(errs, field.Invalid(rJobPath.Child("completions"), *newRJob.Template.Spec.Completions, "completions must be equal to parallelism for Elastic Indexed Jobs"))
+					}
 				}
 			}
 

--- a/pkg/webhooks/jobset_webhook_test.go
+++ b/pkg/webhooks/jobset_webhook_test.go
@@ -3676,7 +3676,7 @@ func TestValidateUpdate(t *testing.T) {
 					ReplicatedJobs: []jobset.ReplicatedJob{
 						{
 							Name:     "test-jobset-replicated-job-0",
-							Replicas: 2, // <--- IMMUTABLE FIELD MODIFIED
+							Replicas: 2, // immutable field modified
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
 									Parallelism: ptr.To[int32](4), // Valid scale operation
@@ -3690,6 +3690,47 @@ func TestValidateUpdate(t *testing.T) {
 				field.Invalid(field.NewPath("spec").Child("replicatedJobs"), "", "field is immutable"),
 			}.ToAggregate(),
 			enableElasticJobSet: true,
+		},
+		{
+			name: "invalid scaling of parallelism and completions when feature gate is disabled",
+			oldJs: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](2),
+									Completions: ptr.To[int32](2),
+								},
+							},
+						},
+					},
+				},
+			},
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](8),
+									Completions: ptr.To[int32](8),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: field.ErrorList{
+				field.Invalid(field.NewPath("spec").Child("replicatedJobs"), "", "field is immutable"),
+			}.ToAggregate(),
+			enableElasticJobSet: false, // Feature gate disabled
 		},
 	}
 

--- a/pkg/webhooks/jobset_webhook_test.go
+++ b/pkg/webhooks/jobset_webhook_test.go
@@ -3461,8 +3461,9 @@ func TestValidateUpdate(t *testing.T) {
 							Replicas: 2,
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
-									Parallelism: ptr.To[int32](2),
-									Completions: ptr.To[int32](2),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
+									Parallelism:    ptr.To[int32](2),
+									Completions:    ptr.To[int32](2),
 								},
 							},
 						},
@@ -3478,8 +3479,9 @@ func TestValidateUpdate(t *testing.T) {
 							Replicas: 2,
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
-									Parallelism: ptr.To[int32](8),
-									Completions: ptr.To[int32](8),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
+									Parallelism:    ptr.To[int32](8),
+									Completions:    ptr.To[int32](8),
 								},
 							},
 						},
@@ -3498,7 +3500,8 @@ func TestValidateUpdate(t *testing.T) {
 							Name: "test-jobset-replicated-job-0",
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
-									Parallelism: ptr.To[int32](2),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
+									Parallelism:    ptr.To[int32](2),
 								},
 							},
 						},
@@ -3513,7 +3516,8 @@ func TestValidateUpdate(t *testing.T) {
 							Name: "test-jobset-replicated-job-0",
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
-									Parallelism: ptr.To[int32](0),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
+									Parallelism:    ptr.To[int32](0),
 								},
 							},
 						},
@@ -3535,7 +3539,8 @@ func TestValidateUpdate(t *testing.T) {
 							Name: "test-jobset-replicated-job-0",
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
-									Completions: ptr.To[int32](2),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
+									Completions:    ptr.To[int32](2),
 								},
 							},
 						},
@@ -3550,7 +3555,8 @@ func TestValidateUpdate(t *testing.T) {
 							Name: "test-jobset-replicated-job-0",
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
-									Completions: ptr.To[int32](0),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
+									Completions:    ptr.To[int32](0),
 								},
 							},
 						},
@@ -3572,7 +3578,8 @@ func TestValidateUpdate(t *testing.T) {
 							Name: "test-jobset-replicated-job-0",
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
-									Parallelism: ptr.To[int32](2),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
+									Parallelism:    ptr.To[int32](2),
 								},
 							},
 						},
@@ -3595,7 +3602,8 @@ func TestValidateUpdate(t *testing.T) {
 							Name: "test-jobset-replicated-job-0",
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
-									Parallelism: ptr.To[int32](4),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
+									Parallelism:    ptr.To[int32](4),
 								},
 							},
 						},
@@ -3617,7 +3625,8 @@ func TestValidateUpdate(t *testing.T) {
 							Name: "test-jobset-replicated-job-0",
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
-									Completions: ptr.To[int32](2),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
+									Completions:    ptr.To[int32](2),
 								},
 							},
 						},
@@ -3640,7 +3649,8 @@ func TestValidateUpdate(t *testing.T) {
 							Name: "test-jobset-replicated-job-0",
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
-									Completions: ptr.To[int32](4),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
+									Completions:    ptr.To[int32](4),
 								},
 							},
 						},
@@ -3663,7 +3673,8 @@ func TestValidateUpdate(t *testing.T) {
 							Replicas: 1,
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
-									Parallelism: ptr.To[int32](2),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
+									Parallelism:    ptr.To[int32](2),
 								},
 							},
 						},
@@ -3679,7 +3690,8 @@ func TestValidateUpdate(t *testing.T) {
 							Replicas: 2, // immutable field modified
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
-									Parallelism: ptr.To[int32](4), // Valid scale operation
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
+									Parallelism:    ptr.To[int32](4), // Valid scale operation
 								},
 							},
 						},
@@ -3743,8 +3755,9 @@ func TestValidateUpdate(t *testing.T) {
 							Replicas: 2,
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
-									Parallelism: ptr.To[int32](2),
-									Completions: ptr.To[int32](2),
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
+									Parallelism:    ptr.To[int32](2),
+									Completions:    ptr.To[int32](2),
 								},
 							},
 						},
@@ -3760,8 +3773,9 @@ func TestValidateUpdate(t *testing.T) {
 							Replicas: 2,
 							Template: batchv1.JobTemplateSpec{
 								Spec: batchv1.JobSpec{
-									Parallelism: ptr.To[int32](4),
-									Completions: ptr.To[int32](5), // mismatch
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
+									Parallelism:    ptr.To[int32](4),
+									Completions:    ptr.To[int32](5), // mismatch
 								},
 							},
 						},
@@ -3770,6 +3784,124 @@ func TestValidateUpdate(t *testing.T) {
 			},
 			want: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "replicatedJobs").Index(0).Child("template", "spec", "completions"), int32(5), "completions must be equal to parallelism for Elastic Indexed Jobs"),
+			}.ToAggregate(),
+			enableElasticJobSet: true,
+		},
+		{
+			name: "adding a new ReplicatedJob while suspended does not panic and is rejected",
+			oldJs: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					Suspend: ptr.To(true),
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "job-a",
+							Template: batchv1.JobTemplateSpec{Spec: batchv1.JobSpec{Parallelism: ptr.To[int32](2)}},
+						},
+					},
+				},
+			},
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					Suspend: ptr.To(true),
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "job-a",
+							Template: batchv1.JobTemplateSpec{Spec: batchv1.JobSpec{Parallelism: ptr.To[int32](2)}},
+						},
+						{
+							Name:     "job-b", // New job added
+							Template: batchv1.JobTemplateSpec{Spec: batchv1.JobSpec{Parallelism: ptr.To[int32](2)}},
+						},
+					},
+				},
+			},
+			want: field.ErrorList{
+				field.Invalid(field.NewPath("spec").Child("replicatedJobs"), "", "field is immutable"),
+			}.ToAggregate(),
+		},
+		{
+			name: "reordering ReplicatedJobs evaluates ElasticJobSet scaling correctly by name",
+			oldJs: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "job-a",
+							Template: batchv1.JobTemplateSpec{Spec: batchv1.JobSpec{Parallelism: ptr.To[int32](2), Completions: ptr.To[int32](2)}},
+						},
+						{
+							Name:     "job-b",
+							Template: batchv1.JobTemplateSpec{Spec: batchv1.JobSpec{Parallelism: ptr.To[int32](2), Completions: ptr.To[int32](2)}},
+						},
+					},
+				},
+			},
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "job-b", // Swapped order
+							Template: batchv1.JobTemplateSpec{Spec: batchv1.JobSpec{Parallelism: ptr.To[int32](2), Completions: ptr.To[int32](2)}},
+						},
+						{
+							Name:     "job-a",
+							Template: batchv1.JobTemplateSpec{Spec: batchv1.JobSpec{Parallelism: ptr.To[int32](4), Completions: ptr.To[int32](4)}}, // Valid scaling operation
+						},
+					},
+				},
+			},
+			want: field.ErrorList{
+				// We do not expect elastic scaling errors (e.g. parallelism mismatch)
+				// proving that the webhook correctly mapped Job A to Job A and Job B to Job B.
+				field.Invalid(field.NewPath("spec").Child("replicatedJobs"), "", "field is immutable"),
+			}.ToAggregate(),
+			enableElasticJobSet: true,
+		},
+		{
+			name: "invalid scaling: immutability enforced for NonIndexed jobs even when ElasticJobSet is enabled",
+			oldJs: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 1,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									CompletionMode: ptr.To(batchv1.NonIndexedCompletion),
+									Parallelism:    ptr.To[int32](2),
+									Completions:    ptr.To[int32](2),
+								},
+							},
+						},
+					},
+				},
+			},
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 1,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									CompletionMode: ptr.To(batchv1.NonIndexedCompletion),
+									Parallelism:    ptr.To[int32](4), // Attempting to scale a NonIndexed job
+									Completions:    ptr.To[int32](4),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: field.ErrorList{
+				// Because it's NonIndexed, the webhook doesn't mask the fields,
+				// so the standard immutability check catches it.
+				field.Invalid(field.NewPath("spec").Child("replicatedJobs"), "", "field is immutable"),
 			}.ToAggregate(),
 			enableElasticJobSet: true,
 		},
@@ -3791,7 +3923,9 @@ func TestValidateUpdate(t *testing.T) {
 
 				for _, cause := range statusErr.ErrStatus.Details.Causes {
 					assert.Contains(t, tc.want.Error(), cause.Field)
-					assert.Contains(t, cause.Message, "field is immutable")
+					parts := strings.Split(cause.Message, ": ")
+					coreReason := parts[len(parts)-1]
+					assert.Contains(t, tc.want.Error(), coreReason)
 				}
 			} else if err != nil && tc.want == nil {
 				t.Errorf("unexpected error: %v", err)

--- a/pkg/webhooks/jobset_webhook_test.go
+++ b/pkg/webhooks/jobset_webhook_test.go
@@ -3449,6 +3449,241 @@ func TestValidateUpdate(t *testing.T) {
 				field.Invalid(field.NewPath("spec").Child("replicatedJobs"), "", "field is immutable"),
 			}.ToAggregate(),
 		},
+		{
+			name: "valid scaling of parallelism and completions",
+			oldJs: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](2),
+									Completions: ptr.To[int32](2),
+								},
+							},
+						},
+					},
+				},
+			},
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](8),
+									Completions: ptr.To[int32](8),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "invalid scaling of parallelism to < 1",
+			oldJs: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name: "test-jobset-replicated-job-0",
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](2),
+								},
+							},
+						},
+					},
+				},
+			},
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name: "test-jobset-replicated-job-0",
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](0),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "replicatedJobs").Index(0).Child("template", "spec", "parallelism"), int32(0), "parallelism must be >= 1"),
+			}.ToAggregate(),
+		},
+		{
+			name: "invalid scaling of completions to < 1",
+			oldJs: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name: "test-jobset-replicated-job-0",
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Completions: ptr.To[int32](2),
+								},
+							},
+						},
+					},
+				},
+			},
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name: "test-jobset-replicated-job-0",
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Completions: ptr.To[int32](0),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "replicatedJobs").Index(0).Child("template", "spec", "completions"), int32(0), "completions must be >= 1"),
+			}.ToAggregate(),
+		},
+		{
+			name: "cannot scale parallelism if JobSet is Completed",
+			oldJs: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name: "test-jobset-replicated-job-0",
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](2),
+								},
+							},
+						},
+					},
+				},
+				Status: jobset.JobSetStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(jobset.JobSetCompleted),
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			},
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name: "test-jobset-replicated-job-0",
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](4),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: field.ErrorList{
+				field.Forbidden(field.NewPath("spec", "replicatedJobs").Index(0).Child("template", "spec"), "Cannot mutate parallelism or completions when JobSet is in a terminal state (Completed or Failed)"),
+			}.ToAggregate(),
+		},
+		{
+			name: "cannot scale completions if JobSet is Failed",
+			oldJs: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name: "test-jobset-replicated-job-0",
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Completions: ptr.To[int32](2),
+								},
+							},
+						},
+					},
+				},
+				Status: jobset.JobSetStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(jobset.JobSetFailed),
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			},
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name: "test-jobset-replicated-job-0",
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Completions: ptr.To[int32](4),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: field.ErrorList{
+				field.Forbidden(field.NewPath("spec", "replicatedJobs").Index(0).Child("template", "spec"), "Cannot mutate parallelism or completions when JobSet is in a terminal state (Completed or Failed)"),
+			}.ToAggregate(),
+		},
+		{
+			name: "immutability still enforced for other fields during valid scale",
+			oldJs: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 1,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](2),
+								},
+							},
+						},
+					},
+				},
+			},
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 2, // <--- IMMUTABLE FIELD MODIFIED
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](4), // Valid scale operation
+								},
+							},
+						},
+					},
+				},
+			},
+			want: field.ErrorList{
+				field.Invalid(field.NewPath("spec").Child("replicatedJobs"), "", "field is immutable"),
+			}.ToAggregate(),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/webhooks/jobset_webhook_test.go
+++ b/pkg/webhooks/jobset_webhook_test.go
@@ -3130,10 +3130,11 @@ func TestValidateUpdate(t *testing.T) {
 		},
 	}
 	testCases := []struct {
-		name  string
-		oldJs *jobset.JobSet
-		js    *jobset.JobSet
-		want  error
+		name                string
+		oldJs               *jobset.JobSet
+		js                  *jobset.JobSet
+		want                error
+		enableElasticJobSet bool
 	}{
 		{
 			name: "update suspend",
@@ -3485,6 +3486,7 @@ func TestValidateUpdate(t *testing.T) {
 					},
 				},
 			},
+			enableElasticJobSet: true,
 		},
 		{
 			name: "invalid scaling of parallelism to < 1",
@@ -3521,6 +3523,7 @@ func TestValidateUpdate(t *testing.T) {
 			want: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "replicatedJobs").Index(0).Child("template", "spec", "parallelism"), int32(0), "parallelism must be >= 1"),
 			}.ToAggregate(),
+			enableElasticJobSet: true,
 		},
 		{
 			name: "invalid scaling of completions to < 1",
@@ -3557,6 +3560,7 @@ func TestValidateUpdate(t *testing.T) {
 			want: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "replicatedJobs").Index(0).Child("template", "spec", "completions"), int32(0), "completions must be >= 1"),
 			}.ToAggregate(),
+			enableElasticJobSet: true,
 		},
 		{
 			name: "cannot scale parallelism if JobSet is Completed",
@@ -3601,6 +3605,7 @@ func TestValidateUpdate(t *testing.T) {
 			want: field.ErrorList{
 				field.Forbidden(field.NewPath("spec", "replicatedJobs").Index(0).Child("template", "spec"), "Cannot mutate parallelism or completions when JobSet is in a terminal state (Completed or Failed)"),
 			}.ToAggregate(),
+			enableElasticJobSet: true,
 		},
 		{
 			name: "cannot scale completions if JobSet is Failed",
@@ -3645,6 +3650,7 @@ func TestValidateUpdate(t *testing.T) {
 			want: field.ErrorList{
 				field.Forbidden(field.NewPath("spec", "replicatedJobs").Index(0).Child("template", "spec"), "Cannot mutate parallelism or completions when JobSet is in a terminal state (Completed or Failed)"),
 			}.ToAggregate(),
+			enableElasticJobSet: true,
 		},
 		{
 			name: "immutability still enforced for other fields during valid scale",
@@ -3683,6 +3689,7 @@ func TestValidateUpdate(t *testing.T) {
 			want: field.ErrorList{
 				field.Invalid(field.NewPath("spec").Child("replicatedJobs"), "", "field is immutable"),
 			}.ToAggregate(),
+			enableElasticJobSet: true,
 		},
 	}
 
@@ -3690,6 +3697,7 @@ func TestValidateUpdate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			fakeClient := fake.NewFakeClient()
 			webhook := &jobSetWebhook{client: fakeClient}
+			features.SetFeatureGateDuringTest(t, features.ElasticJobSet, tc.enableElasticJobSet)
 			newObj := tc.js.DeepCopy()
 			oldObj := tc.oldJs.DeepCopy()
 			_, err := webhook.ValidateUpdate(context.TODO(), oldObj, newObj)

--- a/pkg/webhooks/jobset_webhook_test.go
+++ b/pkg/webhooks/jobset_webhook_test.go
@@ -3732,6 +3732,47 @@ func TestValidateUpdate(t *testing.T) {
 			}.ToAggregate(),
 			enableElasticJobSet: false, // Feature gate disabled
 		},
+		{
+			name: "invalid scaling: parallelism and completions must be equal",
+			oldJs: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](2),
+									Completions: ptr.To[int32](2),
+								},
+							},
+						},
+					},
+				},
+			},
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](4),
+									Completions: ptr.To[int32](5), // mismatch
+								},
+							},
+						},
+					},
+				},
+			},
+			want: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "replicatedJobs").Index(0).Child("template", "spec", "completions"), int32(5), "completions must be equal to parallelism for Elastic Indexed Jobs"),
+			}.ToAggregate(),
+			enableElasticJobSet: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -2854,75 +2854,7 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 				},
 			},
 		}),
-		ginkgo.Entry("dynamic horizontal pod scaling propagates parallelism and completions to child jobs", &testCase{
-			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
-				return testing.MakeJobSet("elastic-js", ns.Name).
-					SuccessPolicy(&jobset.SuccessPolicy{Operator: jobset.OperatorAll, TargetReplicatedJobs: []string{}}).
-					ReplicatedJob(testing.MakeReplicatedJob("workers").
-						Job(testing.MakeJobTemplate("job", ns.Name).
-							PodSpec(testing.TestPodSpec).
-							CompletionMode(batchv1.IndexedCompletion).
-							Parallelism(2).
-							Completions(2).
-							Obj()).
-						Replicas(1).
-						Obj())
-			},
-			steps: []*step{
-				{
-					// Step 1: Wait for the initial job to be created and verify its parallelism/completions.
-					checkJobSetState: func(js *jobset.JobSet) {
-						gomega.Eventually(func() (bool, error) {
-							var jobList batchv1.JobList
-							if err := k8sClient.List(ctx, &jobList, client.InNamespace(js.Namespace)); err != nil {
-								return false, err
-							}
-							if len(jobList.Items) != 1 {
-								return false, nil
-							}
-							p := ptr.Deref(jobList.Items[0].Spec.Parallelism, 0)
-							c := ptr.Deref(jobList.Items[0].Spec.Completions, 0)
-							return p == 2 && c == 2, nil
-						}, timeout, interval).Should(gomega.BeTrue())
-					},
-				},
-				{
-					// Step 2: Simulate an external scaling operation.
-					jobSetUpdateFn: func(js *jobset.JobSet) {
-						var latestJS jobset.JobSet
-						err := k8sClient.Get(ctx, client.ObjectKeyFromObject(js), &latestJS)
-						gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to fetch latest JobSet")
-
-						// Mutating Parallelism and Completions locally and forcing the update to the cluster
-						latestJS.Spec.ReplicatedJobs[0].Template.Spec.Parallelism = ptr.To[int32](4)
-						latestJS.Spec.ReplicatedJobs[0].Template.Spec.Completions = ptr.To[int32](4)
-
-						err = k8sClient.Update(ctx, &latestJS)
-						gomega.Expect(err).NotTo(gomega.HaveOccurred(), "API Server rejected the JobSet update")
-
-						// Update the local pointer so the test framework has the correct ResourceVersion
-						*js = latestJS
-					},
-					// Step 3: Verify the controller caught the update and patched the child job in-place.
-					checkJobSetState: func(js *jobset.JobSet) {
-						ginkgo.By("checking child jobs are patched with new parallelism and completions")
-						gomega.Eventually(func() (bool, error) {
-							var jobList batchv1.JobList
-							if err := k8sClient.List(ctx, &jobList, client.InNamespace(js.Namespace)); err != nil {
-								return false, err
-							}
-							if len(jobList.Items) != 1 {
-								return false, nil
-							}
-							p := ptr.Deref(jobList.Items[0].Spec.Parallelism, 0)
-							c := ptr.Deref(jobList.Items[0].Spec.Completions, 0)
-							return p == 4 && c == 4, nil
-						}, timeout, interval).Should(gomega.BeTrue())
-					},
-				},
-			},
-		}),
-	) // end of DescribeTable
+	)
 
 	ginkgo.When("A JobSet is managed by another controller", ginkgo.Ordered, func() {
 		var (
@@ -3152,6 +3084,243 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 			}, timeout, interval).Should(gomega.BeTrue())
 		})
 	})
+
+	ginkgo.When("the ElasticJobSet feature gate is enabled", func() {
+
+		ginkgo.BeforeEach(func() {
+			err := features.SetEnable(features.ElasticJobSet, true)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.AfterEach(func() {
+			err := features.SetEnable(features.ElasticJobSet, false)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.DescribeTable("Elastic scaling behavior",
+			func(tc *testCase) {
+				ctx := context.Background()
+				// Create test namespace for each entry.
+				ns := &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "jobset-ns-",
+					},
+				}
+				gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+
+				defer func() {
+					gomega.Expect(testutil.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+				}()
+
+				// Create JobSet.
+				js := tc.makeJobSet(ns).Obj()
+
+				// Verify jobset created successfully.
+				ginkgo.By(fmt.Sprintf("creating jobSet %s/%s", js.Name, js.Namespace))
+				gomega.Eventually(func() error {
+					return k8sClient.Create(ctx, js)
+				}, timeout, interval).Should(gomega.Succeed())
+
+				if !tc.skipCreationCheck {
+					ginkgo.By("checking all jobs were created successfully")
+					gomega.Eventually(testutil.NumJobs, timeout, interval).WithArguments(ctx, k8sClient, js).Should(gomega.Equal(testutil.NumExpectedJobs(js)))
+				}
+
+				// Perform a series of updates to jobset resources and check resulting jobset state after each update.
+				for _, up := range tc.steps {
+					var jobSet jobset.JobSet
+					gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: js.Name, Namespace: js.Namespace}, &jobSet)).To(gomega.Succeed())
+
+					if up.jobSetUpdateFn != nil {
+						up.jobSetUpdateFn(&jobSet)
+					} else if up.jobUpdateFn != nil {
+						if up.checkJobCreation == nil {
+							gomega.Eventually(testutil.NumJobs, timeout, interval).WithArguments(ctx, k8sClient, js).Should(gomega.Equal(testutil.NumExpectedJobs(js)))
+						} else {
+							up.checkJobCreation(&jobSet)
+						}
+						// Fetch updated job objects so we always have the latest resource versions to perform mutations on.
+						var jobList batchv1.JobList
+						gomega.Expect(k8sClient.List(ctx, &jobList, client.InNamespace(js.Namespace))).Should(gomega.Succeed())
+						up.jobUpdateFn(&jobList)
+					}
+
+					if up.checkJobSetState != nil {
+						up.checkJobSetState(&jobSet)
+					}
+
+					if up.checkJobSetCondition != nil {
+						up.checkJobSetCondition(ctx, k8sClient, &jobSet, timeout)
+					}
+				}
+			},
+			ginkgo.Entry("dynamic horizontal pod scaling propagates parallelism and completions to child jobs", &testCase{
+				makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+					return testing.MakeJobSet("elastic-js", ns.Name).
+						SuccessPolicy(&jobset.SuccessPolicy{Operator: jobset.OperatorAll, TargetReplicatedJobs: []string{}}).
+						ReplicatedJob(testing.MakeReplicatedJob("workers").
+							Job(testing.MakeJobTemplate("job", ns.Name).
+								PodSpec(corev1.PodSpec{
+									RestartPolicy: "Never",
+									Containers: []corev1.Container{
+										{
+											Name:    "test-container",
+											Image:   "busybox:latest",
+											Command: []string{"sleep", "10"},
+										},
+									},
+								}).
+								CompletionMode(batchv1.IndexedCompletion).
+								Parallelism(2).
+								Completions(2).
+								Obj()).
+							Replicas(1).
+							Obj())
+				},
+				steps: []*step{
+					{
+						// Step 1: Wait for the initial job to be created and verify its parallelism/completions.
+						checkJobSetState: func(js *jobset.JobSet) {
+							gomega.Eventually(func() (bool, error) {
+								var jobList batchv1.JobList
+								if err := k8sClient.List(ctx, &jobList, client.InNamespace(js.Namespace)); err != nil {
+									return false, err
+								}
+								if len(jobList.Items) != 1 {
+									return false, nil
+								}
+								p := ptr.Deref(jobList.Items[0].Spec.Parallelism, 0)
+								c := ptr.Deref(jobList.Items[0].Spec.Completions, 0)
+								return p == 2 && c == 2, nil
+							}, timeout, interval).Should(gomega.BeTrue())
+						},
+					},
+					{
+						// Step 2: Simulate an external scaling operation.
+						jobSetUpdateFn: func(js *jobset.JobSet) {
+							var latestJS jobset.JobSet
+							err := k8sClient.Get(ctx, client.ObjectKeyFromObject(js), &latestJS)
+							gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to fetch latest JobSet")
+
+							// Mutating Parallelism and Completions locally and forcing the update to the cluster
+							latestJS.Spec.ReplicatedJobs[0].Template.Spec.Parallelism = ptr.To[int32](4)
+							latestJS.Spec.ReplicatedJobs[0].Template.Spec.Completions = ptr.To[int32](4)
+
+							err = k8sClient.Update(ctx, &latestJS)
+							gomega.Expect(err).NotTo(gomega.HaveOccurred(), "API Server rejected the JobSet update")
+
+							// Update the local pointer so the test framework has the correct ResourceVersion
+							*js = latestJS
+						},
+						// Step 3: Verify the controller caught the update and patched the child job in-place.
+						checkJobSetState: func(js *jobset.JobSet) {
+							ginkgo.By("checking child jobs are patched with new parallelism and completions")
+							gomega.Eventually(func() (bool, error) {
+								var jobList batchv1.JobList
+								if err := k8sClient.List(ctx, &jobList, client.InNamespace(js.Namespace)); err != nil {
+									return false, err
+								}
+								if len(jobList.Items) != 1 {
+									return false, nil
+								}
+								p := ptr.Deref(jobList.Items[0].Spec.Parallelism, 0)
+								c := ptr.Deref(jobList.Items[0].Spec.Completions, 0)
+								return p == 4 && c == 4, nil
+							}, timeout, interval).Should(gomega.BeTrue())
+						},
+					},
+				},
+			}),
+		)
+	})
+
+	ginkgo.When("the ElasticJobSet feature gate is disabled", func() {
+
+		ginkgo.BeforeEach(func() {
+			// Explicitly turn the feature gate OFF
+			err := features.SetEnable(features.ElasticJobSet, false)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.DescribeTable("Elastic scaling behavior is blocked",
+			func(tc *testCase) {
+				ctx := context.Background()
+				ns := &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "jobset-ns-",
+					},
+				}
+				gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+
+				defer func() {
+					gomega.Expect(testutil.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+				}()
+
+				js := tc.makeJobSet(ns).Obj()
+
+				ginkgo.By(fmt.Sprintf("creating jobSet %s/%s", js.Name, js.Namespace))
+				gomega.Eventually(func() error {
+					return k8sClient.Create(ctx, js)
+				}, timeout, interval).Should(gomega.Succeed())
+
+				if !tc.skipCreationCheck {
+					gomega.Eventually(testutil.NumJobs, timeout, interval).WithArguments(ctx, k8sClient, js).Should(gomega.Equal(testutil.NumExpectedJobs(js)))
+				}
+
+				for _, up := range tc.steps {
+					var jobSet jobset.JobSet
+					gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: js.Name, Namespace: js.Namespace}, &jobSet)).To(gomega.Succeed())
+
+					if up.jobSetUpdateFn != nil {
+						up.jobSetUpdateFn(&jobSet)
+					}
+				}
+			},
+			ginkgo.Entry("rejects updates to parallelism and completions", &testCase{
+				makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+					return testing.MakeJobSet("elastic-js-disabled", ns.Name).
+						SuccessPolicy(&jobset.SuccessPolicy{Operator: jobset.OperatorAll, TargetReplicatedJobs: []string{}}).
+						ReplicatedJob(testing.MakeReplicatedJob("workers").
+							Job(testing.MakeJobTemplate("job", ns.Name).
+								PodSpec(corev1.PodSpec{
+									RestartPolicy: "Never",
+									Containers: []corev1.Container{
+										{
+											Name:    "test-container",
+											Image:   "busybox:latest",
+											Command: []string{"sleep", "10"},
+										},
+									},
+								}).
+								CompletionMode(batchv1.IndexedCompletion).
+								Parallelism(2).
+								Completions(2).
+								Obj()).
+							Replicas(1).
+							Obj())
+				},
+				steps: []*step{
+					{
+						// Attempt an external scaling operation.
+						jobSetUpdateFn: func(js *jobset.JobSet) {
+							var latestJS jobset.JobSet
+							err := k8sClient.Get(ctx, client.ObjectKeyFromObject(js), &latestJS)
+							gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to fetch latest JobSet")
+
+							// Try to mutate Parallelism and Completions
+							latestJS.Spec.ReplicatedJobs[0].Template.Spec.Parallelism = ptr.To[int32](4)
+							latestJS.Spec.ReplicatedJobs[0].Template.Spec.Completions = ptr.To[int32](4)
+
+							err = k8sClient.Update(ctx, &latestJS)
+
+							gomega.Expect(err).To(gomega.HaveOccurred(), "API Server should reject the JobSet update when ElasticJobSet feature gate is disabled")
+						},
+					},
+				},
+			}),
+		)
+	})
+
 }) // end of Describe
 
 func makeAllJobsReady(jl *batchv1.JobList) {

--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -2854,6 +2854,74 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 				},
 			},
 		}),
+		ginkgo.Entry("dynamic horizontal pod scaling propagates parallelism and completions to child jobs", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("elastic-js", ns.Name).
+					SuccessPolicy(&jobset.SuccessPolicy{Operator: jobset.OperatorAll, TargetReplicatedJobs: []string{}}).
+					ReplicatedJob(testing.MakeReplicatedJob("workers").
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							PodSpec(testing.TestPodSpec).
+							CompletionMode(batchv1.IndexedCompletion).
+							Parallelism(2).
+							Completions(2).
+							Obj()).
+						Replicas(1).
+						Obj())
+			},
+			steps: []*step{
+				{
+					// Step 1: Wait for the initial job to be created and verify its parallelism/completions.
+					checkJobSetState: func(js *jobset.JobSet) {
+						gomega.Eventually(func() (bool, error) {
+							var jobList batchv1.JobList
+							if err := k8sClient.List(ctx, &jobList, client.InNamespace(js.Namespace)); err != nil {
+								return false, err
+							}
+							if len(jobList.Items) != 1 {
+								return false, nil
+							}
+							p := ptr.Deref(jobList.Items[0].Spec.Parallelism, 0)
+							c := ptr.Deref(jobList.Items[0].Spec.Completions, 0)
+							return p == 2 && c == 2, nil
+						}, timeout, interval).Should(gomega.BeTrue())
+					},
+				},
+				{
+					// Step 2: Simulate an external scaling operation.
+					jobSetUpdateFn: func(js *jobset.JobSet) {
+						var latestJS jobset.JobSet
+						err := k8sClient.Get(ctx, client.ObjectKeyFromObject(js), &latestJS)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to fetch latest JobSet")
+
+						// Mutating Parallelism and Completions locally and forcing the update to the cluster
+						latestJS.Spec.ReplicatedJobs[0].Template.Spec.Parallelism = ptr.To[int32](4)
+						latestJS.Spec.ReplicatedJobs[0].Template.Spec.Completions = ptr.To[int32](4)
+
+						err = k8sClient.Update(ctx, &latestJS)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred(), "API Server rejected the JobSet update")
+
+						// Update the local pointer so the test framework has the correct ResourceVersion
+						*js = latestJS
+					},
+					// Step 3: Verify the controller caught the update and patched the child job in-place.
+					checkJobSetState: func(js *jobset.JobSet) {
+						ginkgo.By("checking child jobs are patched with new parallelism and completions")
+						gomega.Eventually(func() (bool, error) {
+							var jobList batchv1.JobList
+							if err := k8sClient.List(ctx, &jobList, client.InNamespace(js.Namespace)); err != nil {
+								return false, err
+							}
+							if len(jobList.Items) != 1 {
+								return false, nil
+							}
+							p := ptr.Deref(jobList.Items[0].Spec.Parallelism, 0)
+							c := ptr.Deref(jobList.Items[0].Spec.Completions, 0)
+							return p == 4 && c == 4, nil
+						}, timeout, interval).Should(gomega.BeTrue())
+					},
+				},
+			},
+		}),
 	) // end of DescribeTable
 
 	ginkgo.When("A JobSet is managed by another controller", ginkgo.Ordered, func() {

--- a/test/integration/controller/suite_test.go
+++ b/test/integration/controller/suite_test.go
@@ -31,7 +31,6 @@ import (
 
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 	"sigs.k8s.io/jobset/pkg/controllers"
-	"sigs.k8s.io/jobset/pkg/features"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -58,10 +57,6 @@ func TestAPIs(t *testing.T) {
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
-	var err error
-	err = features.SetEnable(features.ElasticJobSet, true)
-	Expect(err).NotTo(HaveOccurred())
-
 	ctx, cancel = context.WithCancel(context.Background())
 
 	By("bootstrapping test environment")
@@ -70,6 +65,7 @@ var _ = BeforeSuite(func() {
 		ErrorIfCRDPathMissing: true,
 	}
 
+	var err error
 	// cfg is defined in this file globally.
 	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())

--- a/test/integration/controller/suite_test.go
+++ b/test/integration/controller/suite_test.go
@@ -31,6 +31,7 @@ import (
 
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 	"sigs.k8s.io/jobset/pkg/controllers"
+	"sigs.k8s.io/jobset/pkg/features"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -57,6 +58,10 @@ func TestAPIs(t *testing.T) {
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
+	var err error
+	err = features.SetEnable(features.ElasticJobSet, true)
+	Expect(err).NotTo(HaveOccurred())
+
 	ctx, cancel = context.WithCancel(context.Background())
 
 	By("bootstrapping test environment")
@@ -65,7 +70,6 @@ var _ = BeforeSuite(func() {
 		ErrorIfCRDPathMissing: true,
 	}
 
-	var err error
 	// cfg is defined in this file globally.
 	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())

--- a/test/integration/webhook/jobset_webhook_test.go
+++ b/test/integration/webhook/jobset_webhook_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+	"sigs.k8s.io/jobset/pkg/features"
 	"sigs.k8s.io/jobset/pkg/util/testing"
 	"sigs.k8s.io/jobset/test/util"
 )
@@ -45,6 +46,10 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 	var ns *corev1.Namespace
 
 	ginkgo.BeforeEach(func() {
+
+		// Ensure feature gate is off by default for all standard tests
+		_ = features.SetEnable(features.ElasticJobSet, false)
+
 		// Create test namespace before each test.
 		ns = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -73,6 +78,7 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 		defaultsApplied          func(*jobset.JobSet) bool
 		updateJobSet             func(set *jobset.JobSet)
 		updateShouldFail         bool
+		expectedUpdateError      string
 	}
 
 	ginkgo.DescribeTable("jobset webhook tests",
@@ -101,11 +107,15 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 
 			if tc.updateJobSet != nil {
 				tc.updateJobSet(&fetchedJS)
+				err := k8sClient.Update(ctx, &fetchedJS)
 				// Verify jobset created successfully.
 				if tc.updateShouldFail {
-					gomega.Expect(k8sClient.Update(ctx, &fetchedJS)).Should(gomega.Not(gomega.Succeed()))
+					gomega.Expect(err).Should(gomega.HaveOccurred())
+					if tc.expectedUpdateError != "" {
+						gomega.Expect(err.Error()).Should(gomega.ContainSubstring(tc.expectedUpdateError))
+					}
 				} else {
-					gomega.Expect(k8sClient.Update(ctx, &fetchedJS)).Should(gomega.Succeed())
+					gomega.Expect(err).Should(gomega.Succeed())
 				}
 			}
 		},
@@ -752,6 +762,45 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 						Obj())
 			},
 			jobSetCreationShouldFail: true,
+		}),
+		ginkgo.Entry("validate updating parallelism and completions is ALLOWED when ElasticJobSet is enabled", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("elastic-js-webhook-enabled", ns.Name).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob").
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							PodSpec(testing.TestPodSpec).
+							CompletionMode(batchv1.IndexedCompletion).
+							Parallelism(2).
+							Completions(2).Obj()).
+						Obj())
+			},
+			updateJobSet: func(js *jobset.JobSet) {
+				// Turn the feature gate ON just before we hit the update webhook
+				_ = features.SetEnable(features.ElasticJobSet, true)
+				js.Spec.ReplicatedJobs[0].Template.Spec.Parallelism = ptr.To[int32](4)
+				js.Spec.ReplicatedJobs[0].Template.Spec.Completions = ptr.To[int32](4)
+			},
+			updateShouldFail: false,
+		}),
+		ginkgo.Entry("validate updating parallelism and completions FAILS when ElasticJobSet is disabled", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("elastic-js-webhook-disabled", ns.Name).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob").
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							PodSpec(testing.TestPodSpec).
+							CompletionMode(batchv1.IndexedCompletion).
+							Parallelism(2).
+							Completions(2).Obj()).
+						Obj())
+			},
+			updateJobSet: func(js *jobset.JobSet) {
+				// Ensure the feature gate is OFF (testing the default behavior)
+				_ = features.SetEnable(features.ElasticJobSet, false)
+				js.Spec.ReplicatedJobs[0].Template.Spec.Parallelism = ptr.To[int32](4)
+				js.Spec.ReplicatedJobs[0].Template.Spec.Completions = ptr.To[int32](4)
+			},
+			updateShouldFail:    true,
+			expectedUpdateError: "field is immutable",
 		}),
 	) // end of DescribeTable
 }) // end of Describe

--- a/test/integration/webhook/jobset_webhook_test.go
+++ b/test/integration/webhook/jobset_webhook_test.go
@@ -48,7 +48,8 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 	ginkgo.BeforeEach(func() {
 
 		// Ensure feature gate is off by default for all standard tests
-		_ = features.SetEnable(features.ElasticJobSet, false)
+		err := features.SetEnable(features.ElasticJobSet, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Create test namespace before each test.
 		ns = &corev1.Namespace{
@@ -776,11 +777,76 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 			},
 			updateJobSet: func(js *jobset.JobSet) {
 				// Turn the feature gate ON just before we hit the update webhook
-				_ = features.SetEnable(features.ElasticJobSet, true)
+				err := features.SetEnable(features.ElasticJobSet, true)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 				js.Spec.ReplicatedJobs[0].Template.Spec.Parallelism = ptr.To[int32](4)
 				js.Spec.ReplicatedJobs[0].Template.Spec.Completions = ptr.To[int32](4)
 			},
 			updateShouldFail: false,
+		}),
+		ginkgo.Entry("validate updating parallelism and completions FAILS when values are not equal", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("elastic-js-webhook-unequal", ns.Name).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob").
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							PodSpec(testing.TestPodSpec).
+							CompletionMode(batchv1.IndexedCompletion).
+							Parallelism(2).
+							Completions(2).Obj()).
+						Obj())
+			},
+			updateJobSet: func(js *jobset.JobSet) {
+				err := features.SetEnable(features.ElasticJobSet, true)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				js.Spec.ReplicatedJobs[0].Template.Spec.Parallelism = ptr.To[int32](4)
+				js.Spec.ReplicatedJobs[0].Template.Spec.Completions = ptr.To[int32](5) // Mismatched values
+			},
+			updateShouldFail:    true,
+			expectedUpdateError: "completions must be equal to parallelism for Elastic Indexed Jobs",
+		}),
+		ginkgo.Entry("validate updating parallelism and completions FAILS for NonIndexed jobs", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("elastic-js-webhook-nonindexed", ns.Name).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob").
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							PodSpec(testing.TestPodSpec).
+							CompletionMode(batchv1.NonIndexedCompletion).
+							Parallelism(2).
+							Completions(2).Obj()).
+						Obj())
+			},
+			updateJobSet: func(js *jobset.JobSet) {
+				err := features.SetEnable(features.ElasticJobSet, true)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				js.Spec.ReplicatedJobs[0].Template.Spec.Parallelism = ptr.To[int32](4)
+				js.Spec.ReplicatedJobs[0].Template.Spec.Completions = ptr.To[int32](4)
+			},
+			updateShouldFail:    true,
+			expectedUpdateError: "field is immutable", // Webhook should reject
+		}),
+		ginkgo.Entry("validate updating parallelism and completions FAILS when scaling to < 1", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("elastic-js-webhook-zero", ns.Name).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob").
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							PodSpec(testing.TestPodSpec).
+							CompletionMode(batchv1.IndexedCompletion).
+							Parallelism(2).
+							Completions(2).Obj()).
+						Obj())
+			},
+			updateJobSet: func(js *jobset.JobSet) {
+				err := features.SetEnable(features.ElasticJobSet, true)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				js.Spec.ReplicatedJobs[0].Template.Spec.Parallelism = ptr.To[int32](0) // Invalid scale
+				js.Spec.ReplicatedJobs[0].Template.Spec.Completions = ptr.To[int32](0)
+			},
+			updateShouldFail:    true,
+			expectedUpdateError: "parallelism must be >= 1",
 		}),
 		ginkgo.Entry("validate updating parallelism and completions FAILS when ElasticJobSet is disabled", &testCase{
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
@@ -795,7 +861,9 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 			},
 			updateJobSet: func(js *jobset.JobSet) {
 				// Ensure the feature gate is OFF (testing the default behavior)
-				_ = features.SetEnable(features.ElasticJobSet, false)
+				err := features.SetEnable(features.ElasticJobSet, false)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 				js.Spec.ReplicatedJobs[0].Template.Spec.Parallelism = ptr.To[int32](4)
 				js.Spec.ReplicatedJobs[0].Template.Spec.Completions = ptr.To[int32](4)
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/kind api-change

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR implements the pod-level horizontal scaling capabilities outlined in KEP-#463 (Support Elastic JobSets)

Currently, large-scale elastic distributed training workloads require the ability to dynamically scale worker counts up and down in response to hardware failures or resource availability. Previously, JobSet rejected these changes as the entire template was strictly immutable. 

This PR enables elasticity by:

1. Webhook Updates: Relaxing the strict immutability constraint on `parallelism` and `completions`, allowing these specific fields to be mutated mid-run.

2. Constraints: Adding webhook validation to ensure scaling fields are strictly >= 1 and blocking any scaling mutations if the JobSet has already reached a terminal state (Completed or Failed).

3. Controller Synchronization: Through `syncJobScaling`, the controller now detects scaling drift and issues opportunistic in-place PATCH requests to synchronize the active child Jobs with the updated JobSet template.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #463 

#### Special notes for your reviewer:

1. As defined in the KEP, this PR strictly focuses on Pod-level scaling (Elastic Indexed Jobs via KEP-3715). Horizontal Job Scaling (mutating `replicas`) is intentionally deferred to future work.

2. Feature Gate: All new webhook immutability bypasses and controller patching logic are wrapped behind the new `ElasticJobSet` feature gate (Alpha, disabled by default).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```
Users can now dynamically scale the number of pods in a running JobSet by updating the `parallelism` and `completions` fields of a ReplicatedJob template. Updates are seamlessly propagated to active child Jobs in-place. JobSets in a terminal state (Completed or Failed) will reject scaling requests.
```