### PR TITLE
add was e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ YAML_PROCESSOR_LOG_LEVEL ?= info
 
 .PHONY: update-helm
 update-helm: manifests ## Generate Helm templates from Kustomize manifests.
-	$(GO_CMD) run -modfile=$(PROJECT_DIR)/hack/tools/yaml-processor/go.mod \
+	GOFLAGS=-mod=mod $(GO_CMD) run -modfile=$(PROJECT_DIR)/hack/tools/yaml-processor/go.mod \
 	sigs.k8s.io/kueue/hack/tools/yaml-processor \
 	-zap-log-level=$(YAML_PROCESSOR_LOG_LEVEL) $(PROJECT_DIR)/hack/processing-plan.yaml
 
@@ -427,6 +427,26 @@ test-e2e-kind: manifests kustomize fmt vet envtest ginkgo kind-image-build
 .PHONY: test-e2e-kind-customconfigs
 test-e2e-kind-customconfigs: E2E_TEST_PATH = ./test/e2e/customconfigs/...
 test-e2e-kind-customconfigs: test-e2e-kind
+
+## WAS (Workload-Aware Scheduling) Kind cluster management
+# WAS targets use kindest/node:v1.36.x which includes the
+# scheduling.k8s.io/v1alpha2 API group.
+WAS_KIND_CLUSTER_NAME ?= was-test
+WAS_NODE_IMAGE ?= kindest/node:v1.36.1
+
+.PHONY: test-e2e-kind-scheduling
+test-e2e-kind-scheduling: manifests kustomize fmt vet envtest ginkgo kind-image-build ## Run scheduling-specific E2E tests on Kind with WAS feature gates enabled.
+	KIND=$(KIND) WAS_NODE_IMAGE=$(WAS_NODE_IMAGE) KIND_CLUSTER_NAME=$(WAS_KIND_CLUSTER_NAME) USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) ARTIFACTS=$(ARTIFACTS) IMAGE_TAG=$(IMAGE_TAG) ./hack/e2e-scheduling-test.sh
+
+.PHONY: kind-cluster-scheduling
+kind-cluster-scheduling: kustomize kind-image-build ## Create a Kind cluster with WAS feature gates and deploy JobSet.
+	KIND=$(KIND) KUSTOMIZE=$(KUSTOMIZE) KIND_CLUSTER_NAME=$(WAS_KIND_CLUSTER_NAME) WAS_NODE_IMAGE=$(WAS_NODE_IMAGE) IMAGE_TAG=$(IMAGE_TAG) ARTIFACTS=$(ARTIFACTS) \
+	bash -c 'source ./hack/e2e-scheduling-cluster.sh && ensure_scheduling_node_image && create_scheduling_cluster && label_scheduling_nodes && kind_load_image && deploy_scheduling_jobset && verify_scheduling_apis'
+
+.PHONY: kind-cluster-scheduling-delete
+kind-cluster-scheduling-delete: ## Delete the WAS Kind cluster and collect logs.
+	KIND=$(KIND) KIND_CLUSTER_NAME=$(WAS_KIND_CLUSTER_NAME) ARTIFACTS=$(ARTIFACTS) \
+	bash -c 'source ./hack/e2e-scheduling-cluster.sh && delete_scheduling_cluster'
 
 .PHONY: prometheus
 prometheus:

