### PR TITLE
use kind build node images instead of relying on official images

### DIFF
--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -7,6 +7,7 @@ export NAMESPACE="jobset-system"
 export JOBSET_E2E_TESTS_DUMP_NAMESPACE=true
 # E2E config folder to use (defaults to "default")
 export E2E_TARGET_FOLDER="${E2E_TARGET_FOLDER:-default}"
+K8S_VERSION="${E2E_KIND_VERSION##*:}"
 
 # Use a temporary KUBECONFIG so that the script does not mess with the current user's kubeconfig.
 KUBECONFIG=""
@@ -25,6 +26,14 @@ function cleanup {
     fi
     (cd config/components/manager && $KUSTOMIZE edit set image controller=us-central1-docker.pkg.dev/k8s-staging-images/jobset/jobset:main)
 }
+
+function build_node_image {
+
+    if [ $USE_EXISTING_CLUSTER == 'false' ] 
+    then
+	   $KIND build node-image $K8S_VERSION --image jobset/kind-node:${K8S_VERSION}
+    fi
+}
 function startup {
     if [ $USE_EXISTING_CLUSTER == 'false' ] 
     then
@@ -34,7 +43,7 @@ function startup {
             exit 1
         fi
         export KUBECONFIG
-        $KIND create cluster --name $KIND_CLUSTER_NAME --image $E2E_KIND_VERSION --wait 1m
+        $KIND create cluster --name $KIND_CLUSTER_NAME --image jobset/kind-node:${K8S_VERSION}  --wait 1m
         kubectl get nodes > $ARTIFACTS/kind-nodes.log || true
         kubectl describe pods -n kube-system > $ARTIFACTS/kube-system-pods.log || true
     fi
@@ -49,6 +58,7 @@ function jobset_deploy {
     kubectl apply --server-side -k test/e2e/config/$E2E_TARGET_FOLDER
 }
 trap cleanup EXIT
+build_node_image
 startup
 kind_load
 jobset_deploy


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Build kind images from upstream rather than relying on Kind to host official images.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1233 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```