### PR TITLE
Add condition RestartingJobSet

### DIFF
--- a/api/jobset/v1alpha2/jobset_types.go
+++ b/api/jobset/v1alpha2/jobset_types.go
@@ -108,6 +108,8 @@ const (
 	JobSetFailed JobSetConditionType = "Failed"
 	// JobSetSuspended means the job is suspended.
 	JobSetSuspended JobSetConditionType = "Suspended"
+	// JobSetRestarting means the JobSet is restarting.
+	JobSetRestarting JobSetConditionType = "RestartingJobSet"
 	// JobSetStartupPolicyInProgress means the StartupPolicy is in progress.
 	JobSetStartupPolicyInProgress JobSetConditionType = "StartupPolicyInProgress"
 	// JobSetStartupPolicyCompleted means the StartupPolicy has completed.

--- a/keps/262-ConfigurableFailurePolicy/README.md
+++ b/keps/262-ConfigurableFailurePolicy/README.md
@@ -666,6 +666,12 @@ Status
 ```go
 // JobSetStatus defines the observed state of JobSet
 type JobSetStatus struct {
+	// conditions track status
+	// +optional
+	// +listType=map
+	// +listMapKey=type
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
+
 	// restarts tracks the number of times the JobSet has been globally restarted.
 	// That is, restarts is the number of times the restart action RestartJobSet or RestartJobSetAndIgnoreMaxRestarts have been executed and led to the recreation of all Jobs.
 	// +optional
@@ -676,6 +682,8 @@ type JobSetStatus struct {
 	// +optional
 	RestartsCountTowardsMax int32 `json:"restartsCountTowardsMax,omitempty"`
 }
+
+The `RestartingJobSet` condition in `jobSet.status.conditions` tracks the in-progress state of a global restart (recreate-all-jobs). It transitions to `True` with reason `FailurePolicy_{RuleName}` or `DefaultFailurePolicy` when a global restart is triggered (i.e., action `RestartJobSet` or `RestartJobSetAndIgnoreMaxRestarts`) and transitions to `False` with reason `JobsReady` once all recreated jobs are ready or `JobSetCompleted`/`JobSetFailed`/`JobSetSuspended` if the JobSet finishes or is suspended during the restart.
 
 // ReplicatedJobStatus defines the observed ReplicatedJobs Readiness.
 type ReplicatedJobStatus struct {
@@ -778,7 +786,6 @@ Observability:
 
 - `jobSet.status.restarts`, `jobSet.status.restartsCountTowardsMax` and `job.labels['jobset.sigs.k8s.io/restart-attempt']` track only recreate-all-jobs restarts
 - `jobSet.status.replicatedJobsStatus[].jobRestarts`, `jobSet.status.replicatedJobsStatus[].jobRestartsCountTowardsMax` and `job.labels['jobset.sigs.k8s.io/job-restart-attempt']` track only recreate-single-job restarts
-- `RestartingJobSet` condition in `jobSet.status.conditions` tracks the in-progress state of a global restart (recreate-all-jobs). It transitions to `True` with reason `FailurePolicy_{RuleName}` or `DefaultFailurePolicy` when a global restart is triggered (i.e., action `RestartJobSet` or `RestartJobSetAndIgnoreMaxRestarts`) and transitions to `False` with reason `JobsReady` once all recreated jobs are ready or `JobSetCompleted`/`JobSetFailed`/`JobSetSuspended` if the JobSet finishes or is suspended during the restart.
 
 Future changes:
 

--- a/keps/262-ConfigurableFailurePolicy/README.md
+++ b/keps/262-ConfigurableFailurePolicy/README.md
@@ -778,6 +778,7 @@ Observability:
 
 - `jobSet.status.restarts`, `jobSet.status.restartsCountTowardsMax` and `job.labels['jobset.sigs.k8s.io/restart-attempt']` track only recreate-all-jobs restarts
 - `jobSet.status.replicatedJobsStatus[].jobRestarts`, `jobSet.status.replicatedJobsStatus[].jobRestartsCountTowardsMax` and `job.labels['jobset.sigs.k8s.io/job-restart-attempt']` track only recreate-single-job restarts
+- `RestartingJobSet` condition in `jobSet.status.conditions` tracks the in-progress state of a global restart (recreate-all-jobs). It transitions to `True` with reason `FailurePolicy_{RuleName}` or `DefaultFailurePolicy` when a global restart is triggered (i.e., action `RestartJobSet` or `RestartJobSetAndIgnoreMaxRestarts`) and transitions to `False` with reason `JobsReady` once all recreated jobs are ready or `JobSetCompleted`/`JobSetFailed`/`JobSetSuspended` if the JobSet finishes or is suspended during the restart.
 
 Future changes:
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -85,6 +85,18 @@ const (
 	// Event reason and messages related to JobSet restarts.
 	JobSetRestartReason = "Restarting"
 
+	// Condition reasons related to JobSet restarts.
+	RestartingJobSetReasonDefaultFailurePolicy = "DefaultFailurePolicy"
+	RestartingJobSetReasonFailurePolicyFormat  = "FailurePolicy_%s"
+	RestartingJobSetReasonJobsReady            = "JobsReady"
+	RestartingJobSetReasonJobSetFailed         = "JobSetFailed"
+	RestartingJobSetReasonJobSetCompleted      = "JobSetCompleted"
+	RestartingJobSetReasonJobSetSuspended      = "JobSetSuspended"
+
+	// Condition messages related to JobSet restarts.
+	RestartingJobSetReasonJobsReadyMessage    = "all jobs are ready"
+	RestartingJobSetReasonJobSetFailedMessage = "jobset failed"
+
 	// Event reason and messages related to suspending a JobSet.
 	JobSetSuspendedReason  = "SuspendedJobs"
 	JobSetSuspendedMessage = "jobset is suspended"

--- a/pkg/controllers/failure_policy.go
+++ b/pkg/controllers/failure_policy.go
@@ -73,7 +73,7 @@ func executeFailurePolicy(ctx context.Context, js *jobset.JobSet, ownedJobs *chi
 		failurePolicyRuleAction = matchingFailurePolicyRule.Action
 	}
 
-	if err := applyFailurePolicyRuleAction(ctx, js, matchingFailedJob, updateStatusOpts, failurePolicyRuleAction); err != nil {
+	if err := applyFailurePolicyRuleAction(ctx, js, matchingFailedJob, matchingFailurePolicyRule, updateStatusOpts, failurePolicyRuleAction); err != nil {
 		log.Error(err, "applying FailurePolicyRuleAction %v", failurePolicyRuleAction)
 		return err
 	}
@@ -119,7 +119,7 @@ func findFirstFailedPolicyRuleAndJob(ctx context.Context, rules []jobset.Failure
 }
 
 // applyFailurePolicyRuleAction applies the supplied FailurePolicyRuleAction.
-func applyFailurePolicyRuleAction(ctx context.Context, js *jobset.JobSet, matchingFailedJob *batchv1.Job, updateStatusOps *statusUpdateOpts, failurePolicyRuleAction jobset.FailurePolicyAction) error {
+func applyFailurePolicyRuleAction(ctx context.Context, js *jobset.JobSet, matchingFailedJob *batchv1.Job, rule *jobset.FailurePolicyRule, updateStatusOps *statusUpdateOpts, failurePolicyRuleAction jobset.FailurePolicyAction) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	applier, ok := actionFunctionMap[failurePolicyRuleAction]
@@ -129,7 +129,7 @@ func applyFailurePolicyRuleAction(ctx context.Context, js *jobset.JobSet, matchi
 		return err
 	}
 
-	if err := applier(ctx, js, matchingFailedJob, updateStatusOps); err != nil {
+	if err := applier(ctx, js, matchingFailedJob, rule, updateStatusOps); err != nil {
 		log.Error(err, fmt.Sprintf("error applying the FailurePolicyRuleAction: %v", failurePolicyRuleAction))
 		return err
 	}
@@ -183,7 +183,7 @@ func anyMatchFound(ctx context.Context, patterns []string, message string) bool 
 }
 
 // failurePolicyRecreateAll triggers a JobSet restart for the next reconcillation loop.
-func failurePolicyRecreateAll(ctx context.Context, js *jobset.JobSet, shouldCountTowardsMax bool, updateStatusOpts *statusUpdateOpts, event *eventParams) {
+func failurePolicyRecreateAll(ctx context.Context, js *jobset.JobSet, shouldCountTowardsMax bool, updateStatusOpts *statusUpdateOpts, event *eventParams, condOpts *conditionOpts) {
 	log := ctrl.LoggerFrom(ctx)
 
 	if updateStatusOpts == nil {
@@ -199,6 +199,9 @@ func failurePolicyRecreateAll(ctx context.Context, js *jobset.JobSet, shouldCoun
 
 	updateStatusOpts.shouldUpdate = true
 
+	// Set the restarting condition
+	setCondition(js, condOpts, updateStatusOpts)
+
 	// Emit event for each JobSet restarts for observability and debugability.
 	enqueueEvent(updateStatusOpts, event)
 	log.V(2).Info("attempting restart", "restart attempt", js.Status.Restarts)
@@ -206,10 +209,10 @@ func failurePolicyRecreateAll(ctx context.Context, js *jobset.JobSet, shouldCoun
 
 // The type failurePolicyActionApplier applies a FailurePolicyAction and returns nil if the FailurePolicyAction was successfully applied.
 // The function returns an error otherwise.
-type failurePolicyActionApplier = func(ctx context.Context, js *jobset.JobSet, matchingFailedJob *batchv1.Job, updateStatusOpts *statusUpdateOpts) error
+type failurePolicyActionApplier = func(ctx context.Context, js *jobset.JobSet, matchingFailedJob *batchv1.Job, rule *jobset.FailurePolicyRule, updateStatusOpts *statusUpdateOpts) error
 
 // failJobSetActionApplier applies the FailJobSet FailurePolicyAction
-var failJobSetActionApplier failurePolicyActionApplier = func(ctx context.Context, js *jobset.JobSet, matchingFailedJob *batchv1.Job, updateStatusOpts *statusUpdateOpts) error {
+var failJobSetActionApplier failurePolicyActionApplier = func(ctx context.Context, js *jobset.JobSet, matchingFailedJob *batchv1.Job, rule *jobset.FailurePolicyRule, updateStatusOpts *statusUpdateOpts) error {
 	failureBaseMessage := constants.FailJobSetActionMessage
 	failureMessage := messageWithFirstFailedJob(failureBaseMessage, matchingFailedJob.Name)
 
@@ -219,7 +222,7 @@ var failJobSetActionApplier failurePolicyActionApplier = func(ctx context.Contex
 }
 
 // restartJobSetActionApplier applies the RestartJobSet FailurePolicyAction
-var restartJobSetActionApplier failurePolicyActionApplier = func(ctx context.Context, js *jobset.JobSet, matchingFailedJob *batchv1.Job, updateStatusOpts *statusUpdateOpts) error {
+var restartJobSetActionApplier failurePolicyActionApplier = func(ctx context.Context, js *jobset.JobSet, matchingFailedJob *batchv1.Job, rule *jobset.FailurePolicyRule, updateStatusOpts *statusUpdateOpts) error {
 	if (features.Enabled(features.RestartJob) && totalRestartsCountTowardsMax(js) >= js.Spec.FailurePolicy.MaxRestarts) || (js.Status.RestartsCountTowardsMax >= js.Spec.FailurePolicy.MaxRestarts) {
 		failureBaseMessage := constants.ReachedMaxRestartsMessage
 		failureMessage := messageWithFirstFailedJob(failureBaseMessage, matchingFailedJob.Name)
@@ -238,13 +241,30 @@ var restartJobSetActionApplier failurePolicyActionApplier = func(ctx context.Con
 		eventMessage: eventMessage,
 	}
 
+	var reason string
+	if rule != nil {
+		reason = fmt.Sprintf(constants.RestartingJobSetReasonFailurePolicyFormat, rule.Name)
+	} else {
+		reason = constants.RestartingJobSetReasonDefaultFailurePolicy
+	}
+
+	condOpts := &conditionOpts{
+		eventType: corev1.EventTypeWarning,
+		condition: &metav1.Condition{
+			Type:    string(jobset.JobSetRestarting),
+			Status:  metav1.ConditionTrue,
+			Reason:  reason,
+			Message: eventMessage,
+		},
+	}
+
 	shouldCountTowardsMax := true
-	failurePolicyRecreateAll(ctx, js, shouldCountTowardsMax, updateStatusOpts, event)
+	failurePolicyRecreateAll(ctx, js, shouldCountTowardsMax, updateStatusOpts, event, condOpts)
 	return nil
 }
 
 // restartJobSetAndIgnoreMaxRestartsActionApplier applies the RestartJobSetAndIgnoreMaxRestarts FailurePolicyAction
-var restartJobSetAndIgnoreMaxRestartsActionApplier failurePolicyActionApplier = func(ctx context.Context, js *jobset.JobSet, matchingFailedJob *batchv1.Job, updateStatusOpts *statusUpdateOpts) error {
+var restartJobSetAndIgnoreMaxRestartsActionApplier failurePolicyActionApplier = func(ctx context.Context, js *jobset.JobSet, matchingFailedJob *batchv1.Job, rule *jobset.FailurePolicyRule, updateStatusOpts *statusUpdateOpts) error {
 	baseMessage := constants.RestartJobSetAndIgnoreMaxRestartsActionMessage
 	eventMessage := messageWithFirstFailedJob(baseMessage, matchingFailedJob.Name)
 	event := &eventParams{
@@ -254,8 +274,25 @@ var restartJobSetAndIgnoreMaxRestartsActionApplier failurePolicyActionApplier = 
 		eventMessage: eventMessage,
 	}
 
+	var reason string
+	if rule != nil {
+		reason = fmt.Sprintf(constants.RestartingJobSetReasonFailurePolicyFormat, rule.Name)
+	} else {
+		reason = constants.RestartingJobSetReasonDefaultFailurePolicy
+	}
+
+	condOpts := &conditionOpts{
+		eventType: corev1.EventTypeWarning,
+		condition: &metav1.Condition{
+			Type:    string(jobset.JobSetRestarting),
+			Status:  metav1.ConditionTrue,
+			Reason:  reason,
+			Message: eventMessage,
+		},
+	}
+
 	shouldCountTowardsMax := false
-	failurePolicyRecreateAll(ctx, js, shouldCountTowardsMax, updateStatusOpts, event)
+	failurePolicyRecreateAll(ctx, js, shouldCountTowardsMax, updateStatusOpts, event, condOpts)
 	return nil
 }
 
@@ -305,7 +342,7 @@ func failurePolicyRecreateJob(ctx context.Context, js *jobset.JobSet, matchingFa
 }
 
 // restartJobActionApplier applies the RestartJob FailurePolicyAction
-var restartJobActionApplier failurePolicyActionApplier = func(ctx context.Context, js *jobset.JobSet, matchingFailedJob *batchv1.Job, updateStatusOpts *statusUpdateOpts) error {
+var restartJobActionApplier failurePolicyActionApplier = func(ctx context.Context, js *jobset.JobSet, matchingFailedJob *batchv1.Job, rule *jobset.FailurePolicyRule, updateStatusOpts *statusUpdateOpts) error {
 	if !features.Enabled(features.RestartJob) {
 		return fmt.Errorf("RestartJob failure policy action cannot be used when the feature gate RestartJob is disabled")
 	}
@@ -332,7 +369,7 @@ var restartJobActionApplier failurePolicyActionApplier = func(ctx context.Contex
 }
 
 // restartJobAndIgnoreMaxRestartsActionApplier applies the RestartJobAndIgnoreMaxRestarts FailurePolicyAction
-var restartJobAndIgnoreMaxRestartsActionApplier failurePolicyActionApplier = func(ctx context.Context, js *jobset.JobSet, matchingFailedJob *batchv1.Job, updateStatusOpts *statusUpdateOpts) error {
+var restartJobAndIgnoreMaxRestartsActionApplier failurePolicyActionApplier = func(ctx context.Context, js *jobset.JobSet, matchingFailedJob *batchv1.Job, rule *jobset.FailurePolicyRule, updateStatusOpts *statusUpdateOpts) error {
 	if !features.Enabled(features.RestartJob) {
 		return fmt.Errorf("RestartJobAndIgnoreMaxRestarts failure policy action cannot be used when the feature gate RestartJob is disabled")
 	}
@@ -379,6 +416,7 @@ func makeFailedConditionOpts(reason, msg string) *conditionOpts {
 // setJobSetFailedCondition sets a condition and terminal state on the JobSet status indicating it has failed.
 func setJobSetFailedCondition(js *jobset.JobSet, reason, msg string, updateStatusOpts *statusUpdateOpts) {
 	setCondition(js, makeFailedConditionOpts(reason, msg), updateStatusOpts)
+	setRestartingConditionFalse(js, constants.RestartingJobSetReasonJobSetFailed, constants.RestartingJobSetReasonJobSetFailedMessage, updateStatusOpts)
 	js.Status.TerminalState = string(jobset.JobSetFailed)
 	// Update the metrics
 	metrics.JobSetFailed(js.Name, js.Namespace)

--- a/pkg/controllers/failure_policy_test.go
+++ b/pkg/controllers/failure_policy_test.go
@@ -491,7 +491,7 @@ func TestApplyFailurePolicyRuleAction(t *testing.T) {
 					RestartsCountTowardsMax: 1,
 				}).
 				Obj(),
-			matchingFailedJob:   matchingFailedJob,
+			matchingFailedJob: matchingFailedJob,
 			rule: &jobset.FailurePolicyRule{
 				Name:   "Rule1",
 				Action: jobset.RestartJobSet,

--- a/pkg/controllers/failure_policy_test.go
+++ b/pkg/controllers/failure_policy_test.go
@@ -439,6 +439,7 @@ func TestApplyFailurePolicyRuleAction(t *testing.T) {
 		enableRestartJob     bool
 		jobSet               *jobset.JobSet
 		matchingFailedJob    *batchv1.Job
+		rule                 *jobset.FailurePolicyRule
 		failurePolicyAction  jobset.FailurePolicyAction
 		expectedJobSetStatus jobset.JobSetStatus
 	}{
@@ -472,6 +473,40 @@ func TestApplyFailurePolicyRuleAction(t *testing.T) {
 			expectedJobSetStatus: jobset.JobSetStatus{
 				Restarts:                2,
 				RestartsCountTowardsMax: 2,
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(jobset.JobSetRestarting),
+						Status: metav1.ConditionTrue,
+						Reason: constants.RestartingJobSetReasonDefaultFailurePolicy,
+					},
+				},
+			},
+		},
+		{
+			name:             "RestartJobSet when restarts < maxRestarts with matching rule sets FailurePolicy_{RuleName} reason",
+			enableRestartJob: true,
+			jobSet: testutils.MakeJobSet("test-js", "default").FailurePolicy(&jobset.FailurePolicy{MaxRestarts: 5}).
+				SetStatus(jobset.JobSetStatus{
+					Restarts:                1,
+					RestartsCountTowardsMax: 1,
+				}).
+				Obj(),
+			matchingFailedJob:   matchingFailedJob,
+			rule: &jobset.FailurePolicyRule{
+				Name:   "Rule1",
+				Action: jobset.RestartJobSet,
+			},
+			failurePolicyAction: jobset.RestartJobSet,
+			expectedJobSetStatus: jobset.JobSetStatus{
+				Restarts:                2,
+				RestartsCountTowardsMax: 2,
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(jobset.JobSetRestarting),
+						Status: metav1.ConditionTrue,
+						Reason: "FailurePolicy_Rule1",
+					},
+				},
 			},
 		},
 		{
@@ -514,6 +549,13 @@ func TestApplyFailurePolicyRuleAction(t *testing.T) {
 			expectedJobSetStatus: jobset.JobSetStatus{
 				Restarts:                2,
 				RestartsCountTowardsMax: 1, // not incremented
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(jobset.JobSetRestarting),
+						Status: metav1.ConditionTrue,
+						Reason: constants.RestartingJobSetReasonDefaultFailurePolicy,
+					},
+				},
 			},
 		},
 		{
@@ -667,7 +709,7 @@ func TestApplyFailurePolicyRuleAction(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.RestartJob, tc.enableRestartJob)
 			updateStatusOpts := &statusUpdateOpts{}
 			jobSetCopy := tc.jobSet.DeepCopy()
-			err := applyFailurePolicyRuleAction(context.TODO(), jobSetCopy, tc.matchingFailedJob, updateStatusOpts, tc.failurePolicyAction)
+			err := applyFailurePolicyRuleAction(context.TODO(), jobSetCopy, tc.matchingFailedJob, tc.rule, updateStatusOpts, tc.failurePolicyAction)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -182,6 +182,10 @@ func (r *JobSetReconciler) reconcile(ctx context.Context, js *jobset.JobSet, upd
 		return ctrl.Result{}, err
 	}
 
+	if !jobSetSuspended(js) && allJobsReady(js, rjobStatuses) {
+		setRestartingConditionFalse(js, constants.RestartingJobSetReasonJobsReady, constants.RestartingJobSetReasonJobsReadyMessage, updateStatusOpts)
+	}
+
 	// If any jobs have failed, execute the JobSet failure policy (if any).
 	if len(ownedJobs.failed) > 0 {
 		if err := executeFailurePolicy(ctx, js, ownedJobs, updateStatusOpts); err != nil {
@@ -1131,6 +1135,18 @@ func jobSetFinished(js *jobset.JobSet) bool {
 	return false
 }
 
+func allJobsReady(js *jobset.JobSet, rjobStatuses []jobset.ReplicatedJobStatus) bool {
+	totalReplicas := 0
+	readyReplicas := 0
+	for _, rjSpec := range js.Spec.ReplicatedJobs {
+		totalReplicas += int(rjSpec.Replicas)
+	}
+	for _, rjStatus := range rjobStatuses {
+		readyReplicas += int(rjStatus.Ready + rjStatus.Succeeded)
+	}
+	return totalReplicas == readyReplicas
+}
+
 func jobSetMarkedForDeletion(js *jobset.JobSet) bool {
 	return js.DeletionTimestamp != nil
 }
@@ -1226,9 +1242,12 @@ func updateCondition(js *jobset.JobSet, opts *conditionOpts) bool {
 			if newCond.Status != currCond.Status {
 				js.Status.Conditions[i] = newCond
 				shouldUpdate = true
+			} else if newCond.Reason != currCond.Reason || newCond.Message != currCond.Message {
+				newCond.LastTransitionTime = currCond.LastTransitionTime
+				js.Status.Conditions[i] = newCond
+				shouldUpdate = true
 			}
 
-			// If both are true or both are false, this is a duplicate condition, do nothing.
 			found = true
 		} else {
 			// If conditions are of different types, only perform an update if they are both true
@@ -1254,6 +1273,7 @@ func updateCondition(js *jobset.JobSet, opts *conditionOpts) bool {
 // setJobSetCompletedCondition sets a condition and terminal state on the JobSet status indicating it has completed.
 func setJobSetCompletedCondition(js *jobset.JobSet, updateStatusOpts *statusUpdateOpts) {
 	setCondition(js, makeCompletedConditionsOpts(), updateStatusOpts)
+	setRestartingConditionFalse(js, constants.RestartingJobSetReasonJobSetCompleted, constants.AllJobsCompletedMessage, updateStatusOpts)
 	js.Status.TerminalState = string(jobset.JobSetCompleted)
 	// Update the metrics
 	metrics.JobSetCompleted(js.Name, js.Namespace)
@@ -1262,12 +1282,26 @@ func setJobSetCompletedCondition(js *jobset.JobSet, updateStatusOpts *statusUpda
 // setJobSetSuspendedCondition sets a condition on the JobSet status indicating it is currently suspended.
 func setJobSetSuspendedCondition(js *jobset.JobSet, updateStatusOpts *statusUpdateOpts) {
 	setCondition(js, makeSuspendedConditionOpts(), updateStatusOpts)
+	setRestartingConditionFalse(js, constants.RestartingJobSetReasonJobSetSuspended, constants.JobSetSuspendedMessage, updateStatusOpts)
 }
 
 // setJobSetResumedCondition sets a condition on the JobSet status indicating it has been resumed.
 // This updates the "suspended" condition type from "true" to "false."
 func setJobSetResumedCondition(js *jobset.JobSet, updateStatusOpts *statusUpdateOpts) {
 	setCondition(js, makeResumedConditionOpts(), updateStatusOpts)
+}
+
+func setRestartingConditionFalse(js *jobset.JobSet, reason, message string, updateStatusOpts *statusUpdateOpts) {
+	condOpts := &conditionOpts{
+		eventType: corev1.EventTypeNormal,
+		condition: &metav1.Condition{
+			Type:    string(jobset.JobSetRestarting),
+			Status:  metav1.ConditionFalse,
+			Reason:  reason,
+			Message: message,
+		},
+	}
+	setCondition(js, condOpts, updateStatusOpts)
 }
 
 // completedConditionsOpts contains the options we use to generate the JobSet completed condition.

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -1179,12 +1179,55 @@ func TestUpdateConditions(t *testing.T) {
 			opts:           makeCompletedConditionsOpts(),
 			expectedUpdate: false,
 		},
+		{
+			name: "existing conditions, update reason/message but keep status same",
+			js: testutils.MakeJobSet(jobSetName, ns).
+				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName).
+					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
+					Replicas(1).
+					Obj()).
+				Conditions([]metav1.Condition{
+					{
+						Type:    string(jobset.JobSetRestarting),
+						Reason:  constants.RestartingJobSetReasonDefaultFailurePolicy,
+						Message: "old message",
+						Status:  metav1.ConditionTrue,
+					},
+				}).Obj(),
+			opts: &conditionOpts{
+				condition: &metav1.Condition{
+					Type:    string(jobset.JobSetRestarting),
+					Reason:  "NewReason",
+					Message: "new message",
+					Status:  metav1.ConditionTrue,
+				},
+			},
+			expectedUpdate: true,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			var oldTime *metav1.Time
+			var oldStatus *metav1.ConditionStatus
+			for _, c := range tc.js.Status.Conditions {
+				if tc.opts.condition != nil && c.Type == tc.opts.condition.Type {
+					oldTime = &c.LastTransitionTime
+					status := c.Status
+					oldStatus = &status
+				}
+			}
 			gotUpdate := updateCondition(tc.js, tc.opts)
 			if gotUpdate != tc.expectedUpdate {
 				t.Errorf("updateCondition return mismatch (want: %v, got %v)", tc.expectedUpdate, gotUpdate)
+			}
+			if gotUpdate && tc.opts.condition != nil && oldTime != nil && oldStatus != nil {
+				for _, c := range tc.js.Status.Conditions {
+					if c.Type == tc.opts.condition.Type {
+						if *oldStatus == c.Status && c.LastTransitionTime != *oldTime {
+							t.Errorf("LastTransitionTime changed when status did not change")
+						}
+					}
+				}
 			}
 		})
 	}

--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -750,6 +750,45 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 				},
 			},
 		}),
+		ginkgo.Entry("jobset restarting condition transitions", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testJobSet(ns).
+					FailurePolicy(&jobset.FailurePolicy{
+						MaxRestarts: 1,
+						Rules: []jobset.FailurePolicyRule{
+							{
+								Name:                "Rule1",
+								Action:              jobset.RestartJobSet,
+								OnJobFailureReasons: []string{batchv1.JobReasonPodFailurePolicy},
+							},
+						},
+					})
+			},
+			steps: []*step{
+				{
+					jobUpdateFn: func(jobList *batchv1.JobList) {
+						failJobWithOptions(&jobList.Items[0], &failJobOptions{reason: ptr.To(batchv1.JobReasonPodFailurePolicy)})
+					},
+					checkJobSetCondition: func(ctx context.Context, c client.Client, js *jobset.JobSet, timeout time.Duration) {
+						testutil.JobSetActive(ctx, c, js, timeout)
+						testutil.JobSetRestarting(ctx, c, js, metav1.ConditionTrue, "FailurePolicy_Rule1", timeout)
+					},
+				},
+				{
+					jobSetUpdateFn: func(js *jobset.JobSet) {
+						removeForegroundDeletionFinalizers(js, testutil.NumExpectedJobs(js))
+					},
+				},
+				{
+					jobUpdateFn: func(jobList *batchv1.JobList) {
+						readyAllJobs(jobList)
+					},
+					checkJobSetCondition: func(ctx context.Context, c client.Client, js *jobset.JobSet, timeout time.Duration) {
+						testutil.JobSetRestarting(ctx, c, js, metav1.ConditionFalse, "JobsReady", timeout)
+					},
+				},
+			},
+		}),
 		ginkgo.Entry("[failure policy] jobset restarts with RestartJobSet failure policy action (with RestartJob feature gate).", &testCase{
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
 				gomega.Expect(features.SetEnable(features.RestartJob, true)).To(gomega.Succeed())
@@ -3461,6 +3500,12 @@ func readyJob(job *batchv1.Job) {
 		Active: *job.Spec.Parallelism,
 		Ready:  job.Spec.Parallelism,
 	})
+}
+
+func readyAllJobs(jobList *batchv1.JobList) {
+	for i := range jobList.Items {
+		readyJob(&jobList.Items[i])
+	}
 }
 
 // removeForegroundDeletionFinalizers will continually fetch the child jobs for a

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -296,3 +296,21 @@ func removeJobSetFinalizer(js *jobset.JobSet, finalizer string) {
 		}
 	}
 }
+
+func JobSetRestarting(ctx context.Context, k8sClient client.Client, js *jobset.JobSet, status metav1.ConditionStatus, reason string, timeout time.Duration) {
+	ginkgo.By(fmt.Sprintf("checking jobset status is restarting: %v (reason: %s)", status, reason))
+	gomega.Eventually(checkJobSetRestartingCondition, timeout, interval).WithArguments(ctx, k8sClient, js, status, reason).Should(gomega.Equal(true))
+}
+
+func checkJobSetRestartingCondition(ctx context.Context, k8sClient client.Client, js *jobset.JobSet, status metav1.ConditionStatus, reason string) (bool, error) {
+	var fetchedJS jobset.JobSet
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: js.Namespace, Name: js.Name}, &fetchedJS); err != nil {
+		return false, err
+	}
+	for _, c := range fetchedJS.Status.Conditions {
+		if c.Type == string(jobset.JobSetRestarting) && c.Status == status && c.Reason == reason {
+			return true, nil
+		}
+	}
+	return false, nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature
/kind api-change

#### What this PR does / why we need it:

Currently, JobSet global restart actions (recreating all Jobs) are only visible through ephemeral events. This PR implements a new status condition `RestartingJobSet` to provide a persistent, state-based observability signal when a global restart is in progress.

The condition operates as follows:
- Set to `True` when a global restart is triggered by a failure policy rule using restart action `RestartJobSet` or `RestartJobSetAndIgnoreMaxRestarts` (`FailurePolicy_{RuleName}`) or by the default failure policy (`DefaultFailurePolicy`)
- Set to `False` when all recreated jobs are ready (`JobsReady`), or when the JobSet completed (`JobSetCompleted`), failed (`JobSetFailed`) or was suspended (`JobSetSuspended`)

Also updates `updateCondition` to support updating reasons/messages while preserving `LastTransitionTime` if the status remains unchanged.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1219

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add a new status condition `RestartingJobSet` to JobSet status to track when a global restart is in progress.
```