--- a/hack/e2e-scheduling-cluster.sh
+++ b/hack/e2e-scheduling-cluster.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Shared helper functions for creating, deploying to, and tearing down a Kind
+# cluster with Kubernetes WAS (Workload-Aware Scheduling) feature gates enabled.
+#
+# Sourced by:
+#   - hack/e2e-scheduling-test.sh   (CI: create → deploy → test → cleanup)
+#   - Makefile targets               (dev: create, delete, verify independently)
+#
+# Required environment variables (set defaults via Makefile or caller):
+#   KUSTOMIZE, KIND       — paths to tool binaries
+#   KIND_CLUSTER_NAME     — Kind cluster name (default: was-test)
+#   WAS_NODE_IMAGE        — Kind node image (default: kindest/node:v1.36.1)
+#   IMAGE_TAG             — JobSet controller image tag
+#   ARTIFACTS             — directory for logs and test artifacts
+#   E2E_TARGET_FOLDER     — kustomize config folder (default: default)
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Resolve tool paths to absolute to survive subshell cd operations.
+KUSTOMIZE="$(cd "$PWD" && realpath "${KUSTOMIZE:-$PWD/bin/kustomize}")"
+export KUSTOMIZE
+KIND="$(cd "$PWD" && realpath "${KIND:-$PWD/bin/kind}")"
+export KIND
+export KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-was-test}"
+export WAS_NODE_IMAGE="${WAS_NODE_IMAGE:-kindest/node:v1.36.1}"
+export E2E_TARGET_FOLDER="${E2E_TARGET_FOLDER:-default}"
+export NAMESPACE="${NAMESPACE:-jobset-system}"
+export ARTIFACTS="${ARTIFACTS:-$PWD/artifacts}"
+
+# ensure_scheduling_node_image pulls the WAS node image if it is not
+# already present locally.
+function ensure_scheduling_node_image {
+    if docker image inspect "$WAS_NODE_IMAGE" &>/dev/null; then
+        echo "==> Reusing existing node image: $WAS_NODE_IMAGE"
+        return 0
+    fi
+
+    echo "==> Pulling node image: $WAS_NODE_IMAGE"
+    docker pull "$WAS_NODE_IMAGE"
+}
+
+# create_scheduling_cluster creates a Kind cluster with WAS feature gates.
+# Fails if the cluster already exists (use delete_scheduling_cluster first).
+function create_scheduling_cluster {
+    if $KIND get clusters 2>/dev/null | grep -q "^${KIND_CLUSTER_NAME}$"; then
+        echo "Cluster '$KIND_CLUSTER_NAME' already exists."
+        echo "Delete it first: make kind-cluster-scheduling-delete KIND_CLUSTER_NAME=$KIND_CLUSTER_NAME"
+        return 1
+    fi
+
+    echo "==> Creating Kind cluster '$KIND_CLUSTER_NAME' with WAS feature gates..."
+    $KIND create cluster \
+        --name "$KIND_CLUSTER_NAME" \
+        --image "${WAS_NODE_IMAGE}" \
+        --config hack/kind-config-scheduling.yaml \
+        --wait 2m
+}
+
+# label_scheduling_nodes applies topology labels to worker nodes so that
+# topology-aware scheduling tests can verify co-location constraints.
+function label_scheduling_nodes {
+    echo "==> Labelling worker nodes with topology.kubernetes.io/rack..."
+    local workers=()
+    while IFS= read -r node; do
+        workers+=("$node")
+    done < <(kubectl get nodes --no-headers -l '!node-role.kubernetes.io/control-plane' -o custom-columns=NAME:.metadata.name)
+    local half=$(( ${#workers[@]} / 2 ))
+    for i in "${!workers[@]}"; do
+        if [ "$i" -lt "$half" ]; then
+            kubectl label node "${workers[$i]}" topology.kubernetes.io/rack=rack1 --overwrite
+        else
+            kubectl label node "${workers[$i]}" topology.kubernetes.io/rack=rack2 --overwrite
+        fi
+    done
+}
+
+# kind_load_image loads the JobSet controller image into the Kind cluster.
+# Retries a few times to handle transient containerd startup delays.
+function kind_load_image {
+    echo "==> Loading JobSet image into Kind..."
+    local max_retries=5
+    local retry_delay=5
+    for i in $(seq 1 "$max_retries"); do
+        if $KIND load docker-image "$IMAGE_TAG" --name "$KIND_CLUSTER_NAME"; then
+            return 0
+        fi
+        if [ "$i" -lt "$max_retries" ]; then
+            echo "    Retry $i/$max_retries: waiting ${retry_delay}s for containerd..."
+            sleep "$retry_delay"
+        fi
+    done
+    echo "ERROR: failed to load image after $max_retries attempts"
+    return 1
+}
+
+# deploy_scheduling_jobset deploys the JobSet controller via the
+# e2e kustomize overlay.
+function deploy_scheduling_jobset {
+    echo "==> Deploying JobSet controller..."
+    (cd config/components/manager && $KUSTOMIZE edit set image controller="$IMAGE_TAG")
+
+    local deploy_status=0
+    kubectl apply --server-side -k "test/e2e/config/$E2E_TARGET_FOLDER" || deploy_status=$?
+    if [ "$deploy_status" -eq 0 ]; then
+        echo "==> Waiting for JobSet controller to be ready..."
+        kubectl rollout status deployment/jobset-controller-manager -n "$NAMESPACE" --timeout=120s || deploy_status=$?
+    fi
+
+    # Reset kustomize image to default so the working tree stays clean,
+    # regardless of whether the deployment succeeded.
+    (cd config/components/manager && $KUSTOMIZE edit set image controller=us-central1-docker.pkg.dev/k8s-staging-images/jobset/jobset:main)
+
+    return "$deploy_status"
+}
+
+# verify_scheduling_apis checks that the scheduling.k8s.io API types are
+# registered in the cluster.
+function verify_scheduling_apis {
+    echo "==> Verifying scheduling.k8s.io API types..."
+    if kubectl api-resources 2>/dev/null | grep -q 'scheduling.k8s.io'; then
+        kubectl api-resources | grep 'scheduling.k8s.io'
+        echo ""
+        echo "✅ Kind cluster '$KIND_CLUSTER_NAME' is ready with WAS feature gates enabled."
+    else
+        echo "⚠️  scheduling.k8s.io API types not found."
+        echo "   The cluster is running but WAS features may not work."
+        return 1
+    fi
+}
+
+# collect_scheduling_logs saves controller and pod logs before teardown.
+function collect_scheduling_logs {
+    mkdir -p "$ARTIFACTS"
+    echo "==> Collecting logs..."
+    kubectl logs -n "$NAMESPACE" deployment/jobset-controller-manager > "$ARTIFACTS/was-controller-manager.log" 2>&1 || true
+    kubectl describe pods -n "$NAMESPACE" > "$ARTIFACTS/was-system-pods.log" 2>&1 || true
+    $KIND export logs "$ARTIFACTS/was-kind-logs" --name "$KIND_CLUSTER_NAME" 2>/dev/null || true
+}
+
+# delete_scheduling_cluster collects logs and deletes the Kind cluster.
+function delete_scheduling_cluster {
+    collect_scheduling_logs
+    echo "==> Deleting Kind cluster '$KIND_CLUSTER_NAME'..."
+    $KIND delete cluster --name "$KIND_CLUSTER_NAME"
+    echo "✅ Cluster '$KIND_CLUSTER_NAME' deleted. Logs saved to $ARTIFACTS/"
+}

--- a/hack/e2e-scheduling-test.sh
+++ b/hack/e2e-scheduling-test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# E2E test script for Workload-Aware Scheduling integration.
+#
+# Creates a Kind cluster with WAS feature gates enabled, deploys JobSet with
+# WorkloadAwareScheduling, runs the scheduling-specific Ginkgo e2e tests, and
+# cleans up on exit. Intended for CI.
+#
+# For interactive dev use, prefer the individual make targets:
+#   make kind-cluster-scheduling          # create cluster + deploy
+#   make kind-cluster-scheduling-delete   # tear down
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source shared cluster lifecycle functions.
+# shellcheck source=hack/e2e-scheduling-cluster.sh
+source "$SCRIPT_DIR/e2e-scheduling-cluster.sh"
+
+export GINKGO="${GINKGO:-$PWD/bin/ginkgo}"
+export JOBSET_E2E_TESTS_DUMP_NAMESPACE=true
+export E2E_TEST_PATH="${E2E_TEST_PATH:-./test/e2e/scheduling/...}"
+export USE_EXISTING_CLUSTER="${USE_EXISTING_CLUSTER:-false}"
+
+KUBECONFIG="${KUBECONFIG:-}"
+
+function cleanup {
+    if [ "$USE_EXISTING_CLUSTER" == 'false' ]; then
+        collect_scheduling_logs
+        $KIND delete cluster --name "$KIND_CLUSTER_NAME" || true
+        [ -n "$KUBECONFIG" ] && rm -f "$KUBECONFIG"
+    fi
+    (cd config/components/manager && $KUSTOMIZE edit set image controller=us-central1-docker.pkg.dev/k8s-staging-images/jobset/jobset:main)
+}
+
+function startup {
+    if [ "$USE_EXISTING_CLUSTER" == 'false' ]; then
+        KUBECONFIG="$(mktemp)"
+        export KUBECONFIG
+        ensure_scheduling_node_image
+        create_scheduling_cluster
+        label_scheduling_nodes
+    fi
+}
+
+trap cleanup EXIT
+startup
+if [ "$USE_EXISTING_CLUSTER" == 'false' ]; then
+    kind_load_image
+fi
+deploy_scheduling_jobset
+$GINKGO --junit-report=junit.xml --output-dir="$ARTIFACTS" -v "$E2E_TEST_PATH"

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -63,4 +63,4 @@ build_node_image
 startup
 kind_load
 jobset_deploy
-$GINKGO --junit-report=junit.xml --output-dir=$ARTIFACTS -v $E2E_TEST_PATH
+$GINKGO --junit-report=junit.xml --output-dir="$ARTIFACTS" -v --skip-package=scheduling "$E2E_TEST_PATH"

--- a/hack/kind-config-scheduling.yaml
+++ b/hack/kind-config-scheduling.yaml
@@ -1,0 +1,26 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+# NOTE: Do NOT set scheduling-specific feature gates at the cluster level.
+# Kind's featureGates field pushes gates to ALL components including the
+# kubelet, which may not recognize alpha scheduling gates. Instead, enable
+# them only on the apiserver and scheduler via extraArgs.
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: ClusterConfiguration
+        apiVersion: kubeadm.k8s.io/v1beta4
+        apiServer:
+          extraArgs:
+            - name: runtime-config
+              value: "scheduling.k8s.io/v1alpha2=true"
+            - name: feature-gates
+              value: "GenericWorkload=true,GangScheduling=true,TopologyAwareWorkloadScheduling=true,WorkloadAwarePreemption=true"
+        scheduler:
+          extraArgs:
+            - name: feature-gates
+              value: "GenericWorkload=true,GangScheduling=true,TopologyAwareWorkloadScheduling=true,WorkloadAwarePreemption=true"
+  - role: worker
+  - role: worker
+  - role: worker
+  - role: worker

--- a/test/e2e/scheduling/scheduling_test.go
+++ b/test/e2e/scheduling/scheduling_test.go
@@ -1,0 +1,328 @@
+/*
+Copyright The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduling
+
+import (
+	"fmt"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	schedulingv1alpha2 "k8s.io/api/scheduling/v1alpha2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+	testutil "sigs.k8s.io/jobset/test/util"
+)
+
+var _ = ginkgo.Describe("Workload-Aware Scheduling E2E", func() {
+
+	// Each test runs in a separate namespace.
+	var ns *corev1.Namespace
+
+	ginkgo.BeforeEach(func() {
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{GenerateName: "e2e-sched-"},
+		}
+		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(testutil.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+	})
+
+	ginkgo.It("should complete a simple JobSet on a WAS-enabled cluster", func() {
+		ginkgo.By("creating a simple JobSet")
+		js := makeJobSet("simple-was", ns.Name, 1, 1, 1, nil)
+		gomega.Expect(k8sClient.Create(ctx, js)).To(gomega.Succeed())
+
+		ginkgo.By("waiting for JobSet to complete")
+		testutil.JobSetCompleted(ctx, k8sClient, js, timeout)
+	})
+
+	ginkgo.Context("Gang Scheduling", func() {
+		// Follows: site/content/en/docs/workload-aware-scheduling/gang_scheduling.md
+		// Creates a Workload + PodGroup + JobSet with gang scheduling.
+		// All pods must be schedulable before any are admitted.
+
+		ginkgo.It("should gang-schedule all pods in a JobSet", func() {
+			jsName := "gang-js"
+			workloadName := "gang-wl"
+			pgName := "gang-pg"
+			pgTemplateName := "workers"
+			replicas := int32(2)
+			completions := int32(2)
+			totalPods := replicas * completions // 4
+
+			ginkgo.By("creating the Workload")
+			workload := &schedulingv1alpha2.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      workloadName,
+					Namespace: ns.Name,
+				},
+				Spec: schedulingv1alpha2.WorkloadSpec{
+					ControllerRef: &schedulingv1alpha2.TypedLocalObjectReference{
+						APIGroup: jobset.GroupVersion.Group,
+						Kind:     "JobSet",
+						Name:     jsName,
+					},
+					PodGroupTemplates: []schedulingv1alpha2.PodGroupTemplate{
+						{
+							Name: pgTemplateName,
+							SchedulingPolicy: schedulingv1alpha2.PodGroupSchedulingPolicy{
+								Gang: &schedulingv1alpha2.GangSchedulingPolicy{
+									MinCount: totalPods,
+								},
+							},
+						},
+					},
+				},
+			}
+			gomega.Expect(k8sClient.Create(ctx, workload)).To(gomega.Succeed())
+
+			ginkgo.By("creating the PodGroup")
+			pg := &schedulingv1alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pgName,
+					Namespace: ns.Name,
+				},
+				Spec: schedulingv1alpha2.PodGroupSpec{
+					PodGroupTemplateRef: &schedulingv1alpha2.PodGroupTemplateReference{
+						Workload: &schedulingv1alpha2.WorkloadPodGroupTemplateReference{
+							WorkloadName:         workloadName,
+							PodGroupTemplateName: pgTemplateName,
+						},
+					},
+					SchedulingPolicy: schedulingv1alpha2.PodGroupSchedulingPolicy{
+						Gang: &schedulingv1alpha2.GangSchedulingPolicy{
+							MinCount: totalPods,
+						},
+					},
+				},
+			}
+			gomega.Expect(k8sClient.Create(ctx, pg)).To(gomega.Succeed())
+
+			ginkgo.By("creating the JobSet with pods referencing the PodGroup")
+			js := makeJobSet(jsName, ns.Name, replicas, completions, completions, &pgName)
+			gomega.Expect(k8sClient.Create(ctx, js)).To(gomega.Succeed())
+
+			ginkgo.By("verifying all pods are scheduled (gang semantics)")
+			gomega.Eventually(func(g gomega.Gomega) {
+				pods := &corev1.PodList{}
+				g.Expect(k8sClient.List(ctx, pods,
+					client.InNamespace(ns.Name),
+					client.MatchingLabels{jobset.JobSetNameKey: jsName},
+				)).To(gomega.Succeed())
+				scheduledCount := 0
+				for _, pod := range pods.Items {
+					if pod.Spec.NodeName != "" {
+						scheduledCount++
+					}
+				}
+				g.Expect(int32(scheduledCount)).To(gomega.Equal(totalPods),
+					fmt.Sprintf("expected %d pods scheduled, got %d", totalPods, scheduledCount))
+			}, timeout, interval).Should(gomega.Succeed())
+
+			ginkgo.By("verifying the Workload exists")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var wl schedulingv1alpha2.Workload
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: workloadName, Namespace: ns.Name,
+				}, &wl)).To(gomega.Succeed())
+				g.Expect(wl.Spec.ControllerRef).NotTo(gomega.BeNil())
+				g.Expect(wl.Spec.ControllerRef.Name).To(gomega.Equal(jsName))
+			}, timeout, interval).Should(gomega.Succeed())
+
+			ginkgo.By("verifying the PodGroup exists with gang policy")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var podGroup schedulingv1alpha2.PodGroup
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: pgName, Namespace: ns.Name,
+				}, &podGroup)).To(gomega.Succeed())
+				g.Expect(podGroup.Spec.SchedulingPolicy.Gang).NotTo(gomega.BeNil())
+				g.Expect(podGroup.Spec.SchedulingPolicy.Gang.MinCount).To(gomega.Equal(totalPods))
+			}, timeout, interval).Should(gomega.Succeed())
+
+			ginkgo.By("waiting for JobSet to complete")
+			testutil.JobSetCompleted(ctx, k8sClient, js, timeout)
+		})
+	})
+
+	ginkgo.Context("Topology Aware Scheduling", func() {
+		// Follows: site/content/en/docs/workload-aware-scheduling/tas.md
+		// All pods must land on nodes within the same topology domain (rack).
+
+		ginkgo.It("should co-locate all pods within the same rack", func() {
+			jsName := "tas-js"
+			workloadName := "tas-wl"
+			pgName := "tas-pg"
+			pgTemplateName := "workers"
+			replicas := int32(2)
+			completions := int32(2)
+			totalPods := replicas * completions // 4
+
+			ginkgo.By("creating the Workload with gang policy")
+			workload := &schedulingv1alpha2.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      workloadName,
+					Namespace: ns.Name,
+				},
+				Spec: schedulingv1alpha2.WorkloadSpec{
+					ControllerRef: &schedulingv1alpha2.TypedLocalObjectReference{
+						APIGroup: jobset.GroupVersion.Group,
+						Kind:     "JobSet",
+						Name:     jsName,
+					},
+					PodGroupTemplates: []schedulingv1alpha2.PodGroupTemplate{
+						{
+							Name: pgTemplateName,
+							SchedulingPolicy: schedulingv1alpha2.PodGroupSchedulingPolicy{
+								Gang: &schedulingv1alpha2.GangSchedulingPolicy{
+									MinCount: totalPods,
+								},
+							},
+						},
+					},
+				},
+			}
+			gomega.Expect(k8sClient.Create(ctx, workload)).To(gomega.Succeed())
+
+			ginkgo.By("creating the PodGroup with topology constraints")
+			pg := &schedulingv1alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pgName,
+					Namespace: ns.Name,
+				},
+				Spec: schedulingv1alpha2.PodGroupSpec{
+					PodGroupTemplateRef: &schedulingv1alpha2.PodGroupTemplateReference{
+						Workload: &schedulingv1alpha2.WorkloadPodGroupTemplateReference{
+							WorkloadName:         workloadName,
+							PodGroupTemplateName: pgTemplateName,
+						},
+					},
+					SchedulingPolicy: schedulingv1alpha2.PodGroupSchedulingPolicy{
+						Gang: &schedulingv1alpha2.GangSchedulingPolicy{
+							MinCount: totalPods,
+						},
+					},
+					SchedulingConstraints: &schedulingv1alpha2.PodGroupSchedulingConstraints{
+						Topology: []schedulingv1alpha2.TopologyConstraint{
+							{Key: "topology.kubernetes.io/rack"},
+						},
+					},
+				},
+			}
+			gomega.Expect(k8sClient.Create(ctx, pg)).To(gomega.Succeed())
+
+			ginkgo.By("creating the JobSet with pods referencing the PodGroup")
+			js := makeJobSet(jsName, ns.Name, replicas, completions, completions, &pgName)
+			gomega.Expect(k8sClient.Create(ctx, js)).To(gomega.Succeed())
+
+			ginkgo.By("verifying all pods land on nodes in the same rack")
+			gomega.Eventually(func(g gomega.Gomega) {
+				pods := &corev1.PodList{}
+				g.Expect(k8sClient.List(ctx, pods,
+					client.InNamespace(ns.Name),
+					client.MatchingLabels{jobset.JobSetNameKey: jsName},
+				)).To(gomega.Succeed())
+
+				// Collect the rack labels from each pod's assigned node.
+				racks := map[string]bool{}
+				scheduledCount := 0
+				for _, pod := range pods.Items {
+					if pod.Spec.NodeName == "" {
+						continue
+					}
+					scheduledCount++
+					var node corev1.Node
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: pod.Spec.NodeName}, &node)).To(gomega.Succeed())
+					rack, ok := node.Labels["topology.kubernetes.io/rack"]
+					g.Expect(ok).To(gomega.BeTrue(),
+						fmt.Sprintf("node %s missing topology.kubernetes.io/rack label", pod.Spec.NodeName))
+					racks[rack] = true
+				}
+				g.Expect(int32(scheduledCount)).To(gomega.Equal(totalPods),
+					fmt.Sprintf("expected %d pods scheduled, got %d", totalPods, scheduledCount))
+				g.Expect(racks).To(gomega.HaveLen(1),
+					fmt.Sprintf("expected all pods on 1 rack, found %d: %v", len(racks), racks))
+			}, timeout, interval).Should(gomega.Succeed())
+
+			ginkgo.By("verifying PodGroup has topology constraints")
+			var podGroup schedulingv1alpha2.PodGroup
+			gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name: pgName, Namespace: ns.Name,
+			}, &podGroup)).To(gomega.Succeed())
+			gomega.Expect(podGroup.Spec.SchedulingConstraints).NotTo(gomega.BeNil())
+			gomega.Expect(podGroup.Spec.SchedulingConstraints.Topology).To(gomega.HaveLen(1))
+			gomega.Expect(podGroup.Spec.SchedulingConstraints.Topology[0].Key).To(gomega.Equal("topology.kubernetes.io/rack"))
+
+			ginkgo.By("waiting for JobSet to complete")
+			testutil.JobSetCompleted(ctx, k8sClient, js, timeout)
+		})
+	})
+
+})
+
+// makeJobSet creates a JobSet with a single ReplicatedJob. If podGroupName is
+// non-nil, the pod template references it via schedulingGroup.podGroupName.
+func makeJobSet(name, namespace string, replicas, completions, parallelism int32, podGroupName *string) *jobset.JobSet {
+	podSpec := corev1.PodSpec{
+		RestartPolicy:                 corev1.RestartPolicyNever,
+		TerminationGracePeriodSeconds: ptr.To(int64(0)),
+		Containers: []corev1.Container{
+			{
+				Name:    "worker",
+				Image:   "busybox",
+				Command: []string{"sh", "-c", "sleep 5"},
+			},
+		},
+	}
+
+	if podGroupName != nil {
+		podSpec.SchedulingGroup = &corev1.PodSchedulingGroup{
+			PodGroupName: podGroupName,
+		}
+	}
+
+	return &jobset.JobSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: jobset.JobSetSpec{
+			ReplicatedJobs: []jobset.ReplicatedJob{
+				{
+					Name:     "rj",
+					Replicas: replicas,
+					Template: batchv1.JobTemplateSpec{
+						Spec: batchv1.JobSpec{
+							Completions:  ptr.To(completions),
+							Parallelism:  ptr.To(parallelism),
+							BackoffLimit: ptr.To(int32(10)),
+							Template: corev1.PodTemplateSpec{
+								Spec: podSpec,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/test/e2e/scheduling/suite_test.go
+++ b/test/e2e/scheduling/suite_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduling
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+	schedulingv1alpha2 "k8s.io/api/scheduling/v1alpha2"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+	"sigs.k8s.io/jobset/test/util"
+)
+
+const (
+	timeout  = 5 * time.Minute
+	interval = time.Millisecond * 250
+)
+
+var (
+	k8sClient client.Client
+	ctx       context.Context
+)
+
+func TestSchedulingE2E(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Scheduling E2E Suite")
+}
+
+var _ = ginkgo.BeforeSuite(func() {
+	ctx = context.Background()
+	cfg := config.GetConfigOrDie()
+	gomega.Expect(cfg).NotTo(gomega.BeNil())
+
+	err := jobset.AddToScheme(scheme.Scheme)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	err = batchv1.AddToScheme(scheme.Scheme)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	err = schedulingv1alpha2.AddToScheme(scheme.Scheme)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(k8sClient).NotTo(gomega.BeNil())
+
+	util.JobSetReadyForTesting(ctx, k8sClient)
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adding e2e tests for Workload Aware Scheduling and JobSet.
Prep of longer features for Gang JobSets
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Added a e2e test in [test-infra](https://github.com/kubernetes/test-infra/pull/37382).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end coverage for Workload-Aware Scheduling on Kind, including gang scheduling and topology-aware placement.
  * Introduced scheduling-focused Kind cluster creation, deployment, verification, and automated diagnostics/log collection.
  * Added a dedicated scheduling E2E suite and supporting test entrypoints/configuration.
* **Bug Fixes**
  * Prevented scheduling tests from running in the standard E2E pass to avoid overlap.
  * Updated Helm tooling to run the YAML processor with consistent Go module flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->