### PR TITLE
Fix admission webhook to return Invalid instead of Forbidden

### DIFF
--- a/pkg/webhooks/jobset_webhook.go
+++ b/pkg/webhooks/jobset_webhook.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -303,7 +304,7 @@ func (j *jobSetWebhook) ValidateCreate(ctx context.Context, js *jobset.JobSet) (
 		allErrs = append(allErrs, j.validateVolumeClaimPolicies(ctx, js, js.Spec.VolumeClaimPolicies)...)
 	}
 
-	return nil, errors.Join(allErrs...)
+	return nil, invalidError(js.Name, allErrs)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
@@ -326,7 +327,14 @@ func (j *jobSetWebhook) ValidateUpdate(ctx context.Context, oldJs, newJs *jobset
 	// Note that SucccessPolicy and failurePolicy are made immutable via CEL.
 	errs := apivalidation.ValidateImmutableField(newJs.Spec.ReplicatedJobs, oldJs.Spec.ReplicatedJobs, field.NewPath("spec").Child("replicatedJobs"))
 	errs = append(errs, apivalidation.ValidateImmutableField(newJs.Spec.ManagedBy, oldJs.Spec.ManagedBy, field.NewPath("spec").Child("managedBy"))...)
-	return nil, errs.ToAggregate()
+	if len(errs) == 0 {
+		return nil, nil
+	}
+	return nil, apierrors.NewInvalid(
+		schema.GroupKind{Group: "jobset.x-k8s.io", Kind: "JobSet"},
+		newJs.Name,
+		errs,
+	)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
@@ -596,4 +604,38 @@ func replicatedJobByName(js *jobset.JobSet, replicatedJob string) *jobset.Replic
 		}
 	}
 	return nil
+}
+
+// toFieldErrorList converts a slice of errors (which may contain a mix of
+// *field.Error and plain errors) into a field.ErrorList. Existing *field.Error
+// values are preserved as-is; plain errors are wrapped as field.InternalError.
+func toFieldErrorList(errs []error) field.ErrorList {
+	var fieldErrs field.ErrorList
+	for _, err := range errs {
+		if err == nil {
+			continue
+		}
+		var fe *field.Error
+		if errors.As(err, &fe) {
+			fieldErrs = append(fieldErrs, fe)
+		} else {
+			fieldErrs = append(fieldErrs, field.InternalError(nil, err))
+		}
+	}
+	return fieldErrs
+}
+
+// invalidError converts a list of validation errors into an
+// *apierrors.StatusError with HTTP 422 (Unprocessable Entity) and reason
+// "Invalid". Returns nil if there are no errors.
+func invalidError(name string, errs []error) error {
+	fieldErrs := toFieldErrorList(errs)
+	if len(fieldErrs) == 0 {
+		return nil
+	}
+	return apierrors.NewInvalid(
+		schema.GroupKind{Group: "jobset.x-k8s.io", Kind: "JobSet"},
+		name,
+		fieldErrs,
+	)
 }

--- a/pkg/webhooks/jobset_webhook_test.go
+++ b/pkg/webhooks/jobset_webhook_test.go
@@ -9,10 +9,11 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -3085,7 +3086,16 @@ func TestValidateCreate(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.RestartJob, tc.enableRestartJob)
 			_, err := testWebhook.ValidateCreate(context.TODO(), tc.js.DeepCopy())
 			if err != nil && tc.want != nil {
-				assert.Contains(t, err.Error(), tc.want.Error())
+				// Verify it's specifically a 422 StatusError
+				var statusErr *apierrors.StatusError
+				require.ErrorAs(t, err, &statusErr, "expected *apierrors.StatusError")
+				assert.Equal(t, int32(422), statusErr.ErrStatus.Code)
+				assert.Equal(t, metav1.StatusReasonInvalid, statusErr.ErrStatus.Reason)
+
+				// Verify all expected error substrings are present
+				for _, wantErr := range strings.Split(tc.want.Error(), "\n") {
+					assert.Contains(t, err.Error(), wantErr)
+				}
 			} else if err != nil && tc.want == nil {
 				t.Errorf("unexpected error: %v", err)
 			} else if err == nil && tc.want != nil {
@@ -3448,9 +3458,20 @@ func TestValidateUpdate(t *testing.T) {
 			newObj := tc.js.DeepCopy()
 			oldObj := tc.oldJs.DeepCopy()
 			_, err := webhook.ValidateUpdate(context.TODO(), oldObj, newObj)
-			// Ignore bad value to keep test cases short and readable.
-			if diff := cmp.Diff(tc.want, err, cmpopts.IgnoreFields(field.Error{}, "BadValue")); diff != "" {
-				t.Errorf("ValidateResources() mismatch (-want +got):\n%s", diff)
+			if err != nil && tc.want != nil {
+				var statusErr *apierrors.StatusError
+				require.ErrorAs(t, err, &statusErr, "expected *apierrors.StatusError")
+				assert.Equal(t, int32(422), statusErr.ErrStatus.Code)
+				assert.Equal(t, metav1.StatusReasonInvalid, statusErr.ErrStatus.Reason)
+
+				for _, cause := range statusErr.ErrStatus.Details.Causes {
+					assert.Contains(t, tc.want.Error(), cause.Field)
+					assert.Contains(t, cause.Message, "field is immutable")
+				}
+			} else if err != nil && tc.want == nil {
+				t.Errorf("unexpected error: %v", err)
+			} else if err == nil && tc.want != nil {
+				t.Errorf("missing expected error: %v", tc.want)
 			}
 		})
 	}


### PR DESCRIPTION

#### What type of PR is this?

Add one of the following kinds:
/kind bug

#### What this PR does / why we need it:
 When a JobSet is rejected by the validating admission webhook (e.g., invalid failure policy rule name), the API returns HTTP 403 Forbidden instead of the expected 422. This is because ValidateCreate returns a plain error via errors.Join(allErrs...) (line 306 of jobset_webhook.go). Controller-runtime's webhook handler checks if the returned error is an*apierrors.StatusError — if not, it calls admission.Denied() which defaults to 403.
Here is an example:
```
CreateJobSet: admission webhook "validate-jobset-x-k8s-io-v1alpha2-jobset.x-k8s.io" denied the request: invalid failure policy rule name 'fail-non-retryable', a failure policy rule name must start with an alphabetic character, optionally followed by a string of alphanumeric characters or '_,:', and must end with an alphanumeric character or '_' (code=403, reason=Forbidden) service_<truncated 285 symbols, right click to see full line>-v5g-moe-b4c4f: CreateJobSet: admission webhook "validate-jobset-x-k8s-io-v1alpha2-jobset.x-k8s.io" denied the request: invalid failure policy rule name 'fail-non-retryable', a failure policy rule name must start with an alphabetic character, optionally followed by a string of alphanumeric characters or '_,:', and must end with an alphanumeric character or '_' (code=403, reason=Forbidden)
```

#### Test
```
jieh@jieh-mac jobset % go test ./pkg/webhooks/ -count=1
ok      sigs.k8s.io/jobset/pkg/webhooks 0.810s
```

#### Which issue(s) this PR fixes:
Wrap the validation errors in apierrors.NewInvalid() which produces a *apierrors.StatusError with status code 422 and reason "Invalid".

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
"NONE"