### PR TITLE
Refactor: dedupe replicated job status computation

### DIFF
--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/go-logr/logr"
 	"k8s.io/utils/clock"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -449,6 +450,22 @@ func updateReplicatedJobsStatuses(js *jobset.JobSet, statuses []jobset.Replicate
 	updateStatusOpts.shouldUpdate = true
 }
 
+// validateAndGetReplicatedJobName validates that a job has the required ReplicatedJobName label
+// and that it corresponds to a valid ReplicatedJob in the JobSet.
+// Returns the replicatedJobName and a boolean indicating if validation passed.
+func validateAndGetReplicatedJobName(log logr.Logger, job *batchv1.Job, replicatedJobsReady map[string]map[string]int32) (string, bool) {
+	if job.Labels == nil || job.Labels[jobset.ReplicatedJobNameKey] == "" {
+		log.Error(fmt.Errorf("job %s missing ReplicatedJobName label", job.Name), "can't update status")
+		return "", false
+	}
+	replicatedJobName := job.Labels[jobset.ReplicatedJobNameKey]
+	if replicatedJobsReady[replicatedJobName] == nil {
+		log.Error(fmt.Errorf("job %s has ReplicatedJobName %s that is not part of JobSet", job.Name, replicatedJobName), "can't update status", "job", job.Name, "replicatedJobName", replicatedJobName)
+		return "", false
+	}
+	return replicatedJobName, true
+}
+
 // calculateReplicatedJobStatuses uses the JobSet's child jobs to update the statuses
 // of each of its replicatedJobs.
 func (r *JobSetReconciler) calculateReplicatedJobStatuses(ctx context.Context, js *jobset.JobSet, jobs *childJobs) []jobset.ReplicatedJobStatus {
@@ -468,18 +485,12 @@ func (r *JobSetReconciler) calculateReplicatedJobStatuses(ctx context.Context, j
 
 	// Calculate jobsReady for each Replicated Job
 	for _, job := range jobs.active {
-		if job.Labels == nil || job.Labels[jobset.ReplicatedJobNameKey] == "" {
-			log.Error(nil, fmt.Sprintf("job %s missing ReplicatedJobName label, can't update status", job.Name))
-			continue
-		}
-		replicatedJobName := job.Labels[jobset.ReplicatedJobNameKey]
-		if replicatedJobsReady[replicatedJobName] == nil {
-			log.Error(nil, fmt.Sprintf("job %s has ReplicatedJobName %s that is not part of JobSet", job.Name, replicatedJobName))
+		replicatedJobName, ok := validateAndGetReplicatedJobName(log, job, replicatedJobsReady)
+		if !ok {
 			continue
 		}
 		ready := ptr.Deref(job.Status.Ready, 0)
-		// parallelism is always set as it is otherwise defaulted by k8s to 1
-		podsCount := *(job.Spec.Parallelism)
+		podsCount := ptr.Deref(job.Spec.Parallelism, 1)
 		if job.Spec.Completions != nil && *job.Spec.Completions < podsCount {
 			podsCount = *job.Spec.Completions
 		}
@@ -496,13 +507,8 @@ func (r *JobSetReconciler) calculateReplicatedJobStatuses(ctx context.Context, j
 
 	// Calculate succeededJobs
 	for _, job := range jobs.successful {
-		if job.Labels == nil || job.Labels[jobset.ReplicatedJobNameKey] == "" {
-			log.Error(nil, fmt.Sprintf("job %s missing ReplicatedJobName label, can't update status", job.Name))
-			continue
-		}
-		replicatedJobName := job.Labels[jobset.ReplicatedJobNameKey]
-		if replicatedJobsReady[replicatedJobName] == nil {
-			log.Error(nil, fmt.Sprintf("job %s has ReplicatedJobName %s that is not part of JobSet", job.Name, replicatedJobName))
+		replicatedJobName, ok := validateAndGetReplicatedJobName(log, job, replicatedJobsReady)
+		if !ok {
 			continue
 		}
 		replicatedJobsReady[replicatedJobName]["succeeded"]++
@@ -510,13 +516,8 @@ func (r *JobSetReconciler) calculateReplicatedJobStatuses(ctx context.Context, j
 
 	// Calculate failedJobs
 	for _, job := range jobs.failed {
-		if job.Labels == nil || job.Labels[jobset.ReplicatedJobNameKey] == "" {
-			log.Error(nil, fmt.Sprintf("job %s missing ReplicatedJobName label, can't update status", job.Name))
-			continue
-		}
-		replicatedJobName := job.Labels[jobset.ReplicatedJobNameKey]
-		if replicatedJobsReady[replicatedJobName] == nil {
-			log.Error(nil, fmt.Sprintf("job %s has ReplicatedJobName %s that is not part of JobSet", job.Name, replicatedJobName))
+		replicatedJobName, ok := validateAndGetReplicatedJobName(log, job, replicatedJobsReady)
+		if !ok {
 			continue
 		}
 		replicatedJobsReady[replicatedJobName]["failed"]++

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -1539,6 +1539,34 @@ func TestCalculateReplicatedJobStatuses(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "active job with nil Parallelism defaults to 1",
+			js: testutils.MakeJobSet(jobSetName, ns).
+				ReplicatedJob(testutils.MakeReplicatedJob("replicated-job-1").
+					Job(testutils.MakeJobTemplate("test-job", ns).Obj()).
+					Replicas(1).
+					Obj()).Obj(),
+			jobs: childJobs{
+				active: []*batchv1.Job{
+					// Parallelism not set (nil) — ptr.Deref defaults to 1, so Ready(1) makes it ready.
+					makeJob(&makeJobArgs{
+						jobSetName:        jobSetName,
+						replicatedJobName: "replicated-job-1",
+						groupName:         "default",
+						jobName:           "test-jobset-replicated-job-1-test-job-0",
+						ns:                ns,
+						replicas:          1,
+						jobIdx:            0}).
+						Ready(1).Obj(),
+				},
+			},
+			expected: []jobset.ReplicatedJobStatus{
+				{
+					Name:  "replicated-job-1",
+					Ready: 1,
+				},
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Extract validation helper, simplify status calculation.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```