### PR TITLE
Fix image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,6 +306,7 @@ clean-artifacts:
 
 .PHONY: artifacts
 artifacts: clean-artifacts kustomize helm yq helm-chart-package ## Generate release artifacts.
+	cd config/components/manager && $(KUSTOMIZE) edit set image controller=${IMAGE_TAG}
 	$(KUSTOMIZE) build config/default -o artifacts/manifests.yaml
 	$(KUSTOMIZE) build config/prometheus -o artifacts/prometheus.yaml
 	@$(call clean-manifests)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

During release preparation and release artifacts generation, the generated Kubernetes manifests (`artifacts/manifests.yaml`) incorrectly pointed to the staging registry instead of overriding it with the provided production registry.

This PR restores the `kustomize edit set image` command to the `artifacts` target in the `Makefile` to ensure the production registry is correctly utilized during artifact generation.

#### Which issue(s) this PR fixes:

Fixes #1216

#### Special notes for your reviewer:

This change perfectly replicates the correct behavior from older versions (e.g., `v0.9.0`).

#### Does this PR introduce a user-facing change?

```release-note
Fixed a regression in `make artifacts` that caused release manifests to incorrectly use the staging image registry instead of the production image registry.
```

#### Repro

```bash
make artifacts IMAGE_REGISTRY=registry.k8s.io/jobset GIT_TAG=v0.12.0
grep 'image:' artifacts/manifests.yaml
```