### PR TITLE
Failing test 1 36

### DIFF
--- a/main.go
+++ b/main.go
@@ -186,6 +186,15 @@ func main() {
 		KeyName:        options.Metrics.KeyName,
 	}
 	options.Metrics = metricsServerOptions
+
+	ctx := ctrl.SetupSignalHandler()
+	if cfg.InternalCertManagement != nil && *cfg.InternalCertManagement.Enable {
+		if err = cert.BootstrapCerts(ctx, kubeConfig, cfg); err != nil {
+			setupLog.Error(err, "Unable to bootstrap cert rotation")
+			os.Exit(1)
+		}
+	}
+
 	mgr, err := ctrl.NewManager(kubeConfig, options)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
@@ -201,8 +210,6 @@ func main() {
 	} else {
 		close(certsReady)
 	}
-
-	ctx := ctrl.SetupSignalHandler()
 	if err := controllers.SetupJobSetIndexes(ctx, mgr.GetFieldIndexer()); err != nil {
 		setupLog.Error(err, "unable to setup jobset reconciler indexes")
 		os.Exit(1)
@@ -212,11 +219,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Cert won't be ready until manager starts, so start a goroutine here which
-	// will block until the cert is ready before setting up the controllers.
-	// Controllers who register after manager starts will start directly.
-	go setupControllers(mgr, certsReady)
-
+	setupControllers(mgr)
 	setupHealthzAndReadyzCheck(mgr, certsReady)
 
 	setupLog.Info("starting manager")
@@ -226,13 +229,7 @@ func main() {
 	}
 }
 
