### PR TITLE
Jobset admission webhook validate each replicated job

### DIFF
--- a/pkg/webhooks/jobset_webhook.go
+++ b/pkg/webhooks/jobset_webhook.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -304,6 +305,9 @@ func (j *jobSetWebhook) ValidateCreate(ctx context.Context, js *jobset.JobSet) (
 		allErrs = append(allErrs, j.validateVolumeClaimPolicies(ctx, js, js.Spec.VolumeClaimPolicies)...)
 	}
 
+	// Validate each ReplicatedJob's Job template via dry-run creation.
+	allErrs = append(allErrs, j.validateJobTemplates(ctx, js)...)
+
 	return nil, invalidError(js.Name, allErrs)
 }
 
@@ -340,6 +344,38 @@ func (j *jobSetWebhook) ValidateUpdate(ctx context.Context, oldJs, newJs *jobset
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (j *jobSetWebhook) ValidateDelete(ctx context.Context, js *jobset.JobSet) (admission.Warnings, error) {
 	return nil, nil
+}
+
+// validateJobTemplates performs a server-side dry-run creation of a Job for
+// each ReplicatedJob, surfacing Pod/Job spec validation errors at admission
+// time rather than deferring them to Job creation.
+func (j *jobSetWebhook) validateJobTemplates(ctx context.Context, js *jobset.JobSet) []error {
+	var allErrs []error
+	for rJobIdx, rJob := range js.Spec.ReplicatedJobs {
+		fieldPath := field.NewPath("spec", "replicatedJobs").Index(rJobIdx).Child("template")
+		job := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      placement.GenJobName(js.Name, rJob.Name, 0),
+				Namespace: js.Namespace,
+			},
+			Spec: *rJob.Template.Spec.DeepCopy(),
+		}
+		if err := j.client.Create(ctx, job, client.DryRunAll); err != nil {
+			var statusErr *apierrors.StatusError
+			if errors.As(err, &statusErr) && statusErr.Status().Details != nil {
+				for _, cause := range statusErr.Status().Details.Causes {
+					allErrs = append(allErrs, field.Invalid(
+						fieldPath.Child(cause.Field),
+						"",
+						cause.Message,
+					))
+				}
+			} else {
+				allErrs = append(allErrs, field.Invalid(fieldPath, nil, err.Error()))
+			}
+		}
+	}
+	return allErrs
 }
 
 // Failure policy constants.

--- a/test/integration/webhook/jobset_webhook_test.go
+++ b/test/integration/webhook/jobset_webhook_test.go
@@ -753,5 +753,29 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 			},
 			jobSetCreationShouldFail: true,
 		}),
+		ginkgo.Entry("invalid Job template spec (missing volumeMount mountPath) should be rejected", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("invalid-job-template", ns.Name).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob").
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							PodSpec(corev1.PodSpec{
+								RestartPolicy: corev1.RestartPolicyOnFailure,
+								Containers: []corev1.Container{
+									{
+										Name:  "test-container",
+										Image: "busybox:latest",
+										VolumeMounts: []corev1.VolumeMount{
+											{
+												Name: "data",
+											},
+										},
+									},
+								},
+							}).
+							CompletionMode(batchv1.IndexedCompletion).Obj()).
+						Obj())
+			},
+			jobSetCreationShouldFail: true,
+		}),
 	) // end of DescribeTable
 }) // end of Describe


### PR DESCRIPTION

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

The JobSet validation webhook only validated JobSet-level semantics (naming, cross-references, feature gates) but did not validate the inner Job/Pod template spec. Invalid specs like missing volumeMounts[0].mountPath were only caught when the controller tried to create the actual Job. As a result, jobset creation is accepted but later on replicated child job failed with invalid spec. It would be good to reject bad spec in the async path on create jobset.

Example failure
```
job "snr-base64-cks-tier2-3p3b-normsp-vidonly-0081d-w-0" creation failed with error: Job.batch "snr-base64-cks-tier2-3p3b-normsp-vidonly-0081d-w-0" is invalid: spec.template.spec.containers[0].volumeMounts[0].mountPath: Required value
```

#### Which issue(s) this PR fixes:

Added server-side dry-run validation of each ReplicatedJob's Job template during webhook admission.

```
jieh@jieh-mac jobset % go test ./pkg/webhooks/ -count=1
ok      sigs.k8s.io/jobset/pkg/webhooks 0.760s
```

#### Does this PR introduce a user-facing change?

"NONE"