### PR TITLE
Implement KEP 1172: Support granular suspend/resume for individual Jobs

### DIFF
--- a/api/jobset/v1alpha2/jobset_types.go
+++ b/api/jobset/v1alpha2/jobset_types.go
@@ -96,6 +96,12 @@ const (
 	// strategy is not used (or the feature gate is not enabled). One example is
 	// downgrading the JobSet CRD to a version that does not support in-place restart
 	DisableInPlaceRestartKey string = "jobset.sigs.k8s.io/disable-in-place-restart"
+
+	// ReconciliationModeAnnotation is a JobSet annotation that, if set to "Independent" (ReconciliationModeIndependent),
+	// instructs the JobSet controller to not reconcile the suspend state of the JobSet onto its child Jobs.
+	// This also forces the JobSet suspend field to be nil.
+	ReconciliationModeAnnotation  string = "jobset.sigs.k8s.io/reconciliation-mode"
+	ReconciliationModeIndependent string = "Independent"
 )
 
 type JobSetConditionType string

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -219,16 +219,18 @@ func (r *JobSetReconciler) reconcile(ctx context.Context, js *jobset.JobSet, upd
 	}
 
 	// Handle suspending a jobset or resuming a suspended jobset.
-	jobsetSuspended := jobSetSuspended(js)
-	if jobsetSuspended {
-		if err := r.suspendJobs(ctx, js, ownedJobs.active, updateStatusOpts); err != nil {
-			log.Error(err, "suspending jobset")
-			return ctrl.Result{}, err
-		}
-	} else {
-		if err := r.resumeJobsIfNecessary(ctx, js, ownedJobs.active, rjobStatuses, updateStatusOpts); err != nil {
-			log.Error(err, "resuming jobset")
-			return ctrl.Result{}, err
+	if !ShouldSkipSuspendReconciliation(js) {
+		jobsetSuspended := jobSetSuspended(js)
+		if jobsetSuspended {
+			if err := r.suspendJobs(ctx, js, ownedJobs.active, updateStatusOpts); err != nil {
+				log.Error(err, "suspending jobset")
+				return ctrl.Result{}, err
+			}
+		} else {
+			if err := r.resumeJobsIfNecessary(ctx, js, ownedJobs.active, rjobStatuses, updateStatusOpts); err != nil {
+				log.Error(err, "resuming jobset")
+				return ctrl.Result{}, err
+			}
 		}
 	}
 
@@ -881,9 +883,11 @@ func constructJob(js *jobset.JobSet, rjob *jobset.ReplicatedJob, jobIdx int) *ba
 		addTaintToleration(job)
 	}
 
-	// if Suspend is set, then we assume all jobs will be suspended also.
-	jobsetSuspended := jobSetSuspended(js)
-	job.Spec.Suspend = ptr.To(jobsetSuspended)
+	if !ShouldSkipSuspendReconciliation(js) {
+		// if Suspend is set, then we assume all jobs will be suspended also.
+		jobsetSuspended := jobSetSuspended(js)
+		job.Spec.Suspend = ptr.To(jobsetSuspended)
+	}
 
 	// If VolumeClaimPolicies are set, update Job spec to set volumes and volumeMounts.
 	if len(js.Spec.VolumeClaimPolicies) > 0 {
@@ -1065,6 +1069,11 @@ func jobSetSuspended(js *jobset.JobSet) bool {
 
 func jobSuspended(job *batchv1.Job) bool {
 	return ptr.Deref(job.Spec.Suspend, false)
+}
+
+func ShouldSkipSuspendReconciliation(js *jobset.JobSet) bool {
+	val, ok := js.Annotations[jobset.ReconciliationModeAnnotation]
+	return ok && val == jobset.ReconciliationModeIndependent
 }
 
 func findReplicatedJobStatus(replicatedJobStatus []jobset.ReplicatedJobStatus, replicatedJobName string) *jobset.ReplicatedJobStatus {

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -1000,6 +1000,54 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 					Suspend(false).Obj(),
 			},
 		},
+		{
+			name:              "independent reconciliation mode keeps job unsuspended",
+			restartJobEnabled: true,
+			js: testutils.MakeJobSet(jobSetName, ns).
+				SetAnnotations(map[string]string{jobset.ReconciliationModeAnnotation: jobset.ReconciliationModeIndependent}).
+				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName).
+					Job(testutils.MakeJobTemplate(jobName, ns).Suspend(false).Obj()).
+					Replicas(1).
+					GroupName("default").
+					Obj()).
+				Obj(),
+			ownedJobs: &childJobs{},
+			want: []*batchv1.Job{
+				makeJob(&makeJobArgs{
+					jobSetName:        jobSetName,
+					replicatedJobName: replicatedJobName,
+					groupName:         "default",
+					jobName:           "test-jobset-replicated-job-0",
+					ns:                ns,
+					replicas:          1,
+					jobIdx:            0}).
+					Suspend(false).Obj(),
+			},
+		},
+		{
+			name:              "independent reconciliation mode keeps job suspended",
+			restartJobEnabled: true,
+			js: testutils.MakeJobSet(jobSetName, ns).
+				SetAnnotations(map[string]string{jobset.ReconciliationModeAnnotation: jobset.ReconciliationModeIndependent}).
+				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName).
+					Job(testutils.MakeJobTemplate(jobName, ns).Suspend(true).Obj()).
+					Replicas(1).
+					GroupName("default").
+					Obj()).
+				Obj(),
+			ownedJobs: &childJobs{},
+			want: []*batchv1.Job{
+				makeJob(&makeJobArgs{
+					jobSetName:        jobSetName,
+					replicatedJobName: replicatedJobName,
+					groupName:         "default",
+					jobName:           "test-jobset-replicated-job-0",
+					ns:                ns,
+					replicas:          1,
+					jobIdx:            0}).
+					Suspend(true).Obj(),
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -399,6 +399,12 @@ func (j *JobWrapper) Suspend(suspend bool) *JobWrapper {
 	return j
 }
 
+// Suspend sets suspend in the job template spec.
+func (j *JobTemplateWrapper) Suspend(suspend bool) *JobTemplateWrapper {
+	j.Spec.Suspend = ptr.To(suspend)
+	return j
+}
+
 // PodAnnotations merges the given annotations to the existing Pod annotations.
 // Duplicate keys will be overwritten by the new annotations (given in the function
 // parameter).

--- a/pkg/webhooks/jobset_webhook.go
+++ b/pkg/webhooks/jobset_webhook.go
@@ -155,6 +155,11 @@ func (j *jobSetWebhook) Default(ctx context.Context, js *jobset.JobSet) error {
 		}
 	}
 
