### PR TITLE
Enable e2e testing of alpha features via customconfigs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,7 +310,7 @@ type JobSetSpec struct {
 - `KIND_CLUSTER_NAME`: Name of Kind cluster (default: "kind")
 - `USE_EXISTING_CLUSTER`: Set to "true" to test against existing cluster instead of creating new Kind cluster
 - `E2E_KIND_VERSION`: Kubernetes version for Kind cluster (default: kindest/node:v1.34.0)
-- `E2E_TARGET`: Test target pattern (default: ./test/e2e/...)
+- `E2E_TEST_PATH`: Ginkgo test path to run (default: ./test/e2e/...)
 
 ### Webhook Development
 

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ INTEGRATION_TARGET ?= ./test/integration/...
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 JOBSET_CHART_DIR := charts/jobset
 
-E2E_TARGET ?= ./test/e2e/...
+E2E_TEST_PATH ?= ./test/e2e/...
 E2E_KIND_VERSION ?= kindest/node:v1.34.0
 USE_EXISTING_CLUSTER ?= false
 # E2E config folder to use (e.g., "default", "certmanager", etc.)
@@ -422,7 +422,11 @@ test-integration: manifests fmt vet envtest ginkgo ## Run tests.
 
 .PHONY: test-e2e-kind
 test-e2e-kind: manifests kustomize fmt vet envtest ginkgo kind-image-build
-	E2E_KIND_VERSION=$(E2E_KIND_VERSION) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) ARTIFACTS=$(ARTIFACTS) IMAGE_TAG=$(IMAGE_TAG) E2E_TARGET_FOLDER=$(E2E_TARGET_FOLDER) ./hack/e2e-test.sh
+	E2E_KIND_VERSION=$(E2E_KIND_VERSION) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) ARTIFACTS=$(ARTIFACTS) IMAGE_TAG=$(IMAGE_TAG) E2E_TARGET_FOLDER=$(E2E_TARGET_FOLDER) E2E_TEST_PATH=$(E2E_TEST_PATH) ./hack/e2e-test.sh
+
+.PHONY: test-e2e-kind-customconfigs
+test-e2e-kind-customconfigs: E2E_TEST_PATH = ./test/e2e/customconfigs/...
+test-e2e-kind-customconfigs: test-e2e-kind
 
 .PHONY: prometheus
 prometheus:

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -7,6 +7,7 @@ export NAMESPACE="jobset-system"
 export JOBSET_E2E_TESTS_DUMP_NAMESPACE=true
 # E2E config folder to use (defaults to "default")
 export E2E_TARGET_FOLDER="${E2E_TARGET_FOLDER:-default}"
+export E2E_TEST_PATH="${E2E_TEST_PATH:-./test/e2e/...}"
 K8S_VERSION="${E2E_KIND_VERSION##*:}"
 
 # Use a temporary KUBECONFIG so that the script does not mess with the current user's kubeconfig.
@@ -62,4 +63,4 @@ build_node_image
 startup
 kind_load
 jobset_deploy
-$GINKGO --junit-report=junit.xml --output-dir=$ARTIFACTS -v ./test/e2e/...
+$GINKGO --junit-report=junit.xml --output-dir=$ARTIFACTS -v $E2E_TEST_PATH

