### PR TITLE
helm: stop declaring webhook cert Secret data fields

### DIFF
--- a/CHANGELOG/CHANGELOG-0.13.md
+++ b/CHANGELOG/CHANGELOG-0.13.md
@@ -1,0 +1,7 @@
+## v0.13.0
+
+Changes since `v0.12.0`.
+
+  Bug Fixes
+
+  - Stop declaring webhook server cert Secret `data` fields in the Helm chart so that Helm v4 upgrades no longer conflict with the JobSet controller over field ownership of the certificate data (#1205)

--- a/charts/jobset/templates/internalcert/secret.yaml
+++ b/charts/jobset/templates/internalcert/secret.yaml
@@ -24,9 +24,4 @@ metadata:
   {{- include "jobset.webhook.labels" . | nindent 4 }}
   name: '{{ include "jobset.fullname" . }}-webhook-server-cert'
   namespace: '{{ .Release.Namespace }}'
-data:
-  ca.crt: ""
-  ca.key: ""
-  tls.crt: ""
-  tls.key: ""
 {{- end }}

--- a/charts/jobset/tests/internalcert/secret_test.yaml
+++ b/charts/jobset/tests/internalcert/secret_test.yaml
@@ -1,0 +1,50 @@
+#
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: Test internalcert webhook server cert Secret
+
+templates:
+  - internalcert/secret.yaml
+
+release:
+  name: jobset
+  namespace: jobset-system
+
+tests:
+  - it: Should create the webhook server cert Secret by default
+    asserts:
+      - containsDocument:
+          apiVersion: v1
+          kind: Secret
+          name: jobset-webhook-server-cert
+
+  - it: Should not declare the certificate data fields so Helm does not own them
+    # The JobSet controller (cert-controller rotator) populates these fields at
+    # runtime. Declaring them in the chart makes Helm v4 server-side-apply own
+    # them, which then conflicts with the controller on subsequent upgrades
+    # (see issue #1205). The Secret is just an empty shell created by Helm; the
+    # controller fills it in via an Update.
+    asserts:
+      - notExists:
+          path: data
+
+  - it: Should not render the Secret when cert-manager is enabled
+    set:
+      certManager:
+        enable: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/hack/processing-plan.yaml
+++ b/hack/processing-plan.yaml
@@ -191,14 +191,6 @@ files:
           {{- include "jobset.webhook.labels" . | nindent 4 }}
         indentation: 2
       - type: INSERT_TEXT
-        position: END
-        value: |
-          data:
-            ca.crt: ""
-            ca.key: ""
-            tls.crt: ""
-            tls.key: ""
-      - type: INSERT_TEXT
         position: START
         value: |
           {{- if not .Values.certManager.enable }}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Under Helm v4 (server-side apply by default), the internalcert webhook-server-cert Secret template declared four empty `data` keys (`ca.crt`, `ca.key`, `tls.crt`, `tls.key`). Helm becomes the field manager of those keys at install time, but the JobSet controller (cert-controller rotator) then overwrites them via `client.Update`, claiming the fields under its own manager name. The shared ownership makes subsequent `helm upgrade` fail:

```
UPRADE FAILED: ... 4 conflicts with "jobset":
- .data.ca.crt / .ca.key / .tls.crt / .tls.key
```

These fields are fully owned by the controller at runtime, so the chart must not declare them. This drops the `data` section from the template while keeping the Secret object itself: `cert-controller` only `Update`s (never `Create`s) the Secret, so Helm provisions an empty shell and the controller fills it in. This matches the existing kustomize manifest, which never declared these fields.

Changed in `hack/processing-plan.yaml` (the source) and regenerated via `make update-helm`. Added a `helm-unittest` covering both the default and `certManager.enable: true` cases.

#### Which issue(s) this PR fixes:

Fixes #1205

#### Special notes for your reviewer:

Assisted by an AI coding agent during exploration and implementation. The fix is scoped to the Helm chart generation pipeline only (no API/CRD/controller code changes).

Key point worth checking: `cert-controller` v0.16.0 (`pkg/rotator/rotator.go`) only `Update`s the Secret, so the Secret object must still be created by Helm (only the `data` fields are removed). The controller's `refreshCertIfNeeded` handles the `secret.Data == nil` case by generating certs and writing them back.

Verified locally with `CONTAINER_ENGINE=podman make verify` (helm-unittest 39/39 pass, helm-verify pass, generated template matches the processing-plan change with no extra diff).

#### Does this PR introduce a user-facing change?

```release-note
Fix: the Helm chart no longer declares the webhook server cert Secret `data` fields, so `helm upgrade` under Helm v4 (server-side apply) no longer conflicts with the JobSet controller over ownership of the certificate data.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – v0.13.0

* **Bug Fixes**
  * Resolved Helm v4 upgrade conflicts by removing placeholder certificate data fields from the webhook server certificate Secret when cert-manager is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->