+	// Default JobSet suspend to nil if the reconciliation mode annotation is set to independent mode.
+	if controllers.ShouldSkipSuspendReconciliation(js) {
+		js.Spec.Suspend = nil
+	}
+
 	return nil
 }
 
@@ -303,6 +308,11 @@ func (j *jobSetWebhook) ValidateCreate(ctx context.Context, js *jobset.JobSet) (
 		allErrs = append(allErrs, j.validateVolumeClaimPolicies(ctx, js, js.Spec.VolumeClaimPolicies)...)
 	}
 
+	// Block JobSet suspension from being set to another value than nil if the reconciliation mode annotation is set to independent mode.
+	if controllers.ShouldSkipSuspendReconciliation(js) && js.Spec.Suspend != nil {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("suspend"), js.Spec.Suspend, fmt.Sprintf("must be nil when %s annotation is %s", jobset.ReconciliationModeAnnotation, jobset.ReconciliationModeIndependent)))
+	}
+
 	return nil, errors.Join(allErrs...)
 }
 
@@ -326,6 +336,22 @@ func (j *jobSetWebhook) ValidateUpdate(ctx context.Context, oldJs, newJs *jobset
 	// Note that SucccessPolicy and failurePolicy are made immutable via CEL.
 	errs := apivalidation.ValidateImmutableField(newJs.Spec.ReplicatedJobs, oldJs.Spec.ReplicatedJobs, field.NewPath("spec").Child("replicatedJobs"))
 	errs = append(errs, apivalidation.ValidateImmutableField(newJs.Spec.ManagedBy, oldJs.Spec.ManagedBy, field.NewPath("spec").Child("managedBy"))...)
+
+	// Block JobSet suspension from being changed to another value than nil if the reconciliation mode annotation is set to independent mode.
+	if controllers.ShouldSkipSuspendReconciliation(newJs) && newJs.Spec.Suspend != nil {
+		errs = append(errs, field.Invalid(field.NewPath("spec").Child("suspend"), newJs.Spec.Suspend, fmt.Sprintf("must be nil when %s annotation is %s", jobset.ReconciliationModeAnnotation, jobset.ReconciliationModeIndependent)))
+	}
+
+	// Block reconciliation mode annotation be set to independent mode on an existing JobSet.
+	if !controllers.ShouldSkipSuspendReconciliation(oldJs) && controllers.ShouldSkipSuspendReconciliation(newJs) {
+		errs = append(errs, field.Invalid(field.NewPath("metadata").Child("annotations"), jobset.ReconciliationModeAnnotation, fmt.Sprintf("cannot be set to %s on an existing JobSet. It must be done at JobSet creation", jobset.ReconciliationModeIndependent)))
+	}
+
+	// Block reconciliation mode annotation set to independent mode from being removed from an existing JobSet.
+	if controllers.ShouldSkipSuspendReconciliation(oldJs) && !controllers.ShouldSkipSuspendReconciliation(newJs) {
+		errs = append(errs, field.Invalid(field.NewPath("metadata").Child("annotations"), jobset.ReconciliationModeAnnotation, fmt.Sprintf("set to %s cannot be removed from an existing JobSet. It must be done at JobSet creation", jobset.ReconciliationModeIndependent)))
+	}
+
 	return nil, errs.ToAggregate()
 }
 

