### PR TITLE
site: Add Workload Aware Scheduling documentation

### DIFF
--- a/site/content/en/docs/workload-aware-scheduling/_index.md
+++ b/site/content/en/docs/workload-aware-scheduling/_index.md
@@ -1,0 +1,45 @@
+---
+title: "Workload Aware Scheduling"
+linkTitle: "Workload Aware Scheduling"
+weight: 7
+date: 2026-05-31
+description: >
+    Integrating JobSet with Kubernetes Workload Aware Scheduling APIs
+no_list: true
+---
+
+JobSet can integrate with the Kubernetes Workload Aware Scheduling (WAS) APIs (`scheduling.k8s.io/v1alpha2`) to enable gang scheduling and coordinated pod placement. This guide shows how to create the WAS resources alongside your JobSet.
+
+## Prerequisites
+
+The Workload Aware Scheduling APIs require a Kubernetes 1.36+ cluster with the following alpha feature gates enabled:
+
+- `GenericWorkload`
+- `GangScheduling`
+- `TopologyAwareWorkloadScheduling`
+- `WorkloadAwarePreemption`
+
+The API server must also have alpha APIs enabled via `--runtime-config=api/alpha=true`.
+
+You can use [Kind](https://kind.sigs.k8s.io/) to create a local cluster with these feature gates enabled:
+
+{{< include file="/examples/workload-aware-scheduling/kind.yaml" lang="yaml" >}}
+
+```bash
+kind create cluster --image=kindest/node:latest --config kind.yaml
+```
+
+## Overview
+
+The Kubernetes WAS APIs introduce two resources that work with JobSet:
+
+- **Workload**: Represents a higher-level scheduling unit that references the JobSet and defines pod group templates with scheduling policies.
+- **PodGroup**: Groups pods that should be scheduled together according to a shared scheduling policy (e.g., gang scheduling).
+
+Pods in the JobSet are associated with a PodGroup through the `schedulingGroup.podGroupName` field in the pod spec.
+
+## Topics
+
+- [Gang Scheduling](./gang_scheduling): Configure gang scheduling so that all pods in a JobSet must be schedulable before any are admitted.
+- [Preemption](./preemption): Enable workload-aware preemption to preempt entire pod groups rather than individual pods.
+- [Topology Aware Scheduling](./tas): Co-locate all pods in a gang within the same network topology domain for low-latency communication.

--- a/site/content/en/docs/workload-aware-scheduling/gang_scheduling.md
+++ b/site/content/en/docs/workload-aware-scheduling/gang_scheduling.md
@@ -1,0 +1,33 @@
+---
+title: "Gang Scheduling"
+linkTitle: "Gang Scheduling"
+weight: 1
+date: 2026-05-31
+description: >
+    Configure gang scheduling with JobSet using the Kubernetes WAS APIs
+no_list: true
+---
+
+This example configures gang scheduling so that all 6 pods (3 replicas × 2 completions) in a JobSet must be schedulable before any of them are admitted.
+
+## Step 1: Create the Workload
+
+The [Workload](https://github.com/kubernetes-sigs/jobset/blob/main/site/static/examples/workload-aware-scheduling/workload.yaml) references the JobSet and defines a pod group template with a gang scheduling policy:
+
+{{< include file="/examples/workload-aware-scheduling/workload.yaml" lang="yaml" >}}
+
+The `controllerRef` links the Workload to the JobSet. The `podGroupTemplates` entry defines a gang scheduling policy requiring a minimum of 6 pods to be schedulable.
+
+## Step 2: Create the PodGroup
+
+The [PodGroup](https://github.com/kubernetes-sigs/jobset/blob/main/site/static/examples/workload-aware-scheduling/podgroup.yaml) references the pod group template defined in the Workload:
+
+{{< include file="/examples/workload-aware-scheduling/podgroup.yaml" lang="yaml" >}}
+
+## Step 3: Create the JobSet
+
+The [JobSet](https://github.com/kubernetes-sigs/jobset/blob/main/site/static/examples/workload-aware-scheduling/jobset.yaml) pods reference the PodGroup through `schedulingGroup.podGroupName`:
+
+{{< include file="/examples/workload-aware-scheduling/jobset.yaml" lang="yaml" >}}
+
+With gang scheduling and `minCount: 6`, the scheduler ensures all 6 pods can be placed before scheduling any of them. If the cluster cannot accommodate all pods simultaneously, none will be scheduled — preventing partial scheduling where some pods run while others remain pending.

--- a/site/content/en/docs/workload-aware-scheduling/preemption.md
+++ b/site/content/en/docs/workload-aware-scheduling/preemption.md
@@ -1,0 +1,70 @@
+---
+title: "Preemption"
+linkTitle: "Preemption"
+weight: 2
+date: 2026-05-31
+description: >
+    Workload-aware preemption for gang-scheduled JobSets
+no_list: true
+---
+
+When the `WorkloadAwarePreemption` feature gate is enabled, the scheduler can preempt entire pod groups to make room for higher-priority gang-scheduled workloads.
+
+## The Problem
+
+Without workload-aware preemption, the scheduler preempts individual pods. This can cause problems for gang-scheduled workloads — preempting some pods from a running gang breaks the entire workload, and freeing only a subset of the required resources may not be enough to admit the pending gang.
+
+## How It Works
+
+With workload-aware preemption, the scheduler understands that pods belong to a group and makes preemption decisions at the group level. This means:
+
+- **All-or-nothing preemption**: The scheduler will only preempt a pod group if doing so frees enough resources to admit the pending gang in full.
+- **No partial disruption**: Rather than evicting individual pods and breaking a running workload, the scheduler preempts the entire lower-priority pod group.
+
+Two key fields on the PodGroup enable this:
+
+- **`priorityClassName`**: Associates the PodGroup with a Kubernetes `PriorityClass`, giving the scheduler a priority value to compare when deciding what to preempt.
+- **`disruptionMode: PodGroup`**: Ensures the entire gang is preempted together rather than individual pods.
+
+## Example: Gang Preemption
+
+This example demonstrates PodGroup-level gang preemption using two JobSets — a low-priority JobSet that occupies the cluster, and a high-priority JobSet that preempts it.
+
+Each JobSet creates 4 pods (2 replicas × 2 completions). The resource requests are sized so that only one JobSet can fit on the cluster at a time.
+
+### Step 1: Create the PriorityClasses
+
+Create a [low-priority](https://github.com/kubernetes-sigs/jobset/blob/main/site/static/examples/workload-aware-scheduling/preemption/low-priority.yaml) and [high-priority](https://github.com/kubernetes-sigs/jobset/blob/main/site/static/examples/workload-aware-scheduling/preemption/high-priority.yaml) PriorityClass:
+
+{{< include file="/examples/workload-aware-scheduling/preemption/low-priority.yaml" lang="yaml" >}}
+
+{{< include file="/examples/workload-aware-scheduling/preemption/high-priority.yaml" lang="yaml" >}}
+
+### Step 2: Apply the low-priority JobSet
+
+The [low-priority JobSet](https://github.com/kubernetes-sigs/jobset/blob/main/site/static/examples/workload-aware-scheduling/preemption/low-priority-jobset.yaml) includes its Workload and PodGroup. The PodGroup sets `priorityClassName: low-priority` and `disruptionMode: PodGroup`:
+
+{{< include file="/examples/workload-aware-scheduling/preemption/low-priority-jobset.yaml" lang="yaml" >}}
+
+Wait for all 4 pods to be running:
+
+```bash
+kubectl get pods -l jobset.sigs.k8s.io/jobset-name=lp-js
+```
+
+### Step 3: Apply the high-priority JobSet
+
+The [high-priority JobSet](https://github.com/kubernetes-sigs/jobset/blob/main/site/static/examples/workload-aware-scheduling/preemption/high-priority-jobset.yaml) uses the same structure but with `priorityClassName: high-priority`:
+
+{{< include file="/examples/workload-aware-scheduling/preemption/high-priority-jobset.yaml" lang="yaml" >}}
+
+### Step 4: Observe preemption
+
+The scheduler preempts the entire low-priority PodGroup as a gang to make room for the high-priority JobSet:
+
+```bash
+kubectl get pods -l 'jobset.sigs.k8s.io/jobset-name in (lp-js,hp-js)'
+kubectl get events --field-selector reason=Preempted
+```
+
+All 4 low-priority pods are preempted together because of `disruptionMode: PodGroup`, and all 4 high-priority pods schedule and run.

--- a/site/content/en/docs/workload-aware-scheduling/tas.md
+++ b/site/content/en/docs/workload-aware-scheduling/tas.md
@@ -1,0 +1,71 @@
+---
+title: "Topology Aware Scheduling"
+linkTitle: "Topology Aware Scheduling"
+weight: 3
+date: 2026-05-31
+description: >
+    Configure topology aware scheduling with JobSet using the Kubernetes WAS APIs
+no_list: true
+---
+
+Topology Aware Scheduling (TAS) ensures that all pods in a gang are placed within the same network topology domain (e.g., the same rack, block, or data center zone). This is critical for distributed training workloads where inter-pod communication latency directly impacts performance.
+
+## Prerequisites
+
+In addition to the [general WAS prerequisites](../), you must:
+
+1. **Enable the `TopologyAwareWorkloadScheduling` feature gate.** This feature gate is included in the [kind cluster configuration](../) and is required for topology-aware placement.
+
+2. **Label your nodes with topology keys.** The scheduler uses node labels to determine topology domains. Apply labels that represent your topology hierarchy — for example, rack, block, or zone:
+
+    ```bash
+    kubectl label node <node-name> topology.example.com/rack=rack-1
+    ```
+
+    Every node that should participate in topology-aware placement must have the topology label defined in the PodGroup's `schedulingConstraints.topology` field.
+
+## How It Works
+
+The PodGroup's `schedulingConstraints.topology` field tells the scheduler which topology domain to consider when placing pods. The scheduler finds a single topology domain that can accommodate the entire gang and co-locates all pods within it.
+
+For example, setting `topology.example.com/rack` as the topology key ensures all pods in the gang land on nodes within the same rack, minimizing network hops between them.
+
+## Step 1: Create the Workload
+
+The [Workload](https://github.com/kubernetes-sigs/jobset/blob/main/site/static/examples/workload-aware-scheduling/tas/workload.yaml) references the JobSet and defines a pod group template with a gang scheduling policy:
+
+{{< include file="/examples/workload-aware-scheduling/tas/workload.yaml" lang="yaml" >}}
+
+The `controllerRef` links the Workload to the JobSet. The `podGroupTemplates` entry defines a gang scheduling policy requiring all 4 pods to be schedulable.
+
+## Step 2: Create the PodGroup
+
+The [PodGroup](https://github.com/kubernetes-sigs/jobset/blob/main/site/static/examples/workload-aware-scheduling/tas/podgroup.yaml) references the pod group template and adds topology constraints:
+
+{{< include file="/examples/workload-aware-scheduling/tas/podgroup.yaml" lang="yaml" >}}
+
+The key addition compared to basic gang scheduling is `schedulingConstraints.topology`:
+
+- **`key: topology.example.com/rack`**: The scheduler will find a single rack (i.e., a set of nodes sharing the same `topology.example.com/rack` label value) that can fit all 4 pods and schedule them there.
+
+## Step 3: Create the JobSet
+
+The [JobSet](https://github.com/kubernetes-sigs/jobset/blob/main/site/static/examples/workload-aware-scheduling/tas/jobset.yaml) pods reference the PodGroup through `schedulingGroup.podGroupName`:
+
+{{< include file="/examples/workload-aware-scheduling/tas/jobset.yaml" lang="yaml" >}}
+
+This JobSet creates 4 pods total (2 replicas × 2 completions). All 4 pods will be gang-scheduled onto nodes within the same `topology.example.com/rack` domain.
+
+## Verify Topology Placement
+
+After applying all three resources, verify that the pods were co-located within the same topology domain:
+
+```bash
+kubectl get pods -l jobset.sigs.k8s.io/jobset-name=js -o wide
+```
+
+Check that all pods landed on nodes sharing the same topology label value:
+
+```bash
+kubectl get nodes -L topology.example.com/rack
+```

--- a/site/static/examples/workload-aware-scheduling/jobset.yaml
+++ b/site/static/examples/workload-aware-scheduling/jobset.yaml
@@ -1,0 +1,27 @@
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: js
+spec:
+  replicatedJobs:
+  - name: rj
+    replicas: 3
+    template:
+      spec:
+        completions: 2
+        parallelism: 2
+        backoffLimit: 0
+        template:
+          spec:
+            terminationGracePeriodSeconds: 0
+            schedulingGroup:
+              podGroupName: js-abc-workers-def
+            containers:
+            - name: worker
+              image: busybox
+              command: ["/bin/sh", "-c", "sleep infinity"]
+              # Pick resource requests appropriate for your cluster and workload.
+              # These values are just an example.
+              resources:
+                requests:
+                  cpu: "4"

--- a/site/static/examples/workload-aware-scheduling/kind.yaml
+++ b/site/static/examples/workload-aware-scheduling/kind.yaml
@@ -1,0 +1,19 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+featureGates:
+  GenericWorkload: true
+  GangScheduling: true
+  TopologyAwareWorkloadScheduling: true
+  WorkloadAwarePreemption: true
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      extraArgs:
+        runtime-config: "api/alpha=true"
+- role: worker
+- role: worker
+- role: worker
+- role: worker

--- a/site/static/examples/workload-aware-scheduling/podgroup.yaml
+++ b/site/static/examples/workload-aware-scheduling/podgroup.yaml
@@ -1,0 +1,13 @@
+apiVersion: scheduling.k8s.io/v1alpha2
+kind: PodGroup
+metadata:
+  name: js-abc-workers-def
+  namespace: default
+spec:
+  podGroupTemplateRef:
+    workload:
+      workloadName: js-abc
+      podGroupTemplateName: workers
+  schedulingPolicy:
+    gang:
+      minCount: 6

--- a/site/static/examples/workload-aware-scheduling/preemption/high-priority-jobset.yaml
+++ b/site/static/examples/workload-aware-scheduling/preemption/high-priority-jobset.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: scheduling.k8s.io/v1alpha2
+kind: Workload
+metadata:
+  name: hp-abc
+spec:
+  controllerRef:
+    apiGroup: jobset.x-k8s.io
+    kind: JobSet
+    name: hp-js
+  podGroupTemplates:
+  - name: workers
+    schedulingPolicy:
+      gang:
+        minCount: 4
+---
+apiVersion: scheduling.k8s.io/v1alpha2
+kind: PodGroup
+metadata:
+  name: hp-abc-workers-def
+  namespace: default
+spec:
+  podGroupTemplateRef:
+    workload:
+      workloadName: hp-abc
+      podGroupTemplateName: workers
+  priorityClassName: high-priority
+  disruptionMode: PodGroup
+  schedulingPolicy:
+    gang:
+      minCount: 4
+---
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: hp-js
+spec:
+  replicatedJobs:
+  - name: rj
+    replicas: 2
+    template:
+      spec:
+        completions: 2
+        parallelism: 2
+        backoffLimit: 10
+        template:
+          spec:
+            terminationGracePeriodSeconds: 0
+            priorityClassName: high-priority
+            schedulingGroup:
+              podGroupName: hp-abc-workers-def
+            containers:
+            - name: worker
+              image: busybox
+              command: ["sleep", "infinity"]
+              # Pick resource requests appropriate for your cluster and workload.
+              # These values are just an example.
+              resources:
+                requests:
+                  cpu: "3"

--- a/site/static/examples/workload-aware-scheduling/preemption/high-priority.yaml
+++ b/site/static/examples/workload-aware-scheduling/preemption/high-priority.yaml
@@ -1,0 +1,7 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: high-priority
+value: 100000
+globalDefault: false
+description: "High priority class with value 100000"

--- a/site/static/examples/workload-aware-scheduling/preemption/low-priority-jobset.yaml
+++ b/site/static/examples/workload-aware-scheduling/preemption/low-priority-jobset.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: scheduling.k8s.io/v1alpha2
+kind: Workload
+metadata:
+  name: lp-abc
+spec:
+  controllerRef:
+    apiGroup: jobset.x-k8s.io
+    kind: JobSet
+    name: lp-js
+  podGroupTemplates:
+  - name: workers
+    schedulingPolicy:
+      gang:
+        minCount: 4
+---
+apiVersion: scheduling.k8s.io/v1alpha2
+kind: PodGroup
+metadata:
+  name: lp-abc-workers-def
+  namespace: default
+spec:
+  podGroupTemplateRef:
+    workload:
+      workloadName: lp-abc
+      podGroupTemplateName: workers
+  priorityClassName: low-priority
+  disruptionMode: PodGroup
+  schedulingPolicy:
+    gang:
+      minCount: 4
+---
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: lp-js
+spec:
+  replicatedJobs:
+  - name: rj
+    replicas: 2
+    template:
+      spec:
+        completions: 2
+        parallelism: 2
+        backoffLimit: 10
+        template:
+          spec:
+            terminationGracePeriodSeconds: 0
+            priorityClassName: low-priority
+            schedulingGroup:
+              podGroupName: lp-abc-workers-def
+            containers:
+            - name: worker
+              image: busybox
+              command: ["sleep", "infinity"]
+              # Pick resource requests appropriate for your cluster and workload.
+              # These values are just an example.
+              resources:
+                requests:
+                  cpu: "3"

--- a/site/static/examples/workload-aware-scheduling/preemption/low-priority.yaml
+++ b/site/static/examples/workload-aware-scheduling/preemption/low-priority.yaml
@@ -1,0 +1,7 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: low-priority
+value: 1
+globalDefault: false
+description: "Low priority class with value 1"

--- a/site/static/examples/workload-aware-scheduling/tas/jobset.yaml
+++ b/site/static/examples/workload-aware-scheduling/tas/jobset.yaml
@@ -1,0 +1,27 @@
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: js
+spec:
+  failurePolicy:
+    maxRestarts: 10
+  replicatedJobs:
+  - name: rj
+    replicas: 2
+    template:
+      spec:
+        completions: 2
+        parallelism: 2
+        backoffLimit: 0
+        template:
+          spec:
+            terminationGracePeriodSeconds: 0
+            schedulingGroup:
+              podGroupName: js-abc-workers-def
+            containers:
+            - name: worker
+              image: busybox
+              command: ["sleep", "infinity"]
+              resources:
+                requests:
+                  cpu: "500m"

--- a/site/static/examples/workload-aware-scheduling/tas/podgroup.yaml
+++ b/site/static/examples/workload-aware-scheduling/tas/podgroup.yaml
@@ -1,0 +1,16 @@
+apiVersion: scheduling.k8s.io/v1alpha2
+kind: PodGroup
+metadata:
+  name: js-abc-workers-def
+  namespace: default
+spec:
+  podGroupTemplateRef:
+    workload:
+      workloadName: js-abc
+      podGroupTemplateName: workers
+  schedulingPolicy:
+    gang:
+      minCount: 4
+  schedulingConstraints:
+    topology:
+    - key: topology.example.com/rack

--- a/site/static/examples/workload-aware-scheduling/tas/workload.yaml
+++ b/site/static/examples/workload-aware-scheduling/tas/workload.yaml
@@ -1,0 +1,14 @@
+apiVersion: scheduling.k8s.io/v1alpha2
+kind: Workload
+metadata:
+  name: js-abc
+spec:
+  controllerRef:
+    apiGroup: jobset.x-k8s.io
+    kind: JobSet
+    name: js
+  podGroupTemplates:
+  - name: workers
+    schedulingPolicy:
+      gang:
+        minCount: 4

--- a/site/static/examples/workload-aware-scheduling/workload.yaml
+++ b/site/static/examples/workload-aware-scheduling/workload.yaml
@@ -1,0 +1,14 @@
+apiVersion: scheduling.k8s.io/v1alpha2
+kind: Workload
+metadata:
+  name: js-abc
+spec:
+  controllerRef:
+    apiGroup: jobset.x-k8s.io
+    kind: JobSet
+    name: js
+  podGroupTemplates:
+  - name: workers
+    schedulingPolicy:
+      gang:
+        minCount: 6


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Adds a new top-level documentation section for integrating JobSet with the
Kubernetes Workload Aware Scheduling (WAS) APIs (scheduling.k8s.io/v1alpha2).

The section includes:
- **Overview**: Prerequisites (Kubernetes 1.36+, alpha feature gates) and Kind cluster setup
- **Gang Scheduling**: Step-by-step guide to create Workload, PodGroup, and JobSet resources for gang scheduling
- **Preemption**: Demonstrates PodGroup-level gang preemption using PriorityClasses and disruptionMode

All YAML examples are stored under `site/static/examples/workload-aware-scheduling/` and rendered inline using the `include` shortcode.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

I borrowed a lot of this from @GiuseppeTT's doc. https://docs.google.com/document/d/1Akaee7pP3eflf728ZiOwBy1w8Mtn1dkIoHqXX5PWNiw/edit?usp=sharing

#### Does this PR introduce a user-facing change?

```release-note
Add documentation for integrating JobSet with Kubernetes Workload Aware Scheduling APIs, including gang scheduling and preemption examples.
```

---
> **AI Assistance Disclosure**: This pull request was created with the assistance of AI (Claude Code by Anthropic).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Workload Aware Scheduling section with a landing page plus guides for gang scheduling, workload-aware preemption, and topology-aware scheduling, including prerequisites and verification steps
* **Examples**
  * Added multiple Kubernetes example manifests and a local cluster config demonstrating Workload/PodGroup/JobSet setups, PriorityClass usage, gang scheduling, preemption flows, and topology-constrained placement
<!-- end of auto-generated comment: release notes by coderabbit.ai -->