--- a/test/e2e/customconfigs/inplacerestart_test.go
+++ b/test/e2e/customconfigs/inplacerestart_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customconfigs
+
+import (
+	"math"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configv1alpha1 "sigs.k8s.io/jobset/api/config/v1alpha1"
+	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+	"sigs.k8s.io/jobset/pkg/features"
+	testingutil "sigs.k8s.io/jobset/pkg/util/testing"
+	"sigs.k8s.io/jobset/test/util"
+)
+
+var _ = ginkgo.Describe("InPlaceRestart", ginkgo.Ordered, func() {
+	var ns *corev1.Namespace
+
+	ginkgo.BeforeAll(func() {
+		util.UpdateJobSetConfigurationAndRestart(ctx, k8sClient, defaultCfg, func(cfg *configv1alpha1.Configuration) {
+			cfg.FeatureGates = map[string]bool{string(features.InPlaceRestart): true}
+		})
+	})
+
+	ginkgo.BeforeEach(func() {
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "e2e-customconfigs-",
+			},
+		}
+		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+
+		gomega.Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Namespace, Name: ns.Name}, ns)
+		}, timeout, interval).Should(gomega.Succeed())
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(k8sClient.Delete(ctx, ns)).To(gomega.Succeed())
+	})
+
+	ginkgo.When("InPlaceRestart feature gate is enabled", func() {
+		ginkgo.It("should accept a JobSet with InPlaceRestart strategy", func() {
+			ginkgo.By("creating jobset with InPlaceRestart strategy")
+			js := inPlaceRestartTestJobSet(ns)
+
+			ginkgo.By("checking that jobset creation succeeds")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, js))).To(gomega.Succeed())
+			}, timeout, interval).Should(gomega.Succeed())
+		})
+	})
+})
+
+func inPlaceRestartTestJobSet(ns *corev1.Namespace) *jobset.JobSet {
+	jobTemplate := testingutil.MakeJobTemplate("job", ns.Name).
+		PodSpec(corev1.PodSpec{
+			RestartPolicy: "Never",
+			Containers: []corev1.Container{
+				{
+					Name:    "test-container",
+					Image:   "docker.io/library/bash:latest",
+					Command: []string{"bash", "-c", "sleep 5"},
+				},
+			},
+		}).Obj()
+
+	jobTemplate.Spec.BackoffLimit = ptr.To[int32](math.MaxInt32)
+	jobTemplate.Spec.PodReplacementPolicy = ptr.To(batchv1.Failed)
+	jobTemplate.Spec.Completions = ptr.To[int32](1)
+	jobTemplate.Spec.Parallelism = ptr.To[int32](1)
+
+	return testingutil.MakeJobSet("js-in-place-restart", ns.Name).
+		FailurePolicy(&jobset.FailurePolicy{
+			MaxRestarts:     3,
+			RestartStrategy: jobset.InPlaceRestart,
+		}).
+		ReplicatedJob(testingutil.MakeReplicatedJob("rjob").
+			Job(jobTemplate).
+			Replicas(1).
+			Obj()).
+		Obj()
+}