--- a/pkg/webhooks/jobset_webhook_test.go
+++ b/pkg/webhooks/jobset_webhook_test.go
@@ -782,6 +782,60 @@ func TestJobSetDefaulting(t *testing.T) {
 		},
 	}
 
+	independentModeDefaultingTests := []jobSetDefaultingTestCase{
+		{
+			name: "suspend is defaulted to nil when reconciliation mode is Independent",
+			js: &jobset.JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						jobset.ReconciliationModeAnnotation: jobset.ReconciliationModeIndependent,
+					},
+				},
+				Spec: jobset.JobSetSpec{
+					Suspend:       ptr.To(true),
+					SuccessPolicy: defaultSuccessPolicy,
+					StartupPolicy: defaultStartupPolicy,
+					Network:       defaultNetwork,
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Template:       TestPodTemplate,
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
+								},
+							},
+						},
+					},
+					ManagedBy: ptr.To(jobset.JobSetControllerName),
+				},
+			},
+			want: &jobset.JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						jobset.ReconciliationModeAnnotation: jobset.ReconciliationModeIndependent,
+					},
+				},
+				Spec: jobset.JobSetSpec{
+					Suspend:       nil,
+					SuccessPolicy: defaultSuccessPolicy,
+					StartupPolicy: defaultStartupPolicy,
+					Network:       defaultNetwork,
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Template:       TestPodTemplate,
+									CompletionMode: ptr.To(batchv1.IndexedCompletion),
+								},
+							},
+						},
+					},
+					ManagedBy: ptr.To(jobset.JobSetControllerName),
+				},
+			},
+		},
+	}
+
 	testGroups := [][]jobSetDefaultingTestCase{
 		jobCompletionTests,
 		enablingDNSHostnameTests,
@@ -793,6 +847,7 @@ func TestJobSetDefaulting(t *testing.T) {
 		managedByTests,
 		failurePolicyRuleNameTests,
 		volumeRetentionPolicyTests,
+		independentModeDefaultingTests,
 	}
 	var testCases []jobSetDefaultingTestCase
 	for _, testGroup := range testGroups {
@@ -3063,6 +3118,40 @@ func TestValidateCreate(t *testing.T) {
 		},
 	}
 
+	independentModeValidationCreateTests := []validationTestCase{
+		{
+			name: "suspend must be nil when reconciliation mode is Independent",
+			js: &jobset.JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "js",
+					Annotations: map[string]string{
+						jobset.ReconciliationModeAnnotation: jobset.ReconciliationModeIndependent,
+					},
+				},
+				Spec: jobset.JobSetSpec{
+					Suspend: ptr.To(true),
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:      "test-jobset-replicated-job-0",
+							GroupName: "test-group",
+							Replicas:  1,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](1),
+									Template:    validPodTemplateSpec,
+								},
+							},
+						},
+					},
+					SuccessPolicy: &jobset.SuccessPolicy{},
+				},
+			},
+			want: errors.Join(
+				fmt.Errorf("must be nil when %s annotation is %s", jobset.ReconciliationModeAnnotation, jobset.ReconciliationModeIndependent),
+			),
+		},
+	}
+
 	testGroups := [][]validationTestCase{
 		uncategorizedTests,
 		jobsetControllerNameTests,
@@ -3070,6 +3159,7 @@ func TestValidateCreate(t *testing.T) {
 		dependsOnTests,
 		volumeClaimPolicyTests,
 		inPlaceRestartTests,
+		independentModeValidationCreateTests,
 	}
 	var testCases []validationTestCase
 	for _, testGroup := range testGroups {
@@ -3437,6 +3527,82 @@ func TestValidateUpdate(t *testing.T) {
 			},
 			want: field.ErrorList{
 				field.Invalid(field.NewPath("spec").Child("replicatedJobs"), "", "field is immutable"),
+			}.ToAggregate(),
+		},
+		{
+			name: "suspend cannot be set to a value other than nil if reconciliation mode is Independent",
+			js: &jobset.JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "js",
+					Annotations: map[string]string{
+						jobset.ReconciliationModeAnnotation: jobset.ReconciliationModeIndependent,
+					},
+				},
+				Spec: jobset.JobSetSpec{
+					Suspend:        ptr.To(true),
+					ReplicatedJobs: validReplicatedJobs,
+				},
+			},
+			oldJs: &jobset.JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "js",
+					Annotations: map[string]string{
+						jobset.ReconciliationModeAnnotation: jobset.ReconciliationModeIndependent,
+					},
+				},
+				Spec: jobset.JobSetSpec{
+					Suspend:        nil,
+					ReplicatedJobs: validReplicatedJobs,
+				},
+			},
+			want: field.ErrorList{
+				field.Invalid(field.NewPath("spec").Child("suspend"), ptr.To(true), fmt.Sprintf("must be nil when %s annotation is %s", jobset.ReconciliationModeAnnotation, jobset.ReconciliationModeIndependent)),
+			}.ToAggregate(),
+		},
+		{
+			name: "reconciliation mode Independent cannot be added on update",
+			js: &jobset.JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "js",
+					Annotations: map[string]string{
+						jobset.ReconciliationModeAnnotation: jobset.ReconciliationModeIndependent,
+					},
+				},
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: validReplicatedJobs,
+				},
+			},
+			oldJs: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: validReplicatedJobs,
+				},
+			},
+			want: field.ErrorList{
+				field.Invalid(field.NewPath("metadata").Child("annotations"), jobset.ReconciliationModeAnnotation, fmt.Sprintf("cannot be set to %s on an existing JobSet. It must be done at JobSet creation", jobset.ReconciliationModeIndependent)),
+			}.ToAggregate(),
+		},
+		{
+			name: "reconciliation mode Independent cannot be removed on update",
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: validReplicatedJobs,
+				},
+			},
+			oldJs: &jobset.JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "js",
+					Annotations: map[string]string{
+						jobset.ReconciliationModeAnnotation: jobset.ReconciliationModeIndependent,
+					},
+				},
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: validReplicatedJobs,
+				},
+			},
+			want: field.ErrorList{
+				field.Invalid(field.NewPath("metadata").Child("annotations"), jobset.ReconciliationModeAnnotation, fmt.Sprintf("set to %s cannot be removed from an existing JobSet. It must be done at JobSet creation", jobset.ReconciliationModeIndependent)),
 			}.ToAggregate(),
 		},
 	}