-func setupControllers(mgr ctrl.Manager, certsReady chan struct{}) {
-	// The controllers won't work until the webhooks are operating,
-	// and the webhook won't work until the certs are all in places.
-	setupLog.Info("waiting for the cert generation to complete")
-	<-certsReady
-	setupLog.Info("certs ready")
-
+func setupControllers(mgr ctrl.Manager) {
 	// Set up JobSet controller.
 	jobSetController := controllers.NewJobSetReconciler(mgr.GetClient(), mgr.GetScheme(), mgr.GetEventRecorder("jobset"))
 	if err := jobSetController.SetupWithManager(mgr); err != nil {

--- a/pkg/util/cert/cert.go
+++ b/pkg/util/cert/cert.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	config "sigs.k8s.io/jobset/api/config/v1alpha1"
@@ -88,13 +87,10 @@ func BootstrapCerts(ctx context.Context, kubeConfig *rest.Config, cfg config.Con
 	namespace := getOperatorNamespace()
 	bootstrapMgr, err := ctrl.NewManager(kubeConfig, ctrl.Options{
 		Metrics:                metricsserver.Options{BindAddress: "0"},
-		HealthProbeBindAddress: cfg.Health.HealthProbeBindAddress,
+		HealthProbeBindAddress: "0",
 	})
 	if err != nil {
 		return fmt.Errorf("create bootstrap manager: %w", err)
-	}
-	if err := bootstrapMgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		return fmt.Errorf("add bootstrap health check: %w", err)
 	}
 
 	certsReady := make(chan struct{})

--- a/pkg/util/cert/cert.go
+++ b/pkg/util/cert/cert.go
@@ -14,13 +14,17 @@ limitations under the License.
 package cert
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
 
 	cert "github.com/open-policy-agent/cert-controller/pkg/rotator"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	config "sigs.k8s.io/jobset/api/config/v1alpha1"
 )
@@ -46,23 +50,25 @@ func getOperatorNamespace() string {
 //+kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=mutatingwebhookconfigurations,verbs=get;list;watch;update
 //+kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=validatingwebhookconfigurations,verbs=get;list;watch;update
 
-// CertsManager creates certs for webhooks.
-func CertsManager(mgr ctrl.Manager, cfg config.Configuration, setupFinish chan struct{}) error {
-	// Webhook and controller must be deployed in the same namespace.
-	namespace := getOperatorNamespace()
+func webhookCertDir(cfg config.Configuration) string {
+	if cfg.Webhook.CertDir != "" {
+		return cfg.Webhook.CertDir
+	}
+	return certDir
+}
 
-	// DNSName is <service name>.<namespace>.svc
-	var dnsName = fmt.Sprintf("%s.%s.svc", *cfg.InternalCertManagement.WebhookServiceName, namespace)
-	return cert.AddRotator(mgr, &cert.CertRotator{
+func buildCertRotatorConfig(cfg config.Configuration, namespace, controllerName string, setupFinish chan struct{}) *cert.CertRotator {
+	return &cert.CertRotator{
 		SecretKey: types.NamespacedName{
 			Namespace: namespace,
 			Name:      *cfg.InternalCertManagement.WebhookSecretName,
 		},
-		CertDir:        certDir,
+		CertDir:        webhookCertDir(cfg),
 		CAName:         caName,
 		CAOrganization: caOrg,
-		DNSName:        dnsName,
+		DNSName:        fmt.Sprintf("%s.%s.svc", *cfg.InternalCertManagement.WebhookServiceName, namespace),
 		IsReady:        setupFinish,
+		ControllerName: controllerName,
 		Webhooks: []cert.WebhookInfo{
 			{
 				Type: cert.Validating,
@@ -73,5 +79,71 @@ func CertsManager(mgr ctrl.Manager, cfg config.Configuration, setupFinish chan s
 				Name: mutatingWebhookConfName,
 			},
 		},
+	}
+}
+
+// BootstrapCerts creates a minimal manager to generate webhook certificates and
+// waits for them to be mounted before the main manager starts.
+func BootstrapCerts(ctx context.Context, kubeConfig *rest.Config, cfg config.Configuration) error {
+	namespace := getOperatorNamespace()
+	bootstrapMgr, err := ctrl.NewManager(kubeConfig, ctrl.Options{
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+		HealthProbeBindAddress: cfg.Health.HealthProbeBindAddress,
 	})
+	if err != nil {
+		return fmt.Errorf("create bootstrap manager: %w", err)
+	}
+	if err := bootstrapMgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		return fmt.Errorf("add bootstrap health check: %w", err)
+	}
+
+	certsReady := make(chan struct{})
+	if err := cert.AddRotator(bootstrapMgr, buildCertRotatorConfig(cfg, namespace, "cert-rotator-bootstrap", certsReady)); err != nil {
+		return fmt.Errorf("add bootstrap cert rotator: %w", err)
+	}
+
+	bootstrapCtx, bootstrapCancel := context.WithCancel(ctx)
+	defer bootstrapCancel()
+
+	startErr := make(chan error, 1)
+	managerStopped := make(chan struct{})
+	go func() {
+		defer close(managerStopped)
+		if err := bootstrapMgr.Start(bootstrapCtx); err != nil {
+			startErr <- err
+		}
+	}()
+
+	select {
+	case <-certsReady:
+	case err := <-startErr:
+		return fmt.Errorf("start bootstrap manager: %w", err)
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	bootstrapCancel()
+	select {
+	case err := <-startErr:
+		if err != nil {
+			return fmt.Errorf("stop bootstrap manager: %w", err)
+		}
+	case <-managerStopped:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	return nil
+}
+
+// CertsManager adds certificate rotation to the main manager after the initial
+// certificate bootstrap is complete.
+func CertsManager(mgr ctrl.Manager, cfg config.Configuration, setupFinish chan struct{}) error {
+	namespace := getOperatorNamespace()
+	rotatorReady := make(chan struct{})
+	if err := cert.AddRotator(mgr, buildCertRotatorConfig(cfg, namespace, "cert-rotator", rotatorReady)); err != nil {
+		return err
+	}
+	close(setupFinish)
+	return nil
 }

--- a/pkg/util/cert/cert_test.go
+++ b/pkg/util/cert/cert_test.go
@@ -1,0 +1,92 @@
+package cert
+
+import (
+	"testing"
+
+	certrotator "github.com/open-policy-agent/cert-controller/pkg/rotator"
+	"k8s.io/utils/ptr"
+
+	configapi "sigs.k8s.io/jobset/api/config/v1alpha1"
+)
+
+func TestWebhookCertDir(t *testing.T) {
+	tests := map[string]struct {
+		cfg  configapi.Configuration
+		want string
+	}{
+		"default cert dir": {
+			cfg:  configapi.Configuration{},
+			want: certDir,
+		},
+		"custom cert dir": {
+			cfg: configapi.Configuration{
+				ControllerManager: configapi.ControllerManager{
+					Webhook: configapi.ControllerWebhook{CertDir: "/custom/certs"},
+				},
+			},
+			want: "/custom/certs",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := webhookCertDir(tc.cfg); got != tc.want {
+				t.Fatalf("webhookCertDir()=%q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildCertRotatorConfig(t *testing.T) {
+	readyCh := make(chan struct{})
+	cfg := configapi.Configuration{
+		ControllerManager: configapi.ControllerManager{
+			Webhook: configapi.ControllerWebhook{CertDir: "/custom/certs"},
+		},
+		InternalCertManagement: &configapi.InternalCertManagement{
+			Enable:             ptr.To(true),
+			WebhookServiceName: ptr.To("jobset-webhook-service"),
+			WebhookSecretName:  ptr.To("jobset-webhook-server-cert"),
+		},
+	}
+
+	got := buildCertRotatorConfig(cfg, "jobset-system", "cert-rotator-bootstrap", readyCh)
+
+	if got.SecretKey.Namespace != "jobset-system" {
+		t.Fatalf("SecretKey.Namespace=%q, want %q", got.SecretKey.Namespace, "jobset-system")
+	}
+	if got.SecretKey.Name != "jobset-webhook-server-cert" {
+		t.Fatalf("SecretKey.Name=%q, want %q", got.SecretKey.Name, "jobset-webhook-server-cert")
+	}
+	if got.CertDir != "/custom/certs" {
+		t.Fatalf("CertDir=%q, want %q", got.CertDir, "/custom/certs")
+	}
+	if got.CAName != caName {
+		t.Fatalf("CAName=%q, want %q", got.CAName, caName)
+	}
+	if got.CAOrganization != caOrg {
+		t.Fatalf("CAOrganization=%q, want %q", got.CAOrganization, caOrg)
+	}
+	if got.DNSName != "jobset-webhook-service.jobset-system.svc" {
+		t.Fatalf("DNSName=%q, want %q", got.DNSName, "jobset-webhook-service.jobset-system.svc")
+	}
+	if got.IsReady != readyCh {
+		t.Fatalf("IsReady channel was not preserved")
+	}
+	if got.ControllerName != "cert-rotator-bootstrap" {
+		t.Fatalf("ControllerName=%q, want %q", got.ControllerName, "cert-rotator-bootstrap")
+	}
+
+	wantWebhooks := []certrotator.WebhookInfo{
+		{Type: certrotator.Validating, Name: validateWebhookConfName},
+		{Type: certrotator.Mutating, Name: mutatingWebhookConfName},
+	}
+	if len(got.Webhooks) != len(wantWebhooks) {
+		t.Fatalf("len(Webhooks)=%d, want %d", len(got.Webhooks), len(wantWebhooks))
+	}
+	for i := range wantWebhooks {
+		if got.Webhooks[i] != wantWebhooks[i] {
+			t.Fatalf("Webhooks[%d]=%+v, want %+v", i, got.Webhooks[i], wantWebhooks[i])
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix bug when using self signed certs where we hit a race where the deployment won't start due to certificate rotation failing.

This seems to got a lot worse on 1.36.

I mainly copied existing behavior that Kueue has which doesn't seem to suffer from this issue.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1242 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix bootstrapping self signed certificates failure
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved startup sequencing: certificates are bootstrapped synchronously during startup and controller setup no longer waits on an internal readiness gate, resulting in more predictable controller initialization while health/readiness checks remain intact.
  
* **Tests**
  * Added unit tests covering certificate configuration and helper behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->