--- a/test/e2e/customconfigs/restartjob_test.go
+++ b/test/e2e/customconfigs/restartjob_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customconfigs
+
+import (
+	"fmt"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configv1alpha1 "sigs.k8s.io/jobset/api/config/v1alpha1"
+	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+	"sigs.k8s.io/jobset/pkg/constants"
+	"sigs.k8s.io/jobset/pkg/features"
+	testingutil "sigs.k8s.io/jobset/pkg/util/testing"
+	"sigs.k8s.io/jobset/test/util"
+)
+
+var _ = ginkgo.Describe("RestartJob", ginkgo.Ordered, func() {
+	var ns *corev1.Namespace
+
+	ginkgo.BeforeAll(func() {
+		util.UpdateJobSetConfigurationAndRestart(ctx, k8sClient, defaultCfg, func(cfg *configv1alpha1.Configuration) {
+			cfg.FeatureGates = map[string]bool{string(features.RestartJob): true}
+		})
+	})
+
+	ginkgo.BeforeEach(func() {
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "e2e-customconfigs-",
+			},
+		}
+		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+
+		gomega.Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Namespace, Name: ns.Name}, ns)
+		}, timeout, interval).Should(gomega.Succeed())
+	})
+
+	ginkgo.AfterEach(func() {
+		if util.ShouldDumpNamespace() {
+			var printer printers.YAMLPrinter
+
+			ginkgo.By(fmt.Sprintf("dumping relevant resources in namespace %s", ns.Name))
+
+			var jobsets jobset.JobSetList
+			gomega.Expect(k8sClient.List(ctx, &jobsets, client.InNamespace(ns.Name))).To(gomega.Succeed())
+			for _, js := range jobsets.Items {
+				gomega.Expect(printer.PrintObj(&js, ginkgo.GinkgoWriter)).To(gomega.Succeed())
+			}
+
+			var jobs batchv1.JobList
+			gomega.Expect(k8sClient.List(ctx, &jobs, client.InNamespace(ns.Name))).To(gomega.Succeed())
+			for _, job := range jobs.Items {
+				job.SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   batchv1.SchemeGroupVersion.Group,
+					Version: batchv1.SchemeGroupVersion.Version,
+					Kind:    "Job",
+				})
+				gomega.Expect(printer.PrintObj(&job, ginkgo.GinkgoWriter)).To(gomega.Succeed())
+			}
+		}
+
+		gomega.Expect(k8sClient.Delete(ctx, ns)).To(gomega.Succeed())
+	})
+
+	ginkgo.When("JobSet uses RestartJob failure policy action", func() {
+		ginkgo.It("should recover by recreating only the failed job and succeeding eventually", func() {
+			ginkgo.By("creating jobset with RestartJob failure policy")
+			js := restartJobFailurePolicyTestJobSet(ns)
+
+			ginkgo.By("checking that jobset creation succeeds")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, js))).To(gomega.Succeed())
+			}, timeout, interval).Should(gomega.Succeed())
+
+			ginkgo.By("checking jobset succeeds")
+			util.JobSetCompleted(ctx, k8sClient, js, timeout)
+
+			ginkgo.By("checking the jobset was properly restarted at job level")
+			gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: js.Name, Namespace: js.Namespace}, js)).Should(gomega.Succeed())
+			gomega.Expect(js.Status.Restarts).To(gomega.Equal(int32(0)))
+			gomega.Expect(js.Status.RestartsCountTowardsMax).To(gomega.Equal(int32(0)))
+			gomega.Expect(js.Status.ReplicatedJobsStatus[0].JobRestarts).NotTo(gomega.BeNil())
+		})
+	})
+})
+
+func restartJobFailurePolicyTestJobSet(ns *corev1.Namespace) *jobset.JobSet {
+	jsName := "js-restart-job"
+	rjobName := "rjob"
+	replicas := 2
+
+	jobTemplate := testingutil.MakeJobTemplate("job", ns.Name).
+		PodSpec(corev1.PodSpec{
+			RestartPolicy: "Never",
+			Containers: []corev1.Container{
+				{
+					Name:    "test-container",
+					Image:   "docker.io/library/bash:latest",
+					Command: []string{"bash", "-c"},
+					Args: []string{
+						`if [[ "$JOB_INDEX" == "1" && "$JOB_RESTART_ATTEMPT" == "0" ]]; then echo "Failing intentionally"; exit 1; else echo "Succeeding"; exit 0; fi`,
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name: "JOB_INDEX",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: fmt.Sprintf("metadata.annotations['%s']", jobset.JobIndexKey),
+								},
+							},
+						},
+						{
+							Name: "JOB_RESTART_ATTEMPT",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: fmt.Sprintf("metadata.annotations['%s']", constants.JobRestartAttemptKey),
+								},
+							},
+						},
+					},
+				},
+			},
+		}).Obj()
+
+	jobTemplate.Spec.BackoffLimit = ptr.To[int32](0)
+
+	return testingutil.MakeJobSet(jsName, ns.Name).
+		FailurePolicy(&jobset.FailurePolicy{
+			MaxRestarts: 3,
+			Rules: []jobset.FailurePolicyRule{
+				{
+					Action: jobset.RestartJob,
+					OnJobFailureReasons: []string{
+						"BackoffLimitExceeded",
+					},
+				},
+			},
+		}).
+		ReplicatedJob(testingutil.MakeReplicatedJob(rjobName).
+			Job(jobTemplate).
+			Replicas(int32(replicas)).
+			Obj()).
+		Obj()
+}

--- a/test/e2e/customconfigs/suite_test.go
+++ b/test/e2e/customconfigs/suite_test.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package customconfigs
 
 import (
 	"context"
@@ -25,27 +25,26 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
+	configv1alpha1 "sigs.k8s.io/jobset/api/config/v1alpha1"
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 	"sigs.k8s.io/jobset/test/util"
-	//+kubebuilder:scaffold:imports
 )
 
 const (
 	timeout  = 10 * time.Minute
 	interval = time.Millisecond * 250
-
-	fieldManagerName = client.FieldOwner("e2e-test")
 )
 
 var (
-	k8sClient client.Client
-	ctx       context.Context
+	k8sClient  client.Client
+	ctx        context.Context
+	defaultCfg *configv1alpha1.Configuration
 )
 
 func TestAPIs(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t,
-		"End To End Suite",
+		"Custom Configs End To End Suite",
 	)
 }
 
