### PR TITLE
fix connection refused error in e2e tests

### DIFF
--- a/test/util/util.go
+++ b/test/util/util.go
@@ -42,6 +42,7 @@ import (
 	configv1alpha1 "sigs.k8s.io/jobset/api/config/v1alpha1"
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 	"sigs.k8s.io/jobset/pkg/constants"
+	testingutil "sigs.k8s.io/jobset/pkg/util/testing"
 )
 
 const (
@@ -365,6 +366,46 @@ func JobSetReadyForTesting(ctx context.Context, k8sClient client.Client) {
 		))
 		return nil
 	}, timeout, interval).Should(gomega.Succeed())
+
+	// The Deployment being Available doesn't guarantee that the webhook
+	// Service's endpoints have propagated to kube-proxy yet. Without this
+	// check, the very first request relying on the webhooks (e.g. the first
+	// JobSet creation in the suite) can intermittently fail with a
+	// "connection refused" error against the webhook Service ClusterIP.
+	waitForWebhookEndpointsReady(ctx, k8sClient, deploymentKey)
+
+	// Even after the EndpointSlice for the webhook Service reports the pod as
+	// ready, kube-proxy on the node making the request may not have finished
+	// programming the corresponding iptables/ipvs rules yet, since that
+	// propagation happens asynchronously and is not reflected in any object
+	// we can observe through the API server. To guard against this, actively
+	// probe the webhook by issuing dry-run requests that must go through it
+	// until one succeeds.
+	waitForWebhookReachable(ctx, k8sClient)
+}
+
+// waitForWebhookReachable performs dry-run requests that are routed through
+// the JobSet webhooks until one succeeds, to make sure the webhook Service is
+// actually reachable from the client before tests start relying on it.
+func waitForWebhookReachable(ctx context.Context, k8sClient client.Client) {
+	ginkgo.By("waiting for jobset webhooks to be reachable")
+	probe := testJobSet()
+	gomega.Eventually(func(g gomega.Gomega) error {
+		return k8sClient.Create(ctx, probe.DeepCopy(), client.DryRunAll)
+	}, timeout, interval).Should(gomega.Succeed())
+}
+
+// testJobSet returns a minimal, valid JobSet used only to probe whether the
+// webhooks are reachable via dry-run creation requests.
+func testJobSet() *jobset.JobSet {
+	return testingutil.MakeJobSet("webhook-probe", metav1.NamespaceDefault).
+		ReplicatedJob(testingutil.MakeReplicatedJob("probe").
+			Job(testingutil.MakeJobTemplate("probe", metav1.NamespaceDefault).
+				PodSpec(testingutil.TestPodSpec).
+				Obj()).
+			Replicas(1).
+			Obj()).
+		Obj()
 }
 
 func GetJobSetConfiguration(ctx context.Context, k8sClient client.Client) *configv1alpha1.Configuration {
@@ -410,6 +451,7 @@ func RestartJobSetController(ctx context.Context, k8sClient client.Client) {
 	})
 	waitForDeploymentAvailability(ctx, k8sClient, deploymentKey)
 	waitForWebhookEndpointsReady(ctx, k8sClient, deploymentKey)
+	waitForWebhookReachable(ctx, k8sClient)
 }
 
 func updateDeploymentAndWaitForProgressing(ctx context.Context, k8sClient client.Client, key types.NamespacedName, applyChanges func(deployment *appsv1.Deployment)) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind failing-test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Some of our e2e tests fail when deployment isn't quite ready to serve traffic.

Add a check to wait similar to what Kueue does.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test environment readiness checks so the system waits for webhook endpoints to fully catch up after the controller manager becomes available.
  * Reduces intermittent webhook connection failures that could happen immediately after startup, making test setup more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->