### PR TITLE
fix: avoid nil network panic during JobSet reconciliation

### DIFF
--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -1152,7 +1152,7 @@ func jobSetMarkedForDeletion(js *jobset.JobSet) bool {
 }
 
 func dnsHostnamesEnabled(js *jobset.JobSet) bool {
-	return js.Spec.Network.EnableDNSHostnames != nil && *js.Spec.Network.EnableDNSHostnames
+	return js.Spec.Network != nil && js.Spec.Network.EnableDNSHostnames != nil && *js.Spec.Network.EnableDNSHostnames
 }
 
 func jobSetSuspended(js *jobset.JobSet) bool {

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -1733,6 +1733,14 @@ func TestCreateHeadlessSvcIfNecessary(t *testing.T) {
 			existingService: true,
 		},
 		{
+			name: "jobset created before webhook defaulting should not create headless service",
+			jobSet: func() *jobset.JobSet {
+				js := testutils.MakeJobSet(jobSetName, ns).Obj()
+				js.Spec.Network = nil
+				return js
+			}(),
+		},
+		{
 			name:            "headless service creation fails with unexpected error",
 			jobSet:          testutils.MakeJobSet(jobSetName, ns).EnableDNSHostnames(true).Obj(),
 			existingService: false,


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This adds a nil check before reading `spec.network.enableDNSHostnames`.
Without it, an old JobSet that was created before webhook defaulting can blow up the controller with a nil pointer panic. Small fix, nasty bug.

#### Which issue(s) this PR fixes:
Related to #796

#### Special notes for your reviewer:
Used an AI coding tool for the initial patch and test draft, then reviewed and verified the final change locally.

Repro:
1. Create a JobSet before installing the JobSet webhook/controller, so `.spec.network` stays unset.
2. Install or start JobSet.
3. Reconcile hits `dnsHostnamesEnabled()` and panics on a nil `spec.network`.

Local checks:
- `go test ./pkg/controllers -run TestCreateHeadlessSvcIfNecessary`
- `make test`
- `make verify` got through vet, ci-lint, lint-api, manifests, codegen and helm generation before I stopped it during the later docs step on first-run tool/image setup.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a crash when job network settings are missing, so job reconciliation handles unset network configuration safely.
  * Improved headless service creation logic to avoid creating a service when the job configuration has not been defaulted yet.

* **Tests**
  * Added coverage for jobs created before defaulting to confirm no headless service is created in that case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->