### PR TITLE
fix: correct JobSet installation docs references

### DIFF
--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -158,7 +158,7 @@ VERSION={{< param "version" >}}
 kubectl delete -f https://github.com/kubernetes-sigs/jobset/releases/download/$VERSION/manifests.yaml
 ```
 
-To uninstall a released version of Kueue from your cluster by Helm, run the following command:
+To uninstall a released version of JobSet from your cluster by Helm, run the following command:
 
 ```shell
 helm uninstall jobset --namespace jobset-system
@@ -290,4 +290,3 @@ Next, in the file ``jobset/config/default/kustomization.yaml`` replace ``../comp
 ``../components/certmanager`` then uncomment all the lines beginning with ``[CERTMANAGER]``.
 
 Finally, apply these configurations to your cluster with ``kubectl apply --server-side -k config/default``.
-

--- a/site/content/en/docs/troubleshooting/_index.md
+++ b/site/content/en/docs/troubleshooting/_index.md
@@ -36,7 +36,7 @@ Inspect the logs to look for one of the following issues:
 **Cause**: In older versions of JobSet (older than v0.2.1) if the indexes could not be built for some reason, the JobSet controller would log the error and launch anyway. This resulted in confusing behavior later when trying to create JobSets, where the controller would encounter this "index not found" error and not be able to create any jobs. This bug was fixed
 in v0.2.1 so the JobSet controller now fails fast and exits with an error if indexes cannot be built.
 
-**Solution**: Uninstall JobSet and re-install using the latest release (or at minimum, JobSet v0.2.1). See [installation guide](/docs/setup/install.md) for the commands to do this.
+**Solution**: Uninstall JobSet and re-install using the latest release (or at minimum, JobSet v0.2.1). See the [installation guide](/docs/installation/) for the commands to do this.
 
 2. Validation error creating Jobs and/or Services, indicating the Job/Service name is invalid.
 
@@ -58,7 +58,7 @@ Look at the JobSet controller logs and you'll probably see an error like this:
 
 **Cause**: This could be due to a known bug in an older version of JobSet, or a known bug in an older version of Kueue. JobSet and Kueue integration requires JobSet v0.2.3+ and Kueue v0.4.1+.
 
-**Solution**: If you're using JobSet version less than v0.2.3, uninstall and re-install using a versoin >= v0.2.3 (see the JobSet [installation guide](https://jobset.sigs.k8s.io/docs/installation/) for the commands to do this). If you're using a Kueue version less than v0.4.1, uninstall and re-install using a v0.4.1 (see the Kueue [installation guide](https://kueue.sigs.k8s.io/docs/installation/) for the commands to do this).
+**Solution**: If you're using JobSet version less than v0.2.3, uninstall and re-install using a version >= v0.2.3 (see the JobSet [installation guide](https://jobset.sigs.k8s.io/docs/installation/) for the commands to do this). If you're using a Kueue version less than v0.4.1, uninstall and re-install using a v0.4.1 (see the Kueue [installation guide](https://kueue.sigs.k8s.io/docs/installation/) for the commands to do this).
 
 ## 4. Troubleshooting network communication between different Pods
 


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
Fixes a broken troubleshooting link that points to `/docs/setup/install.md`, which does not exist.

Also fixes a typo and corrects the Helm uninstall text so it refers to JobSet, not Kueue. Docs-only, tiny diff, no behavior change.

Repro:
1. Open `site/content/en/docs/troubleshooting/_index.md`.
2. Find the `installation guide` link in section 2.
3. It points to `/docs/setup/install.md`, but this repo only has `/docs/installation/`.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
Used an AI assistant for drafting and verification, per project policy.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the uninstall steps to reference the proper Helm instructions.
  * Updated troubleshooting guidance with revised installation links and clearer wording.
  * Fixed a typo in the troubleshooting content and made minor formatting adjustments for readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->