### PR TITLE
Reorder follower pod validation to surface leader scheduling status

### DIFF
--- a/pkg/webhooks/pod_webhook.go
+++ b/pkg/webhooks/pod_webhook.go
@@ -221,13 +221,6 @@ func (p *podWebhook) ValidateCreate(ctx context.Context, pod *corev1.Pod) (admis
 	if placement.IsLeaderPod(pod) {
 		return nil, nil
 	}
-	// If a follower pod node selector has not been set, reject the creation.
-	if pod.Spec.NodeSelector == nil {
-		return nil, fmt.Errorf("follower pod node selector not set")
-	}
-	if _, exists := pod.Spec.NodeSelector[topologyKey]; !exists {
-		return nil, fmt.Errorf("follower pod node selector for topology domain not found. missing selector: %s", topologyKey)
-	}
 	// For follower pods, validate leader pod exists and is scheduled.
 	leaderScheduled, err := p.leaderPodScheduled(ctx, pod)
 	if err != nil {
@@ -235,6 +228,13 @@ func (p *podWebhook) ValidateCreate(ctx context.Context, pod *corev1.Pod) (admis
 	}
 	if !leaderScheduled {
 		return nil, fmt.Errorf("leader pod not yet scheduled, not creating follower pod. this is an expected, transient error")
+	}
+	// If a follower pod node selector has not been set, reject the creation.
+	if pod.Spec.NodeSelector == nil {
+		return nil, fmt.Errorf("follower pod node selector not set despite leader pod being scheduled")
+	}
+	if _, exists := pod.Spec.NodeSelector[topologyKey]; !exists {
+		return nil, fmt.Errorf("follower pod node selector for topology domain not found. missing selector: %s", topologyKey)
 	}
 	return nil, nil
 }

--- a/pkg/webhooks/pod_webhook_test.go
+++ b/pkg/webhooks/pod_webhook_test.go
@@ -535,6 +535,103 @@ func TestPodWebhookValidateCreate(t *testing.T) {
 			},
 			wantErr: "follower pod node selector not set despite leader pod being scheduled",
 		},
+		{
+			name: "follower pod requires topology node selector key after leader is scheduled",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "js-rjob-0-1-follower",
+					Namespace: "default",
+					Labels: map[string]string{
+						jobset.JobSetNameKey:        "js",
+						jobset.ReplicatedJobNameKey: "rjob",
+						jobset.JobIndexKey:          "0",
+					},
+					Annotations: map[string]string{
+						jobset.JobSetNameKey:                       "js",
+						jobset.ExclusiveKey:                        "topology.kubernetes.io/zone",
+						"batch.kubernetes.io/job-completion-index": "1",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{UID: types.UID("job-uid-1"), Kind: "Job", Controller: ptr.To(true)},
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeSelector: map[string]string{
+						"kubernetes.io/hostname": "node-a",
+					},
+				},
+			},
+			existingObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "js-rjob-0-0-leader",
+						Namespace: "default",
+						Labels: map[string]string{
+							jobset.JobSetNameKey:        "js",
+							jobset.ReplicatedJobNameKey: "rjob",
+							jobset.JobIndexKey:          "0",
+						},
+						Annotations: map[string]string{
+							jobset.ExclusiveKey:                        "topology.kubernetes.io/zone",
+							"batch.kubernetes.io/job-completion-index": "0",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{UID: types.UID("job-uid-1"), Kind: "Job", Controller: ptr.To(true)},
+						},
+					},
+					Spec: corev1.PodSpec{NodeName: "node-a"},
+				},
+			},
+			wantErr: "follower pod node selector for topology domain not found. missing selector: topology.kubernetes.io/zone",
+		},
+		{
+			name: "follower pod allows create when leader is scheduled and topology node selector is set",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "js-rjob-0-1-follower",
+					Namespace: "default",
+					Labels: map[string]string{
+						jobset.JobSetNameKey:        "js",
+						jobset.ReplicatedJobNameKey: "rjob",
+						jobset.JobIndexKey:          "0",
+					},
+					Annotations: map[string]string{
+						jobset.JobSetNameKey:                       "js",
+						jobset.ExclusiveKey:                        "topology.kubernetes.io/zone",
+						"batch.kubernetes.io/job-completion-index": "1",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{UID: types.UID("job-uid-1"), Kind: "Job", Controller: ptr.To(true)},
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeSelector: map[string]string{
+						"topology.kubernetes.io/zone": "zone-a",
+					},
+				},
+			},
+			existingObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "js-rjob-0-0-leader",
+						Namespace: "default",
+						Labels: map[string]string{
+							jobset.JobSetNameKey:        "js",
+							jobset.ReplicatedJobNameKey: "rjob",
+							jobset.JobIndexKey:          "0",
+						},
+						Annotations: map[string]string{
+							jobset.ExclusiveKey:                        "topology.kubernetes.io/zone",
+							"batch.kubernetes.io/job-completion-index": "0",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{UID: types.UID("job-uid-1"), Kind: "Job", Controller: ptr.To(true)},
+						},
+					},
+					Spec: corev1.PodSpec{NodeName: "node-a"},
+				},
+			},
+		},
 	}
 
 	scheme := runtime.NewScheme()