@@ -65,4 +64,11 @@ var _ = ginkgo.BeforeSuite(func() {
 	gomega.Expect(k8sClient).NotTo(gomega.BeNil())
 
 	util.JobSetReadyForTesting(ctx, k8sClient)
+	defaultCfg = util.GetJobSetConfiguration(ctx, k8sClient)
+})
+
+var _ = ginkgo.AfterSuite(func() {
+	if defaultCfg != nil {
+		util.UpdateJobSetConfigurationAndRestart(ctx, k8sClient, defaultCfg, func(cfg *configv1alpha1.Configuration) {})
+	}
 })

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -18,7 +18,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
 	"time"
 
@@ -42,10 +41,6 @@ import (
 	"sigs.k8s.io/jobset/pkg/util/testing"
 	"sigs.k8s.io/jobset/test/util"
 )
-
-func shouldDumpNamespace() bool {
-	return os.Getenv("JOBSET_E2E_TESTS_DUMP_NAMESPACE") == "true"
-}
 
 var _ = ginkgo.Describe("JobSet", func() {
 
@@ -74,7 +69,7 @@ var _ = ginkgo.Describe("JobSet", func() {
 	ginkgo.AfterEach(func() {
 		// Dump the namespace content, optionally.
 		// This is only visible on failure since ginkgo.GinkgoWriter is being used.
-		if shouldDumpNamespace() {
+		if util.ShouldDumpNamespace() {
 			var printer printers.YAMLPrinter
 
 			fmt.Fprintf(ginkgo.GinkgoWriter, "\nDumping relevant resources in namespace %s:\n\n", ns.Name)

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -16,12 +16,15 @@ package util
 import (
 	"context"
 	"fmt"
+	"os"
 	"slices"
 	"strconv"
 	"time"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,13 +33,21 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
+	configv1alpha1 "sigs.k8s.io/jobset/api/config/v1alpha1"
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 	"sigs.k8s.io/jobset/pkg/constants"
 )
 
-const interval = time.Millisecond * 250
+const (
+	timeout  = 10 * time.Minute
+	interval = time.Millisecond * 250
+)
 
 func NumExpectedJobs(js *jobset.JobSet) int {
 	expectedJobs := 0
@@ -313,4 +324,192 @@ func checkJobSetRestartingCondition(ctx context.Context, k8sClient client.Client
 		}
 	}
 	return false, nil
+}
+
+func ShouldDumpNamespace() bool {
+	return os.Getenv("JOBSET_E2E_TESTS_DUMP_NAMESPACE") == "true"
+}
+
+func getNamespace() string {
+	namespace := os.Getenv("NAMESPACE")
+	if namespace == "" {
+		namespace = "jobset-system"
+	}
+	return namespace
+}
+
+func JobSetReadyForTesting(ctx context.Context, k8sClient client.Client) {
+	ginkgo.By("waiting for resources to be ready for testing")
+	deploymentKey := types.NamespacedName{Namespace: getNamespace(), Name: "jobset-controller-manager"}
+	deployment := &appsv1.Deployment{}
+	pods := &corev1.PodList{}
+	gomega.Eventually(func(g gomega.Gomega) error {
+		// Get controller-manager deployment.
+		g.Expect(k8sClient.Get(ctx, deploymentKey, deployment)).To(gomega.Succeed())
+		// Get pods matches for controller-manager deployment.
+		g.Expect(k8sClient.List(ctx, pods, client.InNamespace(deploymentKey.Namespace), client.MatchingLabels(deployment.Spec.Selector.MatchLabels))).To(gomega.Succeed())
+		for _, pod := range pods.Items {
+			for _, cs := range pod.Status.ContainerStatuses {
+				// To make sure that we don't have restarts of controller-manager.
+				// If we have that's mean that something went wrong, and there is
+				// no needs to continue trying check availability.
+				if cs.RestartCount > 0 {
+					return gomega.StopTrying(fmt.Sprintf("%q in %q has restarted %d times", cs.Name, pod.Name, cs.RestartCount))
+				}
+			}
+		}
+		// To verify that webhooks are ready, checking is deployment have condition Available=True.
+		g.Expect(deployment.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(
+			appsv1.DeploymentCondition{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue},
+			cmpopts.IgnoreFields(appsv1.DeploymentCondition{}, "Reason", "Message", "LastUpdateTime", "LastTransitionTime")),
+		))
+		return nil
+	}, timeout, interval).Should(gomega.Succeed())
+}
+
+func GetJobSetConfiguration(ctx context.Context, k8sClient client.Client) *configv1alpha1.Configuration {
+	var cm corev1.ConfigMap
+	gomega.ExpectWithOffset(1, k8sClient.Get(ctx, types.NamespacedName{
+		Namespace: getNamespace(),
+		Name:      "jobset-manager-config",
+	}, &cm)).To(gomega.Succeed())
+
+	cfg := &configv1alpha1.Configuration{}
+	gomega.ExpectWithOffset(1, yaml.Unmarshal([]byte(cm.Data["controller_manager_config.yaml"]), cfg)).To(gomega.Succeed())
+	return cfg
+}
+
+func UpdateJobSetConfigurationAndRestart(ctx context.Context, k8sClient client.Client, defaultCfg *configv1alpha1.Configuration, applyChanges func(cfg *configv1alpha1.Configuration)) {
+	ginkgo.By("updating jobset controller configuration")
+	cfg := defaultCfg.DeepCopy()
+	applyChanges(cfg)
+
+	data, err := yaml.Marshal(cfg)
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+
+	var cm corev1.ConfigMap
+	gomega.ExpectWithOffset(1, k8sClient.Get(ctx, types.NamespacedName{
+		Namespace: getNamespace(),
+		Name:      "jobset-manager-config",
+	}, &cm)).To(gomega.Succeed())
+
+	cm.Data["controller_manager_config.yaml"] = string(data)
+	gomega.ExpectWithOffset(1, k8sClient.Update(ctx, &cm)).To(gomega.Succeed())
+
+	RestartJobSetController(ctx, k8sClient)
+}
+
+func RestartJobSetController(ctx context.Context, k8sClient client.Client) {
+	ginkgo.By("restarting jobset controller")
+	deploymentKey := types.NamespacedName{Namespace: getNamespace(), Name: "jobset-controller-manager"}
+	updateDeploymentAndWaitForProgressing(ctx, k8sClient, deploymentKey, func(deployment *appsv1.Deployment) {
+		if deployment.Spec.Template.Annotations == nil {
+			deployment.Spec.Template.Annotations = make(map[string]string)
+		}
+		deployment.Spec.Template.Annotations["jobset.sigs.k8s.io/restartedAt"] = time.Now().Format(time.RFC3339)
+	})
+	waitForDeploymentAvailability(ctx, k8sClient, deploymentKey)
+	waitForWebhookEndpointsReady(ctx, k8sClient, deploymentKey)
+}
+
+func updateDeploymentAndWaitForProgressing(ctx context.Context, k8sClient client.Client, key types.NamespacedName, applyChanges func(deployment *appsv1.Deployment)) {
+	deployment := &appsv1.Deployment{}
+
+	var beforeObservedGeneration int64
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect(k8sClient.Get(ctx, key, deployment)).To(gomega.Succeed())
+		g.Expect(deployment.Generation).To(gomega.Equal(deployment.Status.ObservedGeneration))
+		beforeObservedGeneration = deployment.Status.ObservedGeneration
+		applyChanges(deployment)
+		g.Expect(k8sClient.Update(ctx, deployment)).To(gomega.Succeed())
+	}, timeout, interval).Should(gomega.Succeed())
+
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect(k8sClient.Get(ctx, key, deployment)).To(gomega.Succeed())
+		g.Expect(deployment.Status.ObservedGeneration).NotTo(gomega.Equal(beforeObservedGeneration))
+	}, timeout, interval).Should(gomega.Succeed())
+}
+
+func waitForDeploymentAvailability(ctx context.Context, k8sClient client.Client, key types.NamespacedName) {
+	ginkgo.By(fmt.Sprintf("waiting for availability of deployment: %q", key))
+	gomega.Eventually(func(g gomega.Gomega) {
+		deployment := &appsv1.Deployment{}
+		g.Expect(k8sClient.Get(ctx, key, deployment)).To(gomega.Succeed())
+		desiredReplicas := *deployment.Spec.Replicas
+		g.Expect(deployment.Status.ObservedGeneration).To(gomega.Equal(deployment.Generation))
+		g.Expect(deployment.Status.Replicas).To(gomega.Equal(desiredReplicas))
+		g.Expect(deployment.Status.UpdatedReplicas).To(gomega.Equal(desiredReplicas))
+		g.Expect(deployment.Status.AvailableReplicas).To(gomega.Equal(desiredReplicas))
+		// For K8s 1.35+ with DeploymentReplicaSetTerminatingReplicas feature gate.
+		// On older versions, TerminatingReplicas is nil, so this is always true.
+		g.Expect(ptr.Deref(deployment.Status.TerminatingReplicas, 0)).To(gomega.BeZero())
+		g.Expect(deployment.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(
+			appsv1.DeploymentCondition{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue},
+			cmpopts.IgnoreFields(appsv1.DeploymentCondition{}, "Reason", "Message", "LastUpdateTime", "LastTransitionTime")),
+		))
+
+		selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		pods := &corev1.PodList{}
+		g.Expect(k8sClient.List(ctx, pods,
+			client.InNamespace(key.Namespace),
+			client.MatchingLabelsSelector{Selector: selector},
+		)).To(gomega.Succeed())
+		readyPods := 0
+		for _, pod := range pods.Items {
+			if pod.DeletionTimestamp != nil {
+				continue
+			}
+			for _, c := range pod.Status.Conditions {
+				if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+					readyPods++
+				}
+			}
+		}
+		g.Expect(int32(readyPods)).To(gomega.Equal(desiredReplicas))
+	}, timeout, interval).Should(gomega.Succeed())
+}
+
+func waitForWebhookEndpointsReady(ctx context.Context, k8sClient client.Client, key types.NamespacedName) {
+	ginkgo.By(fmt.Sprintf("waiting for webhook endpoints to match ready pods: %q", key))
+	gomega.Eventually(func(g gomega.Gomega) {
+		deployment := &appsv1.Deployment{}
+		g.Expect(k8sClient.Get(ctx, key, deployment)).To(gomega.Succeed())
+
+		selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		pods := &corev1.PodList{}
+		g.Expect(k8sClient.List(ctx, pods,
+			client.InNamespace(key.Namespace),
+			client.MatchingLabelsSelector{Selector: selector},
+		)).To(gomega.Succeed())
+
+		readyPodIPs := sets.New[string]()
+		for _, pod := range pods.Items {
+			if pod.DeletionTimestamp == nil && pod.Status.PodIP != "" {
+				for _, c := range pod.Status.Conditions {
+					if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+						readyPodIPs.Insert(pod.Status.PodIP)
+					}
+				}
+			}
+		}
+
+		endpointSlices := &discoveryv1.EndpointSliceList{}
+		g.Expect(k8sClient.List(ctx, endpointSlices,
+			client.InNamespace(key.Namespace),
+			client.MatchingLabels{discoveryv1.LabelServiceName: "jobset-webhook-service"},
+		)).To(gomega.Succeed())
+
+		endpointIPs := sets.New[string]()
+		for _, slice := range endpointSlices.Items {
+			for _, ep := range slice.Endpoints {
+				if ep.Conditions.Ready == nil || *ep.Conditions.Ready {
+					endpointIPs.Insert(ep.Addresses...)
+				}
+			}
+		}
+		g.Expect(endpointIPs).To(gomega.Equal(readyPodIPs))
+	}, timeout, interval).Should(gomega.Succeed())
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

Adds e2e test infrastructure for feature gates. Tests in `test/e2e/customconfigs/` update the controller ConfigMap and restart it at runtime to enable feature gates. 

Includes basic e2e tests for `RestartJob` and `InPlaceRestart`.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1184 

#### Special notes for your reviewer:

The `test/e2e/customconfigs/` approach follows the pattern from the [Kueue project](https://github.com/kubernetes-sigs/kueue/tree/main/test/e2e/customconfigs).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```