### PR TITLE
add a skill to triage the jobset test-infra board

### DIFF
--- a/.agents/skills/testgrid-triage/SKILL.md
+++ b/.agents/skills/testgrid-triage/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: testgrid-triage
+description: Triages failing/flaky CI jobs on JobSet's testgrid dashboards (e.g. sig-apps-jobset-periodics, sig-apps-jobset-presubmits). Summarizes job health, drills into which specific tests are failing vs flaking, fetches raw Prow/GCS build logs to find true root cause, and files well-evidenced GitHub issues with the required AI-usage disclosure. Use whenever asked to check testgrid, summarize CI failures, investigate a flaky/red job, or file a bug report for a failing test.
+---
+
+# Testgrid Triage
+
+Streamlines the workflow of: testgrid summary → drill into a job → find the
+run-length-encoded pass/fail pattern per test → pull the raw build log for
+root cause → (optionally) file a GitHub issue.
+
+Requires: `curl`, `python3`, `jq` (optional), `gsutil` (for raw logs),
+`gh` (authenticated, for filing issues — check with `gh auth status`).
+
+## Step 1 — Get overall dashboard health
+
+```bash
+./scripts/summary.sh sig-apps-jobset-periodics
+```
+
+Prints every job/tab sorted worst-first (FAILING, then FLAKY, then PASSING)
+with its recent pass-rate string. Use this to decide which job(s) deserve a
+closer look. Common dashboards for this repo: `sig-apps-jobset-periodics`,
+`sig-apps-jobset-presubmits` (check testgrid.k8s.io for exact names).
+
+## Step 2 — Drill into a specific job
+
+```bash
+./scripts/failing-tests.sh sig-apps-jobset-periodics periodic-jobset-test-e2e-release-0-12-1-35
+```
+
+Saves the full table JSON to `/tmp/<job>.json` and prints, for every test
+that failed or flaked recently, a run-length-encoded list of
+`(status_value, count)` pairs (most recent run first). Status values:
+`1`=PASS, `0`=NO_RESULT, `12`=FAIL, `13`=FLAKY.
+
+Use this to distinguish patterns:
+- **A cluster of unrelated tests fails together in the same 1-2 runs**
+  (e.g. `(12,1)` sprinkled among long `(1,N)` runs) → likely a transient
+  infra blip (DNS hiccup, resource contention), not a regression.
+- **`overall-status` FAILING with 0% pass and no individual `[It]` test
+  rows at all** (only `Overall`/`Pod`/`[BeforeSuite]` show up) → the job is
+  failing before any test runs — a setup/infra/config problem, not a test
+  bug. Go straight to Step 3 to find why setup fails.
+- **One specific test fails a small, non-trivial fraction of runs while
+  everything else is 100% green** → likely a real flaky test worth its own
+  narrower investigation/issue.
+
+## Step 3 — Get the real error from raw build logs
+
+Testgrid's grid only tells you pass/fail, not *why*. Always confirm root
+cause from the actual Prow log before concluding anything or filing an
+issue:
+
+```bash
+./scripts/fetch-build-log.sh <job-name> list        # list recent build IDs
+./scripts/fetch-build-log.sh <job-name>             # cat latest build's build-log.txt
+./scripts/fetch-build-log.sh <job-name> <build-id>  # cat a specific build
+```
+
+Grep the output for the actual failure, e.g.:
+
+```bash
+./scripts/fetch-build-log.sh periodic-jobset-test-e2e-release-0-11-1-36 \
+  | grep -E -B2 -A15 -i "error|fail|panic"
+```
+
+Compare the same failure across 2+ builds/jobs when possible — if the
+identical error appears in every failing run of multiple jobs, that's
+strong evidence of a systemic cause (e.g. a pinned dependency/image tag
+that no longer resolves) rather than a one-off flake.
+
+## Step 4 — File an issue (only after root cause is confirmed)
+
+Follow [references/issue-template.md](references/issue-template.md) for
+the required structure and the mandatory AI-disclosure note (per this
+repo's `AGENTS.md` / the Kubernetes AI Tool Usage Policy). Then:
+
+```bash
+gh issue create --repo kubernetes-sigs/jobset \
+  --title "<concise, specific title>" \
+  --body-file /tmp/issue_body.md
+```
+
+Do **not** file an issue for a single-run transient blip — only for
+patterns that are reproducible/consistent (e.g. 100% failure over the
+visible history, or a clearly identified systemic root cause).
+
+## Notes
+
+- These scripts only read public testgrid/GCS data and don't need
+  authentication, except `gh issue create` which needs `gh auth status` to
+  show a logged-in account with `repo` scope.
+- Prow job configs (`E2E_KIND_VERSION`, cluster version matrices, etc.) for
+  periodics/presubmits typically live outside this repo (in
+  `kubernetes/test-infra` or `kubernetes-sigs/jobset`'s own
+  `.prow.yaml`/`config/jobs`, if present) — check both when a fix requires
+  a job-config change rather than a source-code change.

--- a/.agents/skills/testgrid-triage/references/issue-template.md
+++ b/.agents/skills/testgrid-triage/references/issue-template.md
@@ -1,0 +1,60 @@
+# CI failure issue template
+
+Use this structure when filing a GitHub issue for a genuine CI/testgrid
+failure (JobSet follows the Kubernetes AI Tool Usage Policy — see
+`AGENTS.md` at the repo root).
+
+```markdown
+## What happened
+
+<Which job(s)/tab(s) on which testgrid dashboard, current pass rate over
+recent runs, and whether individual tests fail or the whole job fails
+before tests even run (setup/infra failure).>
+
+## Root cause
+
+<Paste the relevant excerpt from the Prow build-log.txt / junit output that
+pinpoints the actual error. Explain what it means.>
+
+## Evidence / reproduction
+
+<List specific build IDs / Prow links used as evidence, and note whether
+the pattern is consistent across the recent history shown on testgrid.>
+
+## Expected behavior
+
+<What should happen instead.>
+
+## Suggested fix
+
+<Concrete, minimal suggestion — e.g. bump a pinned image tag, fix a flaky
+wait condition, add a retry, etc. Point at the exact file/config if it
+lives in this repo; note if it's owned by kubernetes/test-infra instead.>
+
+#### Special notes for your reviewer:
+
+This investigation (pulling and analyzing testgrid data and CI logs, and
+drafting this issue) was assisted by an AI coding agent, per the
+[Kubernetes AI Tool Usage Policy](https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance).
+All findings were reviewed before filing.
+```
+
+## Rules (from AGENTS.md / Kubernetes AI policy)
+
+- Always disclose AI assistance in the issue body (the "Special notes for
+  your reviewer" section above is the minimum bar).
+- Never add AI co-author/assisted-by/co-developed commit trailers.
+- Do not use `@mentions` or issue-closing keywords (`Fixes #123`) in commit
+  messages tied to the fix — that linkage belongs in the PR template only.
+- Only file an issue once you've confirmed root cause from raw logs, not
+  just from the testgrid pass/fail grid — testgrid alone often can't
+  distinguish "real regression" from "flaky infra" or "stale pinned
+  version".
+
+## Filing the issue
+
+```bash
+gh issue create --repo kubernetes-sigs/jobset \
+  --title "<concise, specific title including affected job(s)>" \
+  --body-file /tmp/issue_body.md
+```

--- a/.agents/skills/testgrid-triage/scripts/failing-tests.sh
+++ b/.agents/skills/testgrid-triage/scripts/failing-tests.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Fetch a testgrid job's table and list tests that failed or flaked in recent
+# runs, with a per-test breakdown of (status_value, count) runs so you can
+# tell "failed once in 30 runs" (likely flake/infra blip) apart from
+# "fails every run" (likely a real regression or broken job config).
+#
+# Status values (testgrid convention): 1=PASS, 0=NO_RESULT, 12=FAIL, 13=FLAKY
+#
+# Usage: ./failing-tests.sh <dashboard-name> <job-name> [out.json]
+# Example: ./failing-tests.sh sig-apps-jobset-periodics periodic-jobset-test-e2e-main-1-36
+set -euo pipefail
+
+DASHBOARD="${1:?usage: failing-tests.sh <dashboard-name> <job-name> [out.json]}"
+JOB="${2:?usage: failing-tests.sh <dashboard-name> <job-name> [out.json]}"
+OUT="${3:-/tmp/${JOB}.json}"
+
+curl -fsS --max-time 30 "https://testgrid.k8s.io/${DASHBOARD}/table?tab=${JOB}" -o "$OUT"
+
+python3 -c '
+import json
+import sys
+
+d = json.load(open(sys.argv[1]))
+print("overall-status code:", d.get("overall-status"))
+print("columns (most recent first):", d.get("column-header-names"))
+print()
+for t in d.get("tests", []):
+    name = t["name"]
+    statuses = t.get("statuses", [])
+    if any(s.get("value") in (12, 13) for s in statuses):
+        print(name)
+        print("  run-length-encoded statuses (value, count):", [(s.get("value"), s.get("count")) for s in statuses])
+' "$OUT"
+echo
+echo "Raw table saved to: $OUT"

--- a/.agents/skills/testgrid-triage/scripts/fetch-build-log.sh
+++ b/.agents/skills/testgrid-triage/scripts/fetch-build-log.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Fetch the raw Prow build-log.txt for a periodic/presubmit job from the
+# kubernetes-ci-logs GCS bucket, so you can see the actual error instead of
+# just testgrid's pass/fail grid.
+#
+# Usage:
+#   ./fetch-build-log.sh <job-name>              # latest build
+#   ./fetch-build-log.sh <job-name> <build-id>   # specific build
+#   ./fetch-build-log.sh <job-name> list         # list recent build IDs
+#
+# Example:
+#   ./fetch-build-log.sh periodic-jobset-test-e2e-release-0-11-1-36
+set -euo pipefail
+
+JOB="${1:?usage: fetch-build-log.sh <job-name> [build-id|list]}"
+BUILD="${2:-latest}"
+BASE="gs://kubernetes-ci-logs/logs/${JOB}"
+
+if [[ "$BUILD" == "list" ]]; then
+    gsutil ls "$BASE/" | sed "s#$BASE/##;s#/##" | sort -n
+    exit 0
+fi
+
+if [[ "$BUILD" == "latest" ]]; then
+    BUILD=$(gsutil ls "$BASE/" | sed "s#$BASE/##;s#/##" | sort -n | tail -1)
+    echo "# Using latest build: $BUILD" >&2
+fi
+
+echo "# Job:   $JOB" >&2
+echo "# Build: $BUILD" >&2
+echo "# Prow link: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/${JOB}/${BUILD}" >&2
+echo "# ---" >&2
+
+gsutil cat "${BASE}/${BUILD}/build-log.txt"

--- a/.agents/skills/testgrid-triage/scripts/summary.sh
+++ b/.agents/skills/testgrid-triage/scripts/summary.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Fetch and print a compact per-job status summary for a testgrid dashboard.
+#
+# Usage: ./summary.sh <dashboard-name>
+# Example: ./summary.sh sig-apps-jobset-periodics
+set -euo pipefail
+
+DASHBOARD="${1:?usage: summary.sh <dashboard-name>}"
+URL="https://testgrid.k8s.io/${DASHBOARD}/summary"
+
+curl -fsS --max-time 20 "$URL" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+rows = []
+for k, v in d.items():
+    rows.append((v.get("overall_status", "?"), k, v.get("status", "")))
+# sort worst-first: FAILING, FLAKY, then PASSING
+order = {"FAILING": 0, "FLAKY": 1, "PASSING": 2}
+rows.sort(key=lambda r: (order.get(r[0], 1), r[1]))
+for status, name, detail in rows:
+    print(f"{status:10s} {name:55s} {detail}")
+'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Aide in issue triage for failing tests.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
AI was used to generate the issue but the issue was reviewed and understood by me.

#1258 
#1257 

Are examples of the skill output.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Testgrid triage workflow to assess dashboard health, pinpoint failing/flaky jobs, and review raw build logs to confirm root cause.
  * Added helper utilities to summarize dashboard status, inspect failing tests, and fetch raw CI build logs.
  * Added a GitHub issue template to report confirmed genuine CI/testgrid failures with required evidence and filing guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->