--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -1497,6 +1497,44 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 				},
 			},
 		}),
+		ginkgo.Entry("jobset created with independent reconciliation mode keeps jobs unsuspended", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				wrapper := testJobSet(ns).SetAnnotations(map[string]string{jobset.ReconciliationModeAnnotation: jobset.ReconciliationModeIndependent})
+				wrapper.Obj().Spec.Suspend = nil // simulating webhook defaulting behavior
+
+				for i := range wrapper.Obj().Spec.ReplicatedJobs {
+					wrapper.Obj().Spec.ReplicatedJobs[i].Template.Spec.Suspend = ptr.To(false)
+				}
+				return wrapper
+			},
+			steps: []*step{
+				{
+					checkJobSetState: func(js *jobset.JobSet) {
+						ginkgo.By("checking all jobs are unsuspended")
+						gomega.Eventually(matchJobsSuspendState, timeout, interval).WithArguments(js, false).Should(gomega.Equal(true))
+					},
+				},
+			},
+		}),
+		ginkgo.Entry("jobset created with independent reconciliation mode keeps jobs suspended", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				wrapper := testJobSet(ns).SetAnnotations(map[string]string{jobset.ReconciliationModeAnnotation: jobset.ReconciliationModeIndependent})
+				wrapper.Obj().Spec.Suspend = nil // simulating webhook defaulting behavior
+
+				for i := range wrapper.Obj().Spec.ReplicatedJobs {
+					wrapper.Obj().Spec.ReplicatedJobs[i].Template.Spec.Suspend = ptr.To(true)
+				}
+				return wrapper
+			},
+			steps: []*step{
+				{
+					checkJobSetState: func(js *jobset.JobSet) {
+						ginkgo.By("checking all jobs are suspended")
+						gomega.Eventually(matchJobsSuspendState, timeout, interval).WithArguments(js, true).Should(gomega.Equal(true))
+					},
+				},
+			},
+		}),
 		ginkgo.Entry("service deleted", &testCase{
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
 				return testJobSet(ns)

--- a/test/integration/webhook/jobset_webhook_test.go
+++ b/test/integration/webhook/jobset_webhook_test.go
@@ -237,6 +237,74 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 			},
 			updateShouldFail: true,
 		}),