@@ -552,11 +649,17 @@ func TestPodWebhookValidateCreate(t *testing.T) {
 
 			p := &podWebhook{client: fakeClient}
 			_, err := p.ValidateCreate(t.Context(), tc.pod)
-			if err == nil {
-				t.Fatalf("expected error %q, got nil", tc.wantErr)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected error to contain %q, got %q", tc.wantErr, err.Error())
+				}
+				return
 			}
-			if !strings.Contains(err.Error(), tc.wantErr) {
-				t.Fatalf("expected error to contain %q, got %q", tc.wantErr, err.Error())
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
 			}
 		})
 	}

--- a/pkg/webhooks/pod_webhook_test.go
+++ b/pkg/webhooks/pod_webhook_test.go
@@ -441,6 +441,127 @@ func TestDefault(t *testing.T) {
 	}
 }
 
+func TestPodWebhookValidateCreate(t *testing.T) {
+	testCases := []struct {
+		name         string
+		pod          *corev1.Pod
+		existingObjs []runtime.Object
+		wantErr      string
+	}{
+		{
+			name: "follower pod returns transient error when leader is not scheduled even without node selector",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "js-rjob-0-1-follower",
+					Namespace: "default",
+					Labels: map[string]string{
+						jobset.JobSetNameKey:        "js",
+						jobset.ReplicatedJobNameKey: "rjob",
+						jobset.JobIndexKey:          "0",
+					},
+					Annotations: map[string]string{
+						jobset.JobSetNameKey:                       "js",
+						jobset.ExclusiveKey:                        "topology.kubernetes.io/zone",
+						"batch.kubernetes.io/job-completion-index": "1",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{UID: types.UID("job-uid-1"), Kind: "Job", Controller: ptr.To(true)},
+					},
+				},
+			},
+			existingObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "js-rjob-0-0-leader",
+						Namespace: "default",
+						Labels: map[string]string{
+							jobset.JobSetNameKey:        "js",
+							jobset.ReplicatedJobNameKey: "rjob",
+							jobset.JobIndexKey:          "0",
+						},
+						Annotations: map[string]string{
+							jobset.ExclusiveKey:                        "topology.kubernetes.io/zone",
+							"batch.kubernetes.io/job-completion-index": "0",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{UID: types.UID("job-uid-1"), Kind: "Job", Controller: ptr.To(true)},
+						},
+					},
+				},
+			},
+			wantErr: "leader pod not yet scheduled, not creating follower pod. this is an expected, transient error",
+		},
+		{
+			name: "follower pod requires node selector after leader is scheduled",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "js-rjob-0-1-follower",
+					Namespace: "default",
+					Labels: map[string]string{
+						jobset.JobSetNameKey:        "js",
+						jobset.ReplicatedJobNameKey: "rjob",
+						jobset.JobIndexKey:          "0",
+					},
+					Annotations: map[string]string{
+						jobset.JobSetNameKey:                       "js",
+						jobset.ExclusiveKey:                        "topology.kubernetes.io/zone",
+						"batch.kubernetes.io/job-completion-index": "1",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{UID: types.UID("job-uid-1"), Kind: "Job", Controller: ptr.To(true)},
+					},
+				},
+			},
+			existingObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "js-rjob-0-0-leader",
+						Namespace: "default",
+						Labels: map[string]string{
+							jobset.JobSetNameKey:        "js",
+							jobset.ReplicatedJobNameKey: "rjob",
+							jobset.JobIndexKey:          "0",
+						},
+						Annotations: map[string]string{
+							jobset.ExclusiveKey:                        "topology.kubernetes.io/zone",
+							"batch.kubernetes.io/job-completion-index": "0",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{UID: types.UID("job-uid-1"), Kind: "Job", Controller: ptr.To(true)},
+						},
+					},
+					Spec: corev1.PodSpec{NodeName: "node-a"},
+				},
+			},
+			wantErr: "follower pod node selector not set despite leader pod being scheduled",
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add corev1 to scheme: %v", err)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tc.existingObjs...).
+				WithIndex(&corev1.Pod{}, controllers.PodNameKey, controllers.IndexPodName).
+				Build()
+
+			p := &podWebhook{client: fakeClient}
+			_, err := p.ValidateCreate(t.Context(), tc.pod)
+			if err == nil {
+				t.Fatalf("expected error %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error to contain %q, got %q", tc.wantErr, err.Error())
+			}
+		})
+	}
+}
+
 func TestLeaderPodName(t *testing.T) {
 	cases := []struct {
 		desc    string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR improves the diagnostic output of the `vpod` webhook for JobSets using exclusive placement. 

Previously, `ValidateCreate` checked if a follower pod had a `NodeSelector` before checking if the leader pod was scheduled. If the leader was stuck in `Pending` (e.g., due to quotas), the mutating webhook correctly withheld the selector, but the validating webhook immediately rejected the pod with `"follower pod node selector not set"`. This masked the more accurate `"expected, transient error"` regarding the leader pod's status.

By moving the leader scheduling check first, users will now correctly see the transient error, which guides them to investigate the leader pod's resource constraints rather than assuming a JobSet configuration failure.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1187

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```