### PR TITLE
Add jobset.sigs.k8s.io/skip-suspend-reconciliation

### DIFF
--- a/api/jobset/v1alpha2/jobset_types.go
+++ b/api/jobset/v1alpha2/jobset_types.go
@@ -97,10 +97,11 @@ const (
 	// downgrading the JobSet CRD to a version that does not support in-place restart
 	DisableInPlaceRestartKey string = "jobset.sigs.k8s.io/disable-in-place-restart"
 
-	// SkipSuspendReconciliationAnnotation is a JobSet annotation that, if "true", instructs the JobSet controller
-	// to not reconcile the suspend state of the JobSet onto its child Jobs.
+	// ReconciliationModeAnnotation is a JobSet annotation that, if set to "Independent" (ReconciliationModeIndependent),
+	// instructs the JobSet controller to not reconcile the suspend state of the JobSet onto its child Jobs.
 	// This also forces the JobSet suspend field to be nil.
-	SkipSuspendReconciliationAnnotation string = "jobset.sigs.k8s.io/skip-suspend-reconciliation"
+	ReconciliationModeAnnotation  string = "jobset.sigs.k8s.io/reconciliation-mode"
+	ReconciliationModeIndependent string = "Independent"
 )
 
 type JobSetConditionType string

--- a/hack/python-sdk/swagger.json
+++ b/hack/python-sdk/swagger.json
@@ -133,7 +133,7 @@
         "metadata": {
           "description": "metadata is the object metadata for JobSet",
           "default": {},
-          "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.35.1/api/openapi-spec/swagger.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+          "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.35.2/api/openapi-spec/swagger.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
         },
         "spec": {
           "description": "spec is the specification for jobset",
@@ -171,7 +171,7 @@
         },
         "metadata": {
           "default": {},
-          "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.35.1/api/openapi-spec/swagger.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+          "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.35.2/api/openapi-spec/swagger.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
         }
       }
     },
@@ -244,7 +244,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.35.1/api/openapi-spec/swagger.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
+            "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.35.2/api/openapi-spec/swagger.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
           },
           "x-kubernetes-list-map-keys": [
             "type"
@@ -343,7 +343,7 @@
         "template": {
           "description": "template defines the template of the Job that will be created.",
           "default": {},
-          "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.35.1/api/openapi-spec/swagger.json#/definitions/io.k8s.api.batch.v1.JobTemplateSpec"
+          "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.35.2/api/openapi-spec/swagger.json#/definitions/io.k8s.api.batch.v1.JobTemplateSpec"
         }
       }
     },
