### PR TITLE
feat: alpha annotation to publish exclusive-topology value as a pod label

### DIFF
--- a/api/jobset/v1alpha2/jobset_types.go
+++ b/api/jobset/v1alpha2/jobset_types.go
@@ -51,8 +51,20 @@ const (
 	// ensure exclusive job placement per topology, instead of injecting pod affinity/anti-affinites for this.
 	// The user must add the JobSet name node label to the desired topologies separately.
 	NodeSelectorStrategyKey string = "alpha.jobset.sigs.k8s.io/node-selector"
-	NamespacedJobKey        string = "alpha.jobset.sigs.k8s.io/namespaced-job"
-	NoScheduleTaintKey      string = "alpha.jobset.sigs.k8s.io/no-schedule"
+	// ExclusiveTopologyLabelKey is an annotation that can be set on the JobSet or on a
+	// ReplicatedJob template. When set alongside ExclusiveKey, the JobSet pod mutating
+	// webhook copies the resolved exclusive-topology value (read from the leader pod's
+	// Node label identified by ExclusiveKey) onto follower pods under this label key,
+	// so the container can read it via the Downward API
+	// (e.g. fieldRef: metadata.labels['ray.io/gpu-domain']).
+	//
+	// Applies only to follower pods (job completion index != 0). Leader pods are not
+	// labeled because the topology value is not knowable at pod-create admission time.
+	// Requires alpha.jobset.sigs.k8s.io/exclusive-topology on the same scope.
+	// Incompatible with alpha.jobset.sigs.k8s.io/node-selector.
+	ExclusiveTopologyLabelKey string = "alpha.jobset.sigs.k8s.io/exclusive-topology-label-key"
+	NamespacedJobKey          string = "alpha.jobset.sigs.k8s.io/namespaced-job"
+	NoScheduleTaintKey        string = "alpha.jobset.sigs.k8s.io/no-schedule"
 
 	// JobSetControllerName is the reserved value for the managedBy field for the built-in
 	// JobSet controller.

--- a/keps/NNNN-exclusive-topology-label/README.md
+++ b/keps/NNNN-exclusive-topology-label/README.md
@@ -1,0 +1,373 @@
+# KEP-NNNN: Publish resolved exclusive-topology value as a pod label
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Story](#user-story)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [API](#api)
+  - [Implementation](#implementation)
+  - [Validation](#validation)
+  - [Conflict policy](#conflict-policy)
+  - [Test Plan](#test-plan)
+    - [Unit Tests](#unit-tests)
+    - [Integration tests](#integration-tests)
+  - [Graduation Criteria](#graduation-criteria)
+- [Implementation History](#implementation-history)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+  - [Init container with <code>get nodes</code> RBAC](#init-container-with--rbac)
+  - [Direct env var injection into containers](#direct-env-var-injection-into-containers)
+  - [Post-scheduling controller patching of leaders](#post-scheduling-controller-patching-of-leaders)
+  - [<code>pods/binding</code> admission webhook for leaders](#-admission-webhook-for-leaders)
+<!-- /toc -->
+
+## Summary
+
+JobSet's existing `alpha.jobset.sigs.k8s.io/exclusive-topology` annotation pins all
+pods of a Job to a single topology domain (rack, zone, node pool, NVLink island,
+etc.) by writing the resolved value into `pod.spec.nodeSelector` for follower
+pods. Containers, however, cannot read `spec.nodeSelector` through the Kubernetes
+[Downward API][downward], so workloads that need their own topology identifier at
+runtime — e.g. Ray's "Label Locality" feature expecting
+`ray start --labels=ray.io/gpu-domain=<rack>` — currently require an init
+container that calls `GET /api/v1/nodes/<name>` with cluster-scoped `get nodes`
+RBAC.
+
+This KEP proposes a small, opt-in alpha extension: a new annotation
+`alpha.jobset.sigs.k8s.io/exclusive-topology-label-key` whose value is a pod
+label key. When set alongside `exclusive-topology`, the JobSet pod mutating
+webhook copies the resolved topology value (which it already computes for
+`spec.nodeSelector`) onto follower pods under that label key, so containers can
+consume it via the standard Downward API
+(`fieldRef: metadata.labels['…']`). Leader pods are explicitly out of scope in
+alpha — the value is not knowable at pod-create admission time.
+
+[downward]: https://kubernetes.io/docs/concepts/workloads/pods/downward-api/
+
+## Motivation
+
+Distributed runtimes such as [Ray][ray] (with its alpha-stage [Label Locality
+scheduling][label-locality]), MPI launchers building hostfiles per rack, and
+collective-communication libraries that key NCCL/NVLink topology by domain all
+need a stable, runtime-readable rack/domain identifier inside the container.
+
+Kubernetes does not expose arbitrary node labels through the Downward API
+([reference][downward-fields]). KEP-4742 (`PodTopologyLabelsAdmission`) covers
+this only for a hardcoded set of standard topology labels
+(`topology.kubernetes.io/zone`, `topology.kubernetes.io/region`,
+`kubernetes.io/hostname`) and explicitly leaves non-standard labels to custom
+mutating admission webhooks.
+
+JobSet's exclusive-topology mechanism already resolves a topology value during
+pod admission: the pod mutating webhook in `pkg/webhooks/pod_webhook.go` reads
+the leader pod's bound node and writes
+`node.Labels[topologyKey]` into `pod.spec.nodeSelector` for follower pods. The
+value is right there at admission time. This proposal makes that value visible
+to containers without requiring every workload to roll its own init container
+plus `get nodes` RBAC.
+
+[ray]: https://github.com/ray-project/ray
+[label-locality]: https://github.com/ray-project/ray/pull/61442
+[downward-fields]: https://kubernetes.io/docs/concepts/workloads/pods/downward-api/#available-fields
+
+### Goals
+
+- Publish the resolved exclusive-topology value onto follower pods as a label
+  under a user-chosen key.
+- Provide an opt-in alpha API via annotation; preserve backward compatibility
+  with every existing `exclusive-topology` user.
+- Reuse the value already computed by the existing pod mutating webhook (no new
+  Kubernetes API calls per pod beyond what is already made).
+- Surface invalid annotation combinations at admission time with clear errors.
+
+### Non-Goals
+
+- Labeling **leader** pods. At pod-create admission time, a leader pod's
+  `spec.nodeName` is empty and the bound node is not yet known. Any leader-path
+  solution requires either a `pods/binding` subresource webhook or a
+  post-scheduling controller patch (the latter creates a permanent empty-value
+  footgun for any container that captures the label via `fieldRef` env var at
+  start). Both add new webhook infrastructure and are deferred to a follow-up
+  KEP. Ray workers are followers, so the alpha use case still works without
+  leader labeling; the head pod typically doesn't need rack info.
+- Direct injection of env vars into containers. Labels are more general; the
+  Downward API can promote a label to either an env var or a file. Avoiding env
+  injection sidesteps design questions around which containers, init container
+  vs. main container, conflict policy with user-defined env, etc.
+- Propagation of arbitrary node labels onto pods. This proposal only publishes
+  the value of the node label identified by the existing
+  `exclusive-topology` annotation.
+- Replacing the existing `alpha.jobset.sigs.k8s.io/node-selector` fast path.
+  That path bypasses the pod mutating webhook entirely; this new annotation is
+  incompatible with it and is rejected at admission when both are set.
+
+## Proposal
+
+Add one new alpha annotation,
+`alpha.jobset.sigs.k8s.io/exclusive-topology-label-key`. Its value is the
+destination pod label key. When set alongside the existing
+`alpha.jobset.sigs.k8s.io/exclusive-topology` annotation, the JobSet pod
+mutating webhook copies the resolved topology value onto each follower pod's
+`metadata.labels` under that key. Containers consume it via the standard
+Downward API.
+
+Like `exclusive-topology`, the new annotation can be set at the JobSet level or
+on a ReplicatedJob template, with the ReplicatedJob-level setting overriding
+the JobSet-level setting.
+
+### User Story
+
+A team running [Ray][ray] on a Kubernetes cluster with multi-rack NVLink-domain
+GB200/GB300 nodes wants Ray's Label Locality feature to pin a placement group
+to a single rack. Ray Label Locality is triggered by a Ray-level node label
+`ray.io/gpu-domain` whose value identifies the rack. The team's cluster
+operator has labeled each Kubernetes node with the rack id
+(e.g. `topology.example.com/nvlink-domain=rack-DH2-096`).
+
+Without this proposal, the team must add an init container to every Ray worker
+pod that calls `kubectl get node $POD_NODE_NAME -o jsonpath=...` and writes the
+value to a shared emptyDir, then start `ray start` with
+`--labels=ray.io/gpu-domain=$(cat /labels/rack)`. This requires creating a
+`ServiceAccount` with cluster-scoped `get nodes` permission per workload
+namespace.
+
+With this proposal, the team sets two annotations on their JobSet:
+
+```yaml
+metadata:
+  annotations:
+    alpha.jobset.sigs.k8s.io/exclusive-topology: topology.example.com/nvlink-domain
+    alpha.jobset.sigs.k8s.io/exclusive-topology-label-key: ray.io/gpu-domain
+```
+
+and reads the value via Downward API in their Ray worker container spec:
+
+```yaml
+env:
+  - name: RAY_GPU_DOMAIN
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.labels['ray.io/gpu-domain']
+command: ["/bin/bash", "-c"]
+args:
+  - exec ray start --address=... --labels="ray.io/gpu-domain=$RAY_GPU_DOMAIN" --block
+```
+
+No `get nodes` RBAC, no init container, no shared volume.
+
+### Risks and Mitigations
+
+- **Label-key collisions with user-supplied pod labels.** If the destination
+  label key is already set on the pod template with a value different from the
+  resolved topology value, the pod mutating webhook returns an admission error
+  and the pod is rejected. If the existing value already matches, the webhook
+  is a no-op.
+- **Mismatched JobSet vs. ReplicatedJob scoping.** The JobSet validating
+  webhook ensures the new annotation is only valid when paired with
+  `exclusive-topology` on the same scope (JobSet or ReplicatedJob template),
+  matching the existing scoping rules.
+- **Cluster-wide failure modes are unchanged.** The only new webhook code runs
+  in the existing pod mutating webhook's follower path, which is already gated
+  on `exclusive-topology` being set. Workloads that don't opt into the new
+  annotation see no behavior change.
+
+## Design Details
+
+### API
+
+One new constant in `api/jobset/v1alpha2/jobset_types.go`:
+
+```go
+// ExclusiveTopologyLabelKey is an annotation that can be set on the JobSet or on
+// a ReplicatedJob template. When set alongside ExclusiveKey, the JobSet pod
+// mutating webhook copies the resolved exclusive-topology value (read from the
+// leader pod's Node label identified by ExclusiveKey) onto follower pods under
+// this label key, so the container can read it via the Downward API
+// (e.g. fieldRef: metadata.labels['ray.io/gpu-domain']).
+//
+// Applies only to follower pods (job completion index != 0). Leader pods are not
+// labeled because the topology value is not knowable at pod-create admission
+// time. Requires alpha.jobset.sigs.k8s.io/exclusive-topology on the same scope.
+// Incompatible with alpha.jobset.sigs.k8s.io/node-selector.
+ExclusiveTopologyLabelKey string = "alpha.jobset.sigs.k8s.io/exclusive-topology-label-key"
+```
+
+### Implementation
+
+Four code sites:
+
+1. **Annotation propagation** (`pkg/controllers/jobset_controller.go`,
+   `labelAndAnnotateObject`): the new annotation is copied from
+   `JobSet.metadata.annotations` and `ReplicatedJob.Template.metadata.annotations`
+   into the child Job's annotations and pod template annotations, with the
+   ReplicatedJob-level value overriding the JobSet-level value. Identical
+   pattern to the existing `ExclusiveKey` and `NodeSelectorStrategyKey`
+   propagation. Annotation only, not propagated as a label (the label value is
+   computed at admission time, not at controller-time).
+
+2. **Follower mutation** (`pkg/webhooks/pod_webhook.go`, `setNodeSelector`):
+   after the existing
+   `pod.Spec.NodeSelector[topologyKey] = topologyValue` write, when the
+   `ExclusiveTopologyLabelKey` annotation is set, the new helper
+   `setExclusiveTopologyLabel(pod, outKey, topologyValue)` writes the value to
+   `pod.Labels[outKey]`. The helper returns a non-nil error if the label is
+   already present with a different value; the error surfaces as an admission
+   rejection.
+
+3. **JobSet validation** (`pkg/webhooks/jobset_webhook.go`, `ValidateCreate`
+   and `ValidateUpdate`): a new helper
+   `validateExclusiveTopologyLabelKeyAnnotations` checks every annotation set
+   (JobSet-level and per-ReplicatedJob-template) and rejects:
+   - the annotation set without `exclusive-topology` on the same scope,
+   - the annotation set together with `node-selector` strategy on the same scope,
+   - empty values, whitespace-padded values, or values that fail
+     `validation.IsQualifiedName`,
+   - the new annotation and `node-selector` strategy splitting across the
+     JobSet and ReplicatedJob template scopes (per-scope checks pass but
+     the runtime would silently no-op the label publish because the pod
+     mutating webhook bails on `node-selector` strategy).
+
+4. **No new feature gate.** This is an opt-in extension to an existing opt-in
+   alpha annotation with no default behavior change. When the new annotation
+   is absent the controller and webhook paths run identically to today, and
+   when the existing `exclusive-topology` annotation is absent the new
+   annotation has no effect (and is rejected by the JobSet validating
+   webhook). The cluster-wide kill-switch a feature gate would provide is
+   therefore equivalent to the per-workload kill-switch the annotation
+   already provides: not setting it. `kep.yaml` carries `feature-gates: []`
+   and `disable-supported: false` to make this explicit. If maintainers
+   prefer a runtime gate during alpha, one can be added following the
+   `InPlaceRestart` precedent: one entry in `pkg/features/features.go` and a
+   runtime check at the webhook entry points (JobSet `ValidateCreate` /
+   `ValidateUpdate`, controller `labelAndAnnotateObject`, pod webhook
+   `setExclusiveTopologyLabel`). Defining the off-behavior at each of those
+   surfaces would be part of that follow-up.
+
+### Validation
+
+`validation.IsQualifiedName` from `k8s.io/apimachinery/pkg/util/validation`
+enforces Kubernetes label-key syntax (optional `<prefix>/<name>` with
+DNS-subdomain prefix and DNS-1123 name). Leading and trailing whitespace are
+rejected without trimming — Kubernetes annotation values are literal strings
+and silent normalization would create surprising API behavior.
+
+### Conflict policy
+
+If the destination label is already present on the pod with the same value (as
+might happen if the user pre-populates it in their template), the webhook is a
+no-op. If it's present with a different value, the webhook returns an admission
+error. Silent overwrite would violate template ownership; skipping with only a
+warning would start the container without the runtime signal the user
+explicitly opted in to.
+
+### Test Plan
+
+#### Unit Tests
+
+- `pkg/webhooks/pod_webhook_test.go`: extended follower-with-exclusive-placement
+  table-driven cases covering (a) annotation present, label written;
+  (b) existing label same value, no-op; (c) existing label different value,
+  rejected; (d) leader pod with annotation, no label written (leader path
+  unchanged).
+- `pkg/webhooks/jobset_webhook_test.go`: new `exclusiveTopologyLabelKeyTests`
+  group covering (e) valid pairing accepted on JobSet level;
+  (f) valid pairing accepted on ReplicatedJob template;
+  (g) annotation without `exclusive-topology` rejected;
+  (h) annotation with `node-selector` strategy rejected;
+  (i) empty value rejected; (j) whitespace-padded value rejected;
+  (k) invalid label-key syntax rejected;
+  (l) annotation on ReplicatedJob without `exclusive-topology` on RJ rejected.
+- `pkg/controllers/jobset_controller_test.go`: extended exclusive-topology
+  cases assert the new annotation propagates from JobSet/ReplicatedJob onto
+  child Jobs and pod templates with the standard override semantics.
+
+#### Integration tests
+
+- `test/integration/webhook/jobset_webhook_test.go`: new ginkgo entries verify
+  end-to-end through the API server that JobSets are rejected when the new
+  annotation is invalid, and accepted in valid pairings.
+
+### Graduation Criteria
+
+Alpha → Beta:
+
+- At least one external adopter using the feature in a non-toy workload.
+- No reported correctness bugs against the alpha API in a release cycle.
+- Design accepted for an eventual leader-path extension (likely via
+  `pods/binding` admission webhook in a follow-up KEP).
+- Annotation key promotion: rename to `jobset.sigs.k8s.io/exclusive-topology-label-key`
+  alongside the existing `alpha.jobset.sigs.k8s.io/exclusive-topology-label-key`
+  for one release of overlap, then deprecate the alpha form.
+
+## Implementation History
+
+- 2026-05-13: KEP and alpha implementation drafted in a single PR.
+
+## Drawbacks
+
+- **Leader pods are not labeled** in alpha. Workers are the pods that actually
+  need the rack label, and workers are followers, so the gap doesn't block the
+  alpha use case. It becomes a real limitation only when a workload needs
+  leader-side visibility.
+- **Two annotations are required** for the feature
+  (`exclusive-topology` + `exclusive-topology-label-key`). This is intentional:
+  the new annotation does not duplicate the placement signal, only the
+  visibility signal.
+- **Naming is verbose.** `alpha.jobset.sigs.k8s.io/exclusive-topology-label-key`
+  is long. The verbosity is intentional: alpha APIs should optimize for
+  unambiguous review, not elegance. A shorter rename (`topology-label`)
+  would be ambiguous about whether it configures the topology source.
+
+## Alternatives
+
+### Init container with `get nodes` RBAC
+
+Current status quo. Every workload that wants the rack value adds an init
+container plus cluster-scoped `get nodes` RBAC for its `ServiceAccount`. This
+works but: (a) is per-workload boilerplate, (b) requires cluster-scoped read
+access on every namespace that runs such a workload, (c) duplicates work the
+JobSet pod webhook already does. The motivation for this KEP is to eliminate
+this boilerplate.
+
+### Direct env var injection into containers
+
+The webhook could write an env var into `pod.spec.containers[*].env` instead of
+a label. Pros: no DNS-1123 label-value syntax concerns (label values copied
+verbatim from `node.Labels` already satisfy that grammar, but env values are
+unrestricted). Cons: (a) needs decisions about which containers to mutate, init
+containers, sidecars, conflict policy with user-defined env; (b) labels are
+strictly more general — the Downward API can promote any label to either an env
+var or a file at user's discretion. This is the same shape KEP-4742 chose for
+the analogous in-tree problem: stamp a label, let the workload pick how to
+read it.
+
+### Post-scheduling controller patching of leaders
+
+A reconciler could watch leader pods and patch their `metadata.labels` once
+`spec.nodeName` is set. This works for Downward API _volume_ mounts (kubelet
+re-reads the volume contents), but breaks for `fieldRef` env vars, which are
+captured at container start. Containers that consume the label via `fieldRef`
+env vars would see an empty string permanently. This is a worse failure mode
+than honestly not supporting leaders in alpha.
+
+### `pods/binding` admission webhook for leaders
+
+The correct way to label leaders before container start is a mutating
+admission webhook on the `pods/binding` subresource — exactly the pattern
+KEP-4742 (`PodTopologyLabelsAdmission`) uses in-tree. The webhook would observe
+the Binding, read the bound node, and issue a Patch to the Pod's
+`metadata.labels`. This works for both leaders and followers symmetrically.
+However, it introduces: (a) a second webhook configuration with `failurePolicy`
+trade-offs (a strict failure policy can wedge cluster-wide binding on any
+webhook outage), (b) new `get`/`patch pods` cluster-wide RBAC, (c) a side-effect
+Patch pattern that some reviewers dislike.
+
+Too much surface for a first iteration. Punting leader-path support to a
+follow-up KEP keeps the alpha proposal small and lets the worker-only path
+unblock real usage now. The binding-webhook design can be debated on its own
+merits later.

--- a/keps/NNNN-exclusive-topology-label/kep.yaml
+++ b/keps/NNNN-exclusive-topology-label/kep.yaml
@@ -1,0 +1,37 @@
+title: Publish resolved exclusive-topology value as a pod label
+kep-number: NNNN  # assigned by maintainers
+authors:
+  - "@abatilo"
+status: provisional
+creation-date: 2026-05-13
+reviewers:
+  - TBD
+approvers:
+  - TBD
+
+see-also:
+  - "NA"
+replaces:
+  - "NA"
+
+# The target maturity stage in the current dev cycle for this KEP.
+stage: alpha
+
+# The most recent milestone for which work toward delivery of this KEP has been
+# done. This can be the current (upcoming) milestone, if it is being actively
+# worked on.
+latest-milestone: "v0.13.0"
+
+# The milestone at which this feature was, or is targeted to be, at each stage.
+milestone:
+  alpha: "v0.13.0"
+
+# This KEP intentionally does not introduce a feature gate. The new annotation
+# `alpha.jobset.sigs.k8s.io/exclusive-topology-label-key` is opt-in and only
+# takes effect for workloads that have also opted into the existing
+# `alpha.jobset.sigs.k8s.io/exclusive-topology` annotation. With both keys
+# absent the controller code path runs identically to today. Operators disable
+# the feature for a JobSet by removing the annotation; there is no cluster-wide
+# enable/disable knob.
+feature-gates: []
+disable-supported: false

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -1003,7 +1003,7 @@ func shouldCreateJob(jobName string, ownedJobs *childJobs) bool {
 // labelAndAnnotateObjects adds standard JobSet related labels and annotations a k8s object.
 // In practice it is used to label and annotate child Jobs and pods.
 // The same set of labels are also as added as annotations for simplicity's sake.
-// The two exceptions to this are:
+// The exceptions to this are:
 //  1. "alpha.jobset.sigs.k8s.io/exclusive-topology" which is
 //     a JobSet annoation optionally added by the user, so we only add it as an annotation
 //     to child Jobs and pods if it is defined, and do not add it as a label.
@@ -1011,6 +1011,11 @@ func shouldCreateJob(jobName string, ownedJobs *childJobs) bool {
 //     annotation applied by the user to indicate they are using the
 //     nodeSelector exclusive placement strategy, where they have manually
 //     labelled the nodes ahead of time with hack/label_nodes/label_nodes.py
+//  3. "alpha.jobset.sigs.k8s.io/exclusive-topology-label-key" which is
+//     an optional annotation that, when set alongside exclusive-topology, causes the
+//     pod mutating webhook to publish the resolved topology value onto follower pods
+//     under the user-supplied label key. Like the other exclusive-placement annotations,
+//     we only propagate it as an annotation, not a label.
 func labelAndAnnotateObject(obj metav1.Object, js *jobset.JobSet, rjob *jobset.ReplicatedJob, jobIdx int) {
 	jobName := placement.GenJobName(js.Name, rjob.Name, jobIdx)
 
@@ -1064,6 +1069,10 @@ func labelAndAnnotateObject(obj metav1.Object, js *jobset.JobSet, rjob *jobset.R
 		if value, ok := js.Annotations[jobset.NodeSelectorStrategyKey]; ok {
 			annotations[jobset.NodeSelectorStrategyKey] = value
 		}
+		// Check if the user opted in to publishing the resolved topology value as a pod label.
+		if value, ok := js.Annotations[jobset.ExclusiveTopologyLabelKey]; ok {
+			annotations[jobset.ExclusiveTopologyLabelKey] = value
+		}
 	}
 	// Check for ReplicatedJob level exclusive placement.
 	if topologyDomain, exists := rjob.Template.Annotations[jobset.ExclusiveKey]; exists {
@@ -1071,6 +1080,10 @@ func labelAndAnnotateObject(obj metav1.Object, js *jobset.JobSet, rjob *jobset.R
 		// Check if we are using nodeSelectorStrategy implementation of exclusive placement at the ReplicatedJob level.
 		if value, ok := rjob.Template.Annotations[jobset.NodeSelectorStrategyKey]; ok {
 			annotations[jobset.NodeSelectorStrategyKey] = value
+		}
+		// Check if the user opted in to publishing the resolved topology value as a pod label.
+		if value, ok := rjob.Template.Annotations[jobset.ExclusiveTopologyLabelKey]; ok {
+			annotations[jobset.ExclusiveTopologyLabelKey] = value
 		}
 	}
 

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -567,6 +567,73 @@ func TestConstructJobsFromTemplate(t *testing.T) {
 			},
 		},
 		{
+			name:              "exclusive placement with topology label key annotation propagation for entire JobSet",
+			restartJobEnabled: true,
+			js: testutils.MakeJobSet(jobSetName, ns).
+				SetAnnotations(map[string]string{
+					jobset.ExclusiveKey:              topologyDomain,
+					jobset.ExclusiveTopologyLabelKey: "ray.io/gpu-domain",
+				}).
+				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName + "-A").
+					Job(testutils.MakeJobTemplate(jobName, ns).Obj()).
+					Replicas(1).
+					GroupName("default").
+					Obj()).
+				Obj(),
+			ownedJobs: &childJobs{},
+			want: []*batchv1.Job{
+				makeJob(&makeJobArgs{
+					jobSetName:                jobSetName,
+					replicatedJobName:         replicatedJobName + "-A",
+					groupName:                 "default",
+					jobName:                   "test-jobset-replicated-job-A-0",
+					ns:                        ns,
+					replicas:                  1,
+					jobIdx:                    0,
+					topology:                  topologyDomain,
+					exclusiveTopologyLabelKey: "ray.io/gpu-domain"}).
+					Suspend(false).Obj(),
+			},
+		},
+		{
+			// The ReplicatedJob template sets a different value for
+			// ExclusiveTopologyLabelKey than the JobSet. The propagation block
+			// in labelAndAnnotateObject runs the JobSet block first and the
+			// ReplicatedJob block second; this case asserts the
+			// ReplicatedJob-level value wins on the child Job/pod template.
+			name:              "exclusive placement with topology label key annotation propagation, ReplicatedJob template overrides JobSet",
+			restartJobEnabled: true,
+			js: testutils.MakeJobSet(jobSetName, ns).
+				SetAnnotations(map[string]string{
+					jobset.ExclusiveKey:              topologyDomain,
+					jobset.ExclusiveTopologyLabelKey: "js.example.com/topology",
+				}).
+				ReplicatedJob(testutils.MakeReplicatedJob(replicatedJobName + "-A").
+					Job(testutils.MakeJobTemplate(jobName, ns).
+						SetAnnotations(map[string]string{
+							jobset.ExclusiveKey:              topologyDomain,
+							jobset.ExclusiveTopologyLabelKey: "rj.example.com/topology",
+						}).Obj()).
+					Replicas(1).
+					GroupName("default").
+					Obj()).
+				Obj(),
+			ownedJobs: &childJobs{},
+			want: []*batchv1.Job{
+				makeJob(&makeJobArgs{
+					jobSetName:                jobSetName,
+					replicatedJobName:         replicatedJobName + "-A",
+					groupName:                 "default",
+					jobName:                   "test-jobset-replicated-job-A-0",
+					ns:                        ns,
+					replicas:                  1,
+					jobIdx:                    0,
+					topology:                  topologyDomain,
+					exclusiveTopologyLabelKey: "rj.example.com/topology"}).
+					Suspend(false).Obj(),
+			},
+		},
+		{
 			name:              "exclusive placement using nodeSelectorStrategy for entire JobSet",
 			restartJobEnabled: true,
 			js: testutils.MakeJobSet(jobSetName, ns).
@@ -1663,6 +1730,10 @@ type makeJobArgs struct {
 	omitJobRestartAttempt bool
 	topology              string
 	nodeSelectorStrategy  bool
+	// exclusiveTopologyLabelKey is the value of the
+	// alpha.jobset.sigs.k8s.io/exclusive-topology-label-key annotation that we
+	// expect to be propagated onto the child Job/pod template, or "" if absent.
+	exclusiveTopologyLabelKey string
 }
 
 // Helper function to create a Job for unit testing.
@@ -1697,6 +1768,10 @@ func makeJob(args *makeJobArgs) *testutils.JobWrapper {
 		// Exclusive placement topology domain must be set in order to use the node selector strategy.
 		if args.nodeSelectorStrategy {
 			annotations[jobset.NodeSelectorStrategyKey] = "true"
+		}
+		// Optional opt-in: publish the resolved topology value as a pod label.
+		if args.exclusiveTopologyLabelKey != "" {
+			annotations[jobset.ExclusiveTopologyLabelKey] = args.exclusiveTopologyLabelKey
 		}
 	}
 	jobWrapper := testutils.MakeJob(args.jobName, args.ns).

--- a/pkg/webhooks/jobset_webhook.go
+++ b/pkg/webhooks/jobset_webhook.go
@@ -305,7 +305,94 @@ func (j *jobSetWebhook) ValidateCreate(ctx context.Context, js *jobset.JobSet) (
 		allErrs = append(allErrs, j.validateVolumeClaimPolicies(ctx, js, js.Spec.VolumeClaimPolicies)...)
 	}
 
+	// Validate the exclusive-topology-label-key annotation, if set at the JobSet
+	// level or on any ReplicatedJob template.
+	allErrs = append(allErrs, validateExclusiveTopologyLabelKeyAnnotations(js)...)
+
 	return nil, invalidError(js.Name, allErrs)
+}
+
+// validateExclusiveTopologyLabelKeyAnnotations enforces that the alpha
+// "exclusive-topology-label-key" annotation is only set in valid combinations.
+//
+// Per-scope checks (JobSet and each ReplicatedJob template) reject:
+//   - the annotation set without exclusive-topology on the same scope,
+//   - the annotation set together with node-selector strategy on the same scope,
+//   - an empty value, whitespace-padded value, or a value that fails
+//     validation.IsQualifiedName.
+//
+// A cross-scope check rejects splitting the new annotation and
+// node-selector strategy across JobSet and ReplicatedJob template scopes,
+// because the controller propagates both onto the pod and the pod mutating
+// webhook then short-circuits on node-selector strategy before publishing
+// the label.
+func validateExclusiveTopologyLabelKeyAnnotations(js *jobset.JobSet) []error {
+	var errs []error
+	check := func(scope string, annotations map[string]string) {
+		v, ok := annotations[jobset.ExclusiveTopologyLabelKey]
+		if !ok {
+			return
+		}
+		if _, hasExclusive := annotations[jobset.ExclusiveKey]; !hasExclusive {
+			errs = append(errs, fmt.Errorf(
+				"%s annotation %q is set on %s, but %q is not also set on the same scope",
+				jobset.ExclusiveTopologyLabelKey, v, scope, jobset.ExclusiveKey))
+		}
+		if _, hasNodeSelector := annotations[jobset.NodeSelectorStrategyKey]; hasNodeSelector {
+			errs = append(errs, fmt.Errorf(
+				"%s annotation cannot be used together with %q on %s",
+				jobset.ExclusiveTopologyLabelKey, jobset.NodeSelectorStrategyKey, scope))
+		}
+		if v == "" {
+			errs = append(errs, fmt.Errorf(
+				"%s annotation on %s must not be empty",
+				jobset.ExclusiveTopologyLabelKey, scope))
+			return
+		}
+		if strings.TrimSpace(v) != v {
+			errs = append(errs, fmt.Errorf(
+				"%s annotation on %s must not contain leading or trailing whitespace: %q",
+				jobset.ExclusiveTopologyLabelKey, scope, v))
+		}
+		for _, msg := range validation.IsQualifiedName(v) {
+			errs = append(errs, fmt.Errorf(
+				"%s annotation value %q on %s is not a valid Kubernetes label key: %s",
+				jobset.ExclusiveTopologyLabelKey, v, scope, msg))
+		}
+	}
+	check("JobSet", js.Annotations)
+	for i := range js.Spec.ReplicatedJobs {
+		rjob := &js.Spec.ReplicatedJobs[i]
+		check(fmt.Sprintf("ReplicatedJob %q", rjob.Name), rjob.Template.Annotations)
+	}
+
+	// Cross-scope check: ExclusiveTopologyLabelKey and NodeSelectorStrategyKey
+	// target different placement strategies and are mutually exclusive. The
+	// per-scope check above catches the case where both are set on the same
+	// scope; this loop catches the cross-scope split. The runtime failure
+	// mode is silent: labelAndAnnotateObject merges JobSet- and
+	// ReplicatedJob-level annotations onto the pod, and the pod webhook
+	// then bails on NodeSelectorStrategyKey before publishing the label.
+	for i := range js.Spec.ReplicatedJobs {
+		rjob := &js.Spec.ReplicatedJobs[i]
+		_, jsHasETLK := js.Annotations[jobset.ExclusiveTopologyLabelKey]
+		_, rjHasETLK := rjob.Template.Annotations[jobset.ExclusiveTopologyLabelKey]
+		_, jsHasNSS := js.Annotations[jobset.NodeSelectorStrategyKey]
+		_, rjHasNSS := rjob.Template.Annotations[jobset.NodeSelectorStrategyKey]
+		if (jsHasETLK || rjHasETLK) && (jsHasNSS || rjHasNSS) {
+			sameScopeJS := jsHasETLK && jsHasNSS
+			sameScopeRJ := rjHasETLK && rjHasNSS
+			if !sameScopeJS && !sameScopeRJ {
+				errs = append(errs, fmt.Errorf(
+					"%s and %s are set on different scopes for ReplicatedJob %q "+
+						"(JobSet vs. ReplicatedJob template); they are mutually exclusive",
+					jobset.ExclusiveTopologyLabelKey,
+					jobset.NodeSelectorStrategyKey,
+					rjob.Name))
+			}
+		}
+	}
+	return errs
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
@@ -394,6 +481,13 @@ func (j *jobSetWebhook) ValidateUpdate(ctx context.Context, oldJs, newJs *jobset
 	// Note that SucccessPolicy and failurePolicy are made immutable via CEL.
 	errs = append(errs, apivalidation.ValidateImmutableField(mungedSpec.ReplicatedJobs, oldJs.Spec.ReplicatedJobs, field.NewPath("spec").Child("replicatedJobs"))...)
 	errs = append(errs, apivalidation.ValidateImmutableField(newJs.Spec.ManagedBy, oldJs.Spec.ManagedBy, field.NewPath("spec").Child("managedBy"))...)
+
+	// Validate the exclusive-topology-label-key annotation, if set. We check on
+	// every update because annotations are mutable and a user could otherwise add
+	// an invalid pairing after creation.
+	for _, err := range validateExclusiveTopologyLabelKeyAnnotations(newJs) {
+		errs = append(errs, field.Invalid(field.NewPath("metadata", "annotations"), jobset.ExclusiveTopologyLabelKey, err.Error()))
+	}
 
 	if len(errs) == 0 {
 		return nil, nil

--- a/pkg/webhooks/jobset_webhook_test.go
+++ b/pkg/webhooks/jobset_webhook_test.go
@@ -3064,6 +3064,124 @@ func TestValidateCreate(t *testing.T) {
 		},
 	}
 
+	// Helper that builds a JobSet with one ReplicatedJob and the supplied
+	// JobSet-level and ReplicatedJob-template-level annotations.
+	jsWithAnnotations := func(name string, jsAnn, rjAnn map[string]string) *jobset.JobSet {
+		return &jobset.JobSet{
+			TypeMeta:   metav1.TypeMeta{Kind: "JobSet", APIVersion: "jobset.x-k8s.io/v1alpha2"},
+			ObjectMeta: metav1.ObjectMeta{Name: name, Annotations: jsAnn},
+			Spec: jobset.JobSetSpec{
+				ReplicatedJobs: []jobset.ReplicatedJob{
+					{
+						Name:      "rjob",
+						GroupName: "default",
+						Replicas:  1,
+						Template: batchv1.JobTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{Annotations: rjAnn},
+							Spec: batchv1.JobSpec{
+								Template: validPodTemplateSpec,
+							},
+						},
+					},
+				},
+				SuccessPolicy: &jobset.SuccessPolicy{Operator: jobset.OperatorAll},
+			},
+		}
+	}
+
+	exclusiveTopologyLabelKeyTests := []validationTestCase{
+		{
+			name: "exclusive-topology-label-key valid on JobSet",
+			js: jsWithAnnotations("js", map[string]string{
+				jobset.ExclusiveKey:              "topology.kubernetes.io/zone",
+				jobset.ExclusiveTopologyLabelKey: "ray.io/gpu-domain",
+			}, nil),
+			want: nil,
+		},
+		{
+			name: "exclusive-topology-label-key valid on ReplicatedJob template",
+			js: jsWithAnnotations("js", nil, map[string]string{
+				jobset.ExclusiveKey:              "topology.kubernetes.io/zone",
+				jobset.ExclusiveTopologyLabelKey: "ray.io/gpu-domain",
+			}),
+			want: nil,
+		},
+		{
+			name: "exclusive-topology-label-key without exclusive-topology on JobSet rejected",
+			js: jsWithAnnotations("js", map[string]string{
+				jobset.ExclusiveTopologyLabelKey: "ray.io/gpu-domain",
+			}, nil),
+			want: errors.Join(fmt.Errorf(
+				"%s annotation %q is set on JobSet, but %q is not also set on the same scope",
+				jobset.ExclusiveTopologyLabelKey, "ray.io/gpu-domain", jobset.ExclusiveKey)),
+		},
+		{
+			name: "exclusive-topology-label-key with node-selector strategy on JobSet rejected",
+			js: jsWithAnnotations("js", map[string]string{
+				jobset.ExclusiveKey:              "topology.kubernetes.io/zone",
+				jobset.NodeSelectorStrategyKey:   "",
+				jobset.ExclusiveTopologyLabelKey: "ray.io/gpu-domain",
+			}, nil),
+			want: errors.Join(fmt.Errorf(
+				"%s annotation cannot be used together with %q on JobSet",
+				jobset.ExclusiveTopologyLabelKey, jobset.NodeSelectorStrategyKey)),
+		},
+		{
+			name: "exclusive-topology-label-key empty value rejected",
+			js: jsWithAnnotations("js", map[string]string{
+				jobset.ExclusiveKey:              "topology.kubernetes.io/zone",
+				jobset.ExclusiveTopologyLabelKey: "",
+			}, nil),
+			want: errors.Join(fmt.Errorf(
+				"%s annotation on JobSet must not be empty",
+				jobset.ExclusiveTopologyLabelKey)),
+		},
+		{
+			name: "exclusive-topology-label-key whitespace-padded value rejected",
+			js: jsWithAnnotations("js", map[string]string{
+				jobset.ExclusiveKey:              "topology.kubernetes.io/zone",
+				jobset.ExclusiveTopologyLabelKey: " ray.io/gpu-domain ",
+			}, nil),
+			want: errors.Join(fmt.Errorf(
+				"%s annotation on JobSet must not contain leading or trailing whitespace: %q",
+				jobset.ExclusiveTopologyLabelKey, " ray.io/gpu-domain ")),
+		},
+		{
+			name: "exclusive-topology-label-key invalid key syntax rejected",
+			js: jsWithAnnotations("js", map[string]string{
+				jobset.ExclusiveKey:              "topology.kubernetes.io/zone",
+				jobset.ExclusiveTopologyLabelKey: "Not A Valid Key",
+			}, nil),
+			// We don't pin the exact validation message; the runner asserts that
+			// each substring in want.Error() appears in the actual error.
+			want: errors.Join(fmt.Errorf(
+				"%s annotation value %q on JobSet is not a valid Kubernetes label key",
+				jobset.ExclusiveTopologyLabelKey, "Not A Valid Key")),
+		},
+		{
+			name: "exclusive-topology-label-key on ReplicatedJob without exclusive-topology rejected",
+			js: jsWithAnnotations("js", nil, map[string]string{
+				jobset.ExclusiveTopologyLabelKey: "ray.io/gpu-domain",
+			}),
+			want: errors.Join(fmt.Errorf(
+				"%s annotation %q is set on ReplicatedJob %q, but %q is not also set on the same scope",
+				jobset.ExclusiveTopologyLabelKey, "ray.io/gpu-domain", "rjob", jobset.ExclusiveKey)),
+		},
+		{
+			name: "exclusive-topology-label-key cross-scope: JobSet has node-selector strategy, ReplicatedJob has label-key",
+			js: jsWithAnnotations("js", map[string]string{
+				jobset.ExclusiveKey:            "topology.kubernetes.io/zone",
+				jobset.NodeSelectorStrategyKey: "true",
+			}, map[string]string{
+				jobset.ExclusiveKey:              "topology.kubernetes.io/zone",
+				jobset.ExclusiveTopologyLabelKey: "ray.io/gpu-domain",
+			}),
+			want: errors.Join(fmt.Errorf(
+				"%s and %s are set on different scopes for ReplicatedJob %q",
+				jobset.ExclusiveTopologyLabelKey, jobset.NodeSelectorStrategyKey, "rjob")),
+		},
+	}
+
 	testGroups := [][]validationTestCase{
 		uncategorizedTests,
 		jobsetControllerNameTests,
@@ -3071,6 +3189,7 @@ func TestValidateCreate(t *testing.T) {
 		dependsOnTests,
 		volumeClaimPolicyTests,
 		inPlaceRestartTests,
+		exclusiveTopologyLabelKeyTests,
 	}
 	var testCases []validationTestCase
 	for _, testGroup := range testGroups {
@@ -3904,6 +4023,49 @@ func TestValidateUpdate(t *testing.T) {
 				field.Invalid(field.NewPath("spec").Child("replicatedJobs"), "", "field is immutable"),
 			}.ToAggregate(),
 			enableElasticJobSet: true,
+		},
+		{
+			// Annotations are mutable on JobSets. A user can post a valid JobSet
+			// then add an invalid exclusive-topology-label-key pairing via
+			// kubectl annotate. The new validator must catch this on update.
+			name: "update adds exclusive-topology-label-key without exclusive-topology, rejected",
+			oldJs: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec:       jobset.JobSetSpec{ReplicatedJobs: validReplicatedJobs},
+			},
+			js: &jobset.JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "js",
+					Annotations: map[string]string{
+						jobset.ExclusiveTopologyLabelKey: "ray.io/gpu-domain",
+					},
+				},
+				Spec: jobset.JobSetSpec{ReplicatedJobs: validReplicatedJobs},
+			},
+			want: field.ErrorList{
+				field.Invalid(field.NewPath("metadata", "annotations"), jobset.ExclusiveTopologyLabelKey,
+					fmt.Sprintf(
+						"%s annotation %q is set on JobSet, but %q is not also set on the same scope",
+						jobset.ExclusiveTopologyLabelKey, "ray.io/gpu-domain", jobset.ExclusiveKey)),
+			}.ToAggregate(),
+		},
+		{
+			name: "update adds valid exclusive-topology + exclusive-topology-label-key pairing, accepted",
+			oldJs: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec:       jobset.JobSetSpec{ReplicatedJobs: validReplicatedJobs},
+			},
+			js: &jobset.JobSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "js",
+					Annotations: map[string]string{
+						jobset.ExclusiveKey:              "topology.kubernetes.io/zone",
+						jobset.ExclusiveTopologyLabelKey: "ray.io/gpu-domain",
+					},
+				},
+				Spec: jobset.JobSetSpec{ReplicatedJobs: validReplicatedJobs},
+			},
+			want: nil,
 		},
 	}
 

--- a/pkg/webhooks/pod_webhook.go
+++ b/pkg/webhooks/pod_webhook.go
@@ -174,6 +174,33 @@ func (p *podWebhook) setNodeSelector(ctx context.Context, pod *corev1.Pod) error
 	}
 	log.V(2).Info(fmt.Sprintf("setting nodeSelector %s: %s to follow leader pod %s", topologyKey, topologyValue, leaderPod.Name))
 	pod.Spec.NodeSelector[topologyKey] = topologyValue
+
+	// If the user opted in, publish the resolved topology value onto the pod as a
+	// label under their chosen key, so the container can read it via the Downward API.
+	if outKey, ok := pod.Annotations[jobset.ExclusiveTopologyLabelKey]; ok && outKey != "" {
+		log.V(2).Info(fmt.Sprintf("setting label %s: %s to follow leader pod %s", outKey, topologyValue, leaderPod.Name))
+		if err := setExclusiveTopologyLabel(pod, outKey, topologyValue); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// setExclusiveTopologyLabel writes the resolved topology value onto the pod as a
+// label under the user-selected key. Returns an error if the label already
+// exists on the pod with a different value (caller surfaces this as an
+// admission rejection).
+//
+// The conflict error deliberately does not name the existing value so the
+// rejection cannot be used as an oracle for node label values.
+func setExclusiveTopologyLabel(pod *corev1.Pod, key, value string) error {
+	if pod.Labels == nil {
+		pod.Labels = map[string]string{}
+	}
+	if existing, has := pod.Labels[key]; has && existing != value {
+		return fmt.Errorf("cannot set pod label %q: already has a different value", key)
+	}
+	pod.Labels[key] = value
 	return nil
 }
 

--- a/pkg/webhooks/pod_webhook_test.go
+++ b/pkg/webhooks/pod_webhook_test.go
@@ -406,6 +406,309 @@ func TestDefault(t *testing.T) {
 			wantPod: nil,
 			wantErr: apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "nodes"}, "node-a"),
 		},
+		{
+			name: "follower pod with exclusive-topology-label-key annotation, publishes label",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "js-rjob-0-1-follower",
+					Namespace: "default",
+					Labels: map[string]string{
+						"jobset.sigs.k8s.io/jobset-name":        "js",
+						"jobset.sigs.k8s.io/replicatedjob-name": "rjob",
+						"jobset.sigs.k8s.io/job-index":          "0",
+					},
+					Annotations: map[string]string{
+						"jobset.sigs.k8s.io/jobset-name":                        "js",
+						"alpha.jobset.sigs.k8s.io/exclusive-topology":           "topology.kubernetes.io/zone",
+						"alpha.jobset.sigs.k8s.io/exclusive-topology-label-key": "ray.io/gpu-domain",
+						"batch.kubernetes.io/job-completion-index":              "1",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{UID: types.UID("job-uid-1"), Kind: "Job", Controller: ptr.To(true)},
+					},
+				},
+				Spec: corev1.PodSpec{
+					Priority: ptr.To(int32(100)),
+				},
+			},
+			existingObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "js-rjob-0-0-leader",
+						Namespace: "default",
+						Labels: map[string]string{
+							"jobset.sigs.k8s.io/jobset-name":        "js",
+							"jobset.sigs.k8s.io/replicatedjob-name": "rjob",
+							"jobset.sigs.k8s.io/job-index":          "0",
+						},
+						Annotations: map[string]string{
+							"alpha.jobset.sigs.k8s.io/exclusive-topology": "topology.kubernetes.io/zone",
+							"batch.kubernetes.io/job-completion-index":    "0",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{UID: types.UID("job-uid-1"), Kind: "Job", Controller: ptr.To(true)},
+						},
+					},
+					Spec: corev1.PodSpec{NodeName: "node-a"},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "node-a",
+						Labels: map[string]string{"topology.kubernetes.io/zone": "zone-a"},
+					},
+				},
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "js-rjob-0-1-follower",
+					Namespace: "default",
+					Labels: map[string]string{
+						"jobset.sigs.k8s.io/jobset-name":        "js",
+						"jobset.sigs.k8s.io/replicatedjob-name": "rjob",
+						"jobset.sigs.k8s.io/job-index":          "0",
+						"jobset.sigs.k8s.io/priority":           "100",
+						"ray.io/gpu-domain":                     "zone-a",
+					},
+					Annotations: map[string]string{
+						"jobset.sigs.k8s.io/jobset-name":                        "js",
+						"alpha.jobset.sigs.k8s.io/exclusive-topology":           "topology.kubernetes.io/zone",
+						"alpha.jobset.sigs.k8s.io/exclusive-topology-label-key": "ray.io/gpu-domain",
+						"batch.kubernetes.io/job-completion-index":              "1",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{UID: types.UID("job-uid-1"), Kind: "Job", Controller: ptr.To(true)},
+					},
+				},
+				Spec: corev1.PodSpec{
+					Priority:     ptr.To(int32(100)),
+					NodeSelector: map[string]string{"topology.kubernetes.io/zone": "zone-a"},
+				},
+			},
+		},
+		{
+			name: "follower pod with exclusive-topology-label-key, existing label same value",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "js-rjob-0-1-follower",
+					Namespace: "default",
+					Labels: map[string]string{
+						"jobset.sigs.k8s.io/jobset-name":        "js",
+						"jobset.sigs.k8s.io/replicatedjob-name": "rjob",
+						"jobset.sigs.k8s.io/job-index":          "0",
+						"ray.io/gpu-domain":                     "zone-a", // already correct
+					},
+					Annotations: map[string]string{
+						"jobset.sigs.k8s.io/jobset-name":                        "js",
+						"alpha.jobset.sigs.k8s.io/exclusive-topology":           "topology.kubernetes.io/zone",
+						"alpha.jobset.sigs.k8s.io/exclusive-topology-label-key": "ray.io/gpu-domain",
+						"batch.kubernetes.io/job-completion-index":              "1",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{UID: types.UID("job-uid-1"), Kind: "Job", Controller: ptr.To(true)},
+					},
+				},
+				Spec: corev1.PodSpec{
+					Priority: ptr.To(int32(100)),
+				},
+			},
+			existingObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "js-rjob-0-0-leader",
+						Namespace: "default",
+						Labels: map[string]string{
+							"jobset.sigs.k8s.io/jobset-name":        "js",
+							"jobset.sigs.k8s.io/replicatedjob-name": "rjob",
+							"jobset.sigs.k8s.io/job-index":          "0",
+						},
+						Annotations: map[string]string{
+							"alpha.jobset.sigs.k8s.io/exclusive-topology": "topology.kubernetes.io/zone",
+							"batch.kubernetes.io/job-completion-index":    "0",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{UID: types.UID("job-uid-1"), Kind: "Job", Controller: ptr.To(true)},
+						},
+					},
+					Spec: corev1.PodSpec{NodeName: "node-a"},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "node-a",
+						Labels: map[string]string{"topology.kubernetes.io/zone": "zone-a"},
+					},
+				},
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "js-rjob-0-1-follower",
+					Namespace: "default",
+					Labels: map[string]string{
+						"jobset.sigs.k8s.io/jobset-name":        "js",
+						"jobset.sigs.k8s.io/replicatedjob-name": "rjob",
+						"jobset.sigs.k8s.io/job-index":          "0",
+						"jobset.sigs.k8s.io/priority":           "100",
+						"ray.io/gpu-domain":                     "zone-a",
+					},
+					Annotations: map[string]string{
+						"jobset.sigs.k8s.io/jobset-name":                        "js",
+						"alpha.jobset.sigs.k8s.io/exclusive-topology":           "topology.kubernetes.io/zone",
+						"alpha.jobset.sigs.k8s.io/exclusive-topology-label-key": "ray.io/gpu-domain",
+						"batch.kubernetes.io/job-completion-index":              "1",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{UID: types.UID("job-uid-1"), Kind: "Job", Controller: ptr.To(true)},
+					},
+				},
+				Spec: corev1.PodSpec{
+					Priority:     ptr.To(int32(100)),
+					NodeSelector: map[string]string{"topology.kubernetes.io/zone": "zone-a"},
+				},
+			},
+		},
+		{
+			name: "follower pod with exclusive-topology-label-key, existing label different value, rejected",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "js-rjob-0-1-follower",
+					Namespace: "default",
+					Labels: map[string]string{
+						"jobset.sigs.k8s.io/jobset-name":        "js",
+						"jobset.sigs.k8s.io/replicatedjob-name": "rjob",
+						"jobset.sigs.k8s.io/job-index":          "0",
+						"ray.io/gpu-domain":                     "wrong-zone",
+					},
+					Annotations: map[string]string{
+						"jobset.sigs.k8s.io/jobset-name":                        "js",
+						"alpha.jobset.sigs.k8s.io/exclusive-topology":           "topology.kubernetes.io/zone",
+						"alpha.jobset.sigs.k8s.io/exclusive-topology-label-key": "ray.io/gpu-domain",
+						"batch.kubernetes.io/job-completion-index":              "1",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{UID: types.UID("job-uid-1"), Kind: "Job", Controller: ptr.To(true)},
+					},
+				},
+				Spec: corev1.PodSpec{
+					Priority: ptr.To(int32(100)),
+				},
+			},
+			existingObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "js-rjob-0-0-leader",
+						Namespace: "default",
+						Labels: map[string]string{
+							"jobset.sigs.k8s.io/jobset-name":        "js",
+							"jobset.sigs.k8s.io/replicatedjob-name": "rjob",
+							"jobset.sigs.k8s.io/job-index":          "0",
+						},
+						Annotations: map[string]string{
+							"alpha.jobset.sigs.k8s.io/exclusive-topology": "topology.kubernetes.io/zone",
+							"batch.kubernetes.io/job-completion-index":    "0",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{UID: types.UID("job-uid-1"), Kind: "Job", Controller: ptr.To(true)},
+						},
+					},
+					Spec: corev1.PodSpec{NodeName: "node-a"},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "node-a",
+						Labels: map[string]string{"topology.kubernetes.io/zone": "zone-a"},
+					},
+				},
+			},
+			wantPod: nil,
+			wantErr: fmt.Errorf(`cannot set pod label "ray.io/gpu-domain": already has a different value`),
+		},
+		{
+			name: "leader pod with exclusive-topology-label-key, leader is not labeled",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "js-rjob-0-0-leader",
+					Namespace: "default",
+					Labels: map[string]string{
+						"jobset.sigs.k8s.io/jobset-name":        "js",
+						"jobset.sigs.k8s.io/replicatedjob-name": "rjob",
+						"jobset.sigs.k8s.io/job-index":          "0",
+						"jobset.sigs.k8s.io/job-key":            "job-key-1",
+					},
+					Annotations: map[string]string{
+						"jobset.sigs.k8s.io/jobset-name":                        "js",
+						"alpha.jobset.sigs.k8s.io/exclusive-topology":           "topology.kubernetes.io/zone",
+						"alpha.jobset.sigs.k8s.io/exclusive-topology-label-key": "ray.io/gpu-domain",
+						"batch.kubernetes.io/job-completion-index":              "0",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{UID: types.UID("job-uid-1"), Kind: "Job", Controller: ptr.To(true)},
+					},
+				},
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "js-rjob-0-0-leader",
+					Namespace: "default",
+					Labels: map[string]string{
+						"jobset.sigs.k8s.io/jobset-name":        "js",
+						"jobset.sigs.k8s.io/replicatedjob-name": "rjob",
+						"jobset.sigs.k8s.io/job-index":          "0",
+						"jobset.sigs.k8s.io/job-key":            "job-key-1",
+					},
+					Annotations: map[string]string{
+						"jobset.sigs.k8s.io/jobset-name":                        "js",
+						"alpha.jobset.sigs.k8s.io/exclusive-topology":           "topology.kubernetes.io/zone",
+						"alpha.jobset.sigs.k8s.io/exclusive-topology-label-key": "ray.io/gpu-domain",
+						"batch.kubernetes.io/job-completion-index":              "0",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{UID: types.UID("job-uid-1"), Kind: "Job", Controller: ptr.To(true)},
+					},
+				},
+				Spec: corev1.PodSpec{
+					Affinity: &corev1.Affinity{
+						PodAffinity: &corev1.PodAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+										{
+											Key:      "jobset.sigs.k8s.io/job-key",
+											Operator: metav1.LabelSelectorOpIn,
+											Values:   []string{"job-key-1"},
+										},
+									}},
+									TopologyKey:       "topology.kubernetes.io/zone",
+									NamespaceSelector: &metav1.LabelSelector{},
+								},
+							},
+						},
+						PodAntiAffinity: &corev1.PodAntiAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+										{
+											Key:      "jobset.sigs.k8s.io/job-key",
+											Operator: metav1.LabelSelectorOpExists,
+										},
+										{
+											Key:      "jobset.sigs.k8s.io/job-key",
+											Operator: metav1.LabelSelectorOpNotIn,
+											Values:   []string{"job-key-1"},
+										},
+										{
+											Key:      "jobset.sigs.k8s.io/priority",
+											Operator: metav1.LabelSelectorOpIn,
+											Values:   []string{""},
+										},
+									}},
+									TopologyKey:       "topology.kubernetes.io/zone",
+									NamespaceSelector: &metav1.LabelSelector{},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	scheme := runtime.NewScheme()
@@ -425,9 +728,22 @@ func TestDefault(t *testing.T) {
 			podCopy := tc.pod.DeepCopy()
 			err := p.Default(context.Background(), podCopy)
 
-			if diff := cmp.Diff(tc.wantErr, err); diff != "" {
-				fmt.Printf("%+v", err)
-				t.Errorf("error mismatch (-want +got):\n%s", diff)
+			// Compare error messages by string rather than cmp.Diff: this test
+			// has both typed apierrors values and ad-hoc fmt.Errorf values, and
+			// cmp.Diff panics on the unexported errorString field of the
+			// latter. The .Error() string is what users see and is sufficient
+			// for these assertions; this matches the pattern used by the
+			// JobSet ValidateCreate test runner in this package.
+			gotErrStr := ""
+			if err != nil {
+				gotErrStr = err.Error()
+			}
+			wantErrStr := ""
+			if tc.wantErr != nil {
+				wantErrStr = tc.wantErr.Error()
+			}
+			if gotErrStr != wantErrStr {
+				t.Errorf("error mismatch:\n  want: %q\n  got:  %q", wantErrStr, gotErrStr)
 			}
 
 			if tc.wantPod == nil {

--- a/test/integration/webhook/jobset_webhook_test.go
+++ b/test/integration/webhook/jobset_webhook_test.go
@@ -566,6 +566,62 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 			},
 			jobSetCreationShouldFail: true,
 		}),
