### PR TITLE
Add more golangci-lint linters and fix misspellings

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,13 @@
 version: "2"
 linters:
   enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - misspell
+    - nilerr
+    - staticcheck
+    - unconvert
     - unparam
   exclusions:
     generated: lax

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -658,7 +658,7 @@ func (r *JobSetReconciler) createJobs(ctx context.Context, js *jobset.JobSet, jo
 	workqueue.ParallelizeUntil(ctx, constants.MaxParallelism, len(jobs), func(i int) {
 		job := jobs[i]
 
-		// Set jobset controller as owner of the job for garbage collection and reconcilation.
+		// Set jobset controller as owner of the job for garbage collection and reconciliation.
 		if err := ctrl.SetControllerReference(js, job, r.Scheme); err != nil {
 			lock.Lock()
 			defer lock.Unlock()
@@ -739,7 +739,7 @@ func (r *JobSetReconciler) createHeadlessSvcIfNecessary(ctx context.Context, js 
 			},
 		}
 
-		// Set controller owner reference for garbage collection and reconcilation.
+		// Set controller owner reference for garbage collection and reconciliation.
 		if err := ctrl.SetControllerReference(js, &headlessSvc, r.Scheme); err != nil {
 			return err
 		}
@@ -1014,7 +1014,7 @@ func managedByExternalController(js *jobset.JobSet) *string {
 }
 
 // enqueueEvent appends a new k8s event to be emitted if and only after running the status
-// update functions in the updateStatusOpts, the status update API call suceeds.
+// update functions in the updateStatusOpts, the status update API call succeeds.
 func enqueueEvent(updateStatusOpts *statusUpdateOpts, event *eventParams) {
 	updateStatusOpts.events = append(updateStatusOpts.events, event)
 }

--- a/pkg/controllers/startup_policy_test.go
+++ b/pkg/controllers/startup_policy_test.go
@@ -80,7 +80,7 @@ func TestReplicatedJobStarted(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "replicas 4; replicatedJobStatus mix of ready, failed and succeded",
+			name:     "replicas 4; replicatedJobStatus mix of ready, failed and succeeded",
 			replicas: 4,
 			replicatedJobStatus: &jobset.ReplicatedJobStatus{
 				Name:      "test",


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Enables 7 additional golangci-lint linters (`errcheck`, `govet`, `ineffassign`, `misspell`, `nilerr`, `staticcheck`, `unconvert`) in `.golangci.yaml`. These are low-noise, high-signal linters widely used across kubernetes-sigs projects.

Also fixes 4 misspellings caught by the `misspell` linter:
- `reconcilation` → `reconciliation` (2 occurrences in `jobset_controller.go`)
- `suceeds` → `succeeds` (1 occurrence in `jobset_controller.go`)
- `succeded` → `succeeded` (1 occurrence in `startup_policy_test.go`)

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

`make ci-lint` passes with 0 issues.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```