@@ -444,7 +444,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.35.1/api/openapi-spec/swagger.json#/definitions/io.k8s.api.core.v1.PersistentVolumeClaim"
+            "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.35.2/api/openapi-spec/swagger.json#/definitions/io.k8s.api.core.v1.PersistentVolumeClaim"
           },
           "x-kubernetes-list-type": "atomic"
         }

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -996,8 +996,8 @@ func jobSetSuspended(js *jobset.JobSet) bool {
 }
 
 func ShouldSkipSuspendReconciliation(js *jobset.JobSet) bool {
-	val, ok := js.Annotations[jobset.SkipSuspendReconciliationAnnotation]
-	return ok && val == "true"
+	val, ok := js.Annotations[jobset.ReconciliationModeAnnotation]
+	return ok && val == jobset.ReconciliationModeIndependent
 }
 
 func jobSuspended(job *batchv1.Job) bool {

--- a/pkg/webhooks/jobset_webhook.go
+++ b/pkg/webhooks/jobset_webhook.go
@@ -329,19 +329,19 @@ func (j *jobSetWebhook) ValidateUpdate(ctx context.Context, oldJS, js *jobset.Jo
 	errs := apivalidation.ValidateImmutableField(mungedSpec.ReplicatedJobs, oldJS.Spec.ReplicatedJobs, field.NewPath("spec").Child("replicatedJobs"))
 	errs = append(errs, apivalidation.ValidateImmutableField(mungedSpec.ManagedBy, oldJS.Spec.ManagedBy, field.NewPath("spec").Child("managedBy"))...)
 
-	// Block JobSet suspendsion from being changed to another value than nil if the skip suspend reconciliation annotation is set.
+	// Block JobSet suspension from being changed to another value than nil if the reconciliation mode annotation is set to independent mode.
 	if controllers.ShouldSkipSuspendReconciliation(js) && js.Spec.Suspend != nil {
-		errs = append(errs, field.Invalid(field.NewPath("spec").Child("suspend"), js.Spec.Suspend, fmt.Sprintf("must be nil when %s annotation is true", jobset.SkipSuspendReconciliationAnnotation)))
+		errs = append(errs, field.Invalid(field.NewPath("spec").Child("suspend"), js.Spec.Suspend, fmt.Sprintf("must be nil when %s annotation is %s", jobset.ReconciliationModeAnnotation, jobset.ReconciliationModeIndependent)))
 	}
 
-	// Block skip suspend reconciliation annotation from being added to an existing JobSet
+	// Block reconciliation mode annotation be set to independent mode on an existing JobSet.
 	if !controllers.ShouldSkipSuspendReconciliation(oldJS) && controllers.ShouldSkipSuspendReconciliation(js) {
-		errs = append(errs, field.Invalid(field.NewPath("metadata").Child("annotations"), js.Annotations[jobset.SkipSuspendReconciliationAnnotation], fmt.Sprintf("cannot be set to true on an existing JobSet. It must be done at JobSet creation")))
+		errs = append(errs, field.Invalid(field.NewPath("metadata").Child("annotations"), jobset.ReconciliationModeAnnotation, fmt.Sprintf("cannot be set to %s on an existing JobSet. It must be done at JobSet creation", jobset.ReconciliationModeIndependent)))
 	}
 
-	// Block skip suspend reconciliation annotation from being removed from an existing JobSet
+	// Block reconciliation mode annotation set to independent mode from being removed from an existing JobSet.
 	if controllers.ShouldSkipSuspendReconciliation(oldJS) && !controllers.ShouldSkipSuspendReconciliation(js) {
-		errs = append(errs, field.Invalid(field.NewPath("metadata").Child("annotations"), js.Annotations[jobset.SkipSuspendReconciliationAnnotation], fmt.Sprintf("cannot be removed from an existing JobSet. It must be done at JobSet creation")))
+		errs = append(errs, field.Invalid(field.NewPath("metadata").Child("annotations"), jobset.ReconciliationModeAnnotation, fmt.Sprintf("set to %s cannot be removed from an existing JobSet. It must be done at JobSet creation", jobset.ReconciliationModeIndependent)))
 	}
 
 	return nil, errs.ToAggregate()

--- a/pkg/webhooks/jobset_webhook_test.go
+++ b/pkg/webhooks/jobset_webhook_test.go
@@ -783,11 +783,11 @@ func TestJobSetDefaulting(t *testing.T) {
 	}
 	skipSuspendReconciliationTests := []jobSetDefaultingTestCase{
 		{
-			name: "JobSet suspend is defaulted to nil if skip suspend reconciliation annotation is enabled",
+			name: "JobSet suspend is defaulted to nil if reconciliation mode is independent",
 			js: &jobset.JobSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						jobset.SkipSuspendReconciliationAnnotation: "true",
+						jobset.ReconciliationModeAnnotation: jobset.ReconciliationModeIndependent,
 					},
 				},
 				Spec: jobset.JobSetSpec{
@@ -811,7 +811,7 @@ func TestJobSetDefaulting(t *testing.T) {
 			want: &jobset.JobSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						jobset.SkipSuspendReconciliationAnnotation: "true",
+						jobset.ReconciliationModeAnnotation: jobset.ReconciliationModeIndependent,
 					},
 				},
 				Spec: jobset.JobSetSpec{
@@ -3358,12 +3358,12 @@ func TestValidateUpdate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		{
-			name: "suspend must be nil when skip suspend reconciliation annotation is true",
+			name: "suspend must be nil when reconciliation mode is independent",
 			js: &jobset.JobSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "js",
 					Annotations: map[string]string{
-						jobset.SkipSuspendReconciliationAnnotation: "true",
+						jobset.ReconciliationModeAnnotation: jobset.ReconciliationModeIndependent,
 					},
 				},
 				Spec: jobset.JobSetSpec{
@@ -3375,7 +3375,7 @@ func TestValidateUpdate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "js",
 					Annotations: map[string]string{
-						jobset.SkipSuspendReconciliationAnnotation: "true",
+						jobset.ReconciliationModeAnnotation: jobset.ReconciliationModeIndependent,
 					},
 				},
 				Spec: jobset.JobSetSpec{
@@ -3384,16 +3384,16 @@ func TestValidateUpdate(t *testing.T) {
 				},
 			},
 			want: field.ErrorList{
-				field.Invalid(field.NewPath("spec").Child("suspend"), ptr.To(true), fmt.Sprintf("must be nil when %s annotation is true", jobset.SkipSuspendReconciliationAnnotation)),
+				field.Invalid(field.NewPath("spec").Child("suspend"), ptr.To(true), fmt.Sprintf("must be nil when %s annotation is %s", jobset.ReconciliationModeAnnotation, jobset.ReconciliationModeIndependent)),
 			}.ToAggregate(),
 		},
 		{
-			name: "skip suspend reconciliation annotation cannot be added to an existing JobSet",
+			name: "reconciliation mode annotation cannot be added to an existing JobSet",
 			js: &jobset.JobSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "js",
 					Annotations: map[string]string{
-						jobset.SkipSuspendReconciliationAnnotation: "true",
+						jobset.ReconciliationModeAnnotation: jobset.ReconciliationModeIndependent,
 					},
 				},
 				Spec: jobset.JobSetSpec{
@@ -3409,11 +3409,11 @@ func TestValidateUpdate(t *testing.T) {
 				},
 			},
 			want: field.ErrorList{
-				field.Invalid(field.NewPath("metadata").Child("annotations"), "true", "cannot be set to true on an existing JobSet. It must be done at JobSet creation"),
+				field.Invalid(field.NewPath("metadata").Child("annotations"), jobset.ReconciliationModeIndependent, fmt.Sprintf("cannot be set to %s on an existing JobSet. It must be done at JobSet creation", jobset.ReconciliationModeIndependent)),
 			}.ToAggregate(),
 		},
 		{
-			name: "skip suspend reconciliation annotation cannot be removed from an existing JobSet",
+			name: "reconciliation mode annotation cannot be removed from an existing JobSet",
 			js: &jobset.JobSet{
 				ObjectMeta: validObjectMeta,
 				Spec: jobset.JobSetSpec{
@@ -3425,7 +3425,7 @@ func TestValidateUpdate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "js",
 					Annotations: map[string]string{
-						jobset.SkipSuspendReconciliationAnnotation: "true",
+						jobset.ReconciliationModeAnnotation: jobset.ReconciliationModeIndependent,
 					},
 				},
 				Spec: jobset.JobSetSpec{
@@ -3434,7 +3434,7 @@ func TestValidateUpdate(t *testing.T) {
 				},
 			},
 			want: field.ErrorList{
-				field.Invalid(field.NewPath("metadata").Child("annotations"), "", "cannot be removed from an existing JobSet. It must be done at JobSet creation"),
+				field.Invalid(field.NewPath("metadata").Child("annotations"), jobset.ReconciliationModeAnnotation, fmt.Sprintf("set to %s cannot be removed from an existing JobSet. It must be done at JobSet creation", jobset.ReconciliationModeIndependent)),
 			}.ToAggregate(),
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Add the JobSet annotation `jobset.sigs.k8s.io/skip-suspend-reconciliation` that makes the JobSet controller not reconcile the suspension state of its child Jobs.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1172

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```