+		ginkgo.Entry("suspend is forced to nil when reconciliation mode is Independent", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("independent-mode", ns.Name).
+					SetAnnotations(map[string]string{
+						jobset.ReconciliationModeAnnotation: jobset.ReconciliationModeIndependent,
+					}).
+					Suspend(true).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob").
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							PodSpec(testing.TestPodSpec).
+							CompletionMode(batchv1.IndexedCompletion).Obj()).
+						Obj())
+			},
+			defaultsApplied: func(js *jobset.JobSet) bool {
+				return js.Spec.Suspend == nil
+			},
+		}),
+		ginkgo.Entry("adding Independent reconciliation mode annotation to an existing JobSet is rejected", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("independent-mode-add", ns.Name).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob").
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							PodSpec(testing.TestPodSpec).
+							CompletionMode(batchv1.IndexedCompletion).Obj()).
+						Obj())
+			},
+			updateJobSet: func(js *jobset.JobSet) {
+				if js.Annotations == nil {
+					js.Annotations = make(map[string]string)
+				}
+				js.Annotations[jobset.ReconciliationModeAnnotation] = jobset.ReconciliationModeIndependent
+			},
+			updateShouldFail: true,
+		}),
+		ginkgo.Entry("removing Independent reconciliation mode annotation from an existing JobSet is rejected", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("independent-mode-remove", ns.Name).
+					SetAnnotations(map[string]string{
+						jobset.ReconciliationModeAnnotation: jobset.ReconciliationModeIndependent,
+					}).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob").
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							PodSpec(testing.TestPodSpec).
+							CompletionMode(batchv1.IndexedCompletion).Obj()).
+						Obj())
+			},
+			updateJobSet: func(js *jobset.JobSet) {
+				delete(js.Annotations, jobset.ReconciliationModeAnnotation)
+			},
+			updateShouldFail: true,
+		}),
+		ginkgo.Entry("modifying suspend state when Independent reconciliation mode is set is rejected", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("independent-mode-suspend", ns.Name).
+					SetAnnotations(map[string]string{
+						jobset.ReconciliationModeAnnotation: jobset.ReconciliationModeIndependent,
+					}).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob").
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							PodSpec(testing.TestPodSpec).
+							CompletionMode(batchv1.IndexedCompletion).Obj()).
+						Obj())
+			},
+			updateJobSet: func(js *jobset.JobSet) {
+				js.Spec.Suspend = ptr.To(true)
+			},
+			updateShouldFail: true,
+		}),
 		ginkgo.Entry("success policy defaults to all", &testCase{
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
 				return testing.MakeJobSet("success-policy", ns.Name).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

Implement [KEP 1172](https://github.com/kubernetes-sigs/jobset/pull/1178) to add support for granular suspend/resume for individual Jobs. See the KEP for more details.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #1172

#### Special notes for your reviewer:

/hold while we wait for the KEP to be approved.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add support for granular suspend/resume for individual Jobs (KEP 1172).
```