+		ginkgo.Entry("exclusive-topology-label-key annotation set together with exclusive-topology is accepted", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("etl-key-valid", ns.Name).
+					SetAnnotations(map[string]string{
+						jobset.ExclusiveKey:              "topology.kubernetes.io/zone",
+						jobset.ExclusiveTopologyLabelKey: "ray.io/gpu-domain",
+					}).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob").
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							PodSpec(testing.TestPodSpec).Obj()).
+						Obj())
+			},
+			jobSetCreationShouldFail: false,
+		}),
+		ginkgo.Entry("exclusive-topology-label-key annotation without exclusive-topology is rejected", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("etl-key-without-et", ns.Name).
+					SetAnnotations(map[string]string{
+						jobset.ExclusiveTopologyLabelKey: "ray.io/gpu-domain",
+					}).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob").
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							PodSpec(testing.TestPodSpec).Obj()).
+						Obj())
+			},
+			jobSetCreationShouldFail: true,
+		}),
+		ginkgo.Entry("exclusive-topology-label-key annotation with node-selector strategy is rejected", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("etl-key-with-ns-strategy", ns.Name).
+					SetAnnotations(map[string]string{
+						jobset.ExclusiveKey:              "topology.kubernetes.io/zone",
+						jobset.NodeSelectorStrategyKey:   "true",
+						jobset.ExclusiveTopologyLabelKey: "ray.io/gpu-domain",
+					}).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob").
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							PodSpec(testing.TestPodSpec).Obj()).
+						Obj())
+			},
+			jobSetCreationShouldFail: true,
+		}),
+		ginkgo.Entry("exclusive-topology-label-key annotation with invalid key syntax is rejected", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("etl-key-invalid-syntax", ns.Name).
+					SetAnnotations(map[string]string{
+						jobset.ExclusiveKey:              "topology.kubernetes.io/zone",
+						jobset.ExclusiveTopologyLabelKey: "Not A Valid Key",
+					}).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob").
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							PodSpec(testing.TestPodSpec).Obj()).
+						Obj())
+			},
+			jobSetCreationShouldFail: true,
+		}),
 		ginkgo.Entry("VolumeClaimPolicies defaults are applied when empty", &testCase{
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
 				return testing.MakeJobSet("volume-claim-policies", ns.Name).


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

Adds a new opt-in alpha annotation `alpha.jobset.sigs.k8s.io/exclusive-topology-label-key`. When set alongside the existing `alpha.jobset.sigs.k8s.io/exclusive-topology` annotation, the JobSet pod mutating webhook copies the resolved topology value (which it already computes for `spec.nodeSelector` on follower pods) onto the follower pod's `metadata.labels` under the user-supplied key. Containers consume it via the standard Downward API:

```yaml
metadata:
  annotations:
    alpha.jobset.sigs.k8s.io/exclusive-topology: topology.example.com/nvlink-domain
    alpha.jobset.sigs.k8s.io/exclusive-topology-label-key: ray.io/gpu-domain
spec:
  replicatedJobs:
  - name: worker
    template:
      spec:
        template:
          spec:
            containers:
            - name: ray-worker
              env:
              - name: RAY_GPU_DOMAIN
                valueFrom:
                  fieldRef:
                    fieldPath: metadata.labels['ray.io/gpu-domain']
```

The motivating use case is Ray's [Label Locality scheduling](https://github.com/ray-project/ray/pull/61442), which expects a Ray-level label `ray.io/gpu-domain` populated with a rack/NVLink-domain identifier. Without this feature, every workload that wants this value has to ship an init container that calls `GET /api/v1/nodes/<name>` with cluster-scoped `get nodes` RBAC. The JobSet pod webhook already resolves this value to write `spec.nodeSelector` for followers — this PR exposes it to the container as well.

#### Which issue(s) this PR fixes:

Fixes #

This PR is provisional KEP + reference implementation in a single review unit. The KEP at `keps/NNNN-exclusive-topology-label/` carries `kep-number: NNNN`; please assign a real number during review. `reviewers:` and `approvers:` in `kep.yaml` are `- TBD` for the same reason.

#### Special notes for your reviewer:

- **Alpha-prefixed annotation, opt-in.** Workloads that don't set the new annotation see no behavior change.
- **Follower pods only.** Leader pods are out of scope for alpha because their bound node is not knowable at pod-create admission. A follow-up KEP would add a `pods/binding` admission webhook to cover them. KEP §Non-Goals and §Drawbacks document this explicitly.
- **No feature gate.** The annotation is itself the kill switch. New code paths only run when both `exclusive-topology` and the new annotation are set. `kep.yaml` carries `feature-gates: []` and `disable-supported: false` to make the decision explicit. KEP §"Design Details, point 4" walks through this with a fallback path if maintainers prefer a runtime gate.
- **Commits are split into 5 atomic logical changes**, each independently reviewable:
  1. `docs(keps): propose exclusive-topology-label-key alpha feature` — KEP only
  2. `feat(api): add ExclusiveTopologyLabelKey alpha annotation` — new constant only
  3. `feat(controller): propagate ExclusiveTopologyLabelKey to child Jobs` — mirrors existing `ExclusiveKey`/`NodeSelectorStrategyKey` propagation in `labelAndAnnotateObject`
  4. `feat(webhook): publish exclusive-topology value as a follower pod label` — pod mutating webhook + tests
  5. `feat(webhook): validate ExclusiveTopologyLabelKey annotation combinations` — JobSet `ValidateCreate`/`ValidateUpdate` + unit + integration tests
- **Tests.** Unit + integration. `make test` and `make test-integration` both pass locally. The pod webhook test runner compares error strings rather than `cmp.Diff`-ing typed errors so it can coexist with the new conflict-rejection assertion (`cmp.Diff` panics on `fmt.Errorf`'s unexported `errorString`); this matches the pattern the package's `ValidateCreate` runner already uses.

#### Does this PR introduce a user-facing change?

```release-note
Introduces the `alpha.jobset.sigs.k8s.io/exclusive-topology-label-key` annotation. When set alongside `alpha.jobset.sigs.k8s.io/exclusive-topology` (at the JobSet level or on a ReplicatedJob template), the JobSet pod mutating webhook publishes the resolved exclusive-topology value onto each follower pod as a label under the user-supplied key. Containers can then consume the value via the standard Downward API, eliminating the need for an init container that reads the node's label via the Kubernetes API. Leader pods are not labeled in alpha. The annotation is rejected at admission when paired with `alpha.jobset.sigs.k8s.io/node-selector`.
```
