### PR TITLE
Fix validation for generateName-derived child resource names

### DIFF
--- a/pkg/webhooks/jobset_webhook.go
+++ b/pkg/webhooks/jobset_webhook.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -165,6 +166,7 @@ func (j *jobSetWebhook) Default(ctx context.Context, js *jobset.JobSet) error {
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (j *jobSetWebhook) ValidateCreate(ctx context.Context, js *jobset.JobSet) (admission.Warnings, error) {
 	var allErrs []error
+	jobSetNameForValidation := getJobSetNameForValidation(js)
 
 	// Validate InPlaceRestart feature gate.
 	// The in-place restart API should be used only when the feature gate is enabled.
@@ -233,7 +235,7 @@ func (j *jobSetWebhook) ValidateCreate(ctx context.Context, js *jobset.JobSet) (
 		}
 		// Check that the generated job names for this replicated job will be DNS 1035 compliant.
 		// Use the largest job index as it will have the longest name.
-		longestJobName := placement.GenJobName(js.Name, rJob.Name, int(rJob.Replicas-1))
+		longestJobName := placement.GenJobName(jobSetNameForValidation, rJob.Name, int(rJob.Replicas-1))
 		for _, errMessage := range validation.IsDNS1035Label(longestJobName) {
 			if strings.Contains(errMessage, dns1035MaxLengthExceededErrorMsg) {
 				errMessage = jobNameTooLongErrorMsg
@@ -246,7 +248,7 @@ func (j *jobSetWebhook) ValidateCreate(ctx context.Context, js *jobset.JobSet) (
 			maxJobIndex := strconv.Itoa(int(rJob.Replicas - 1))
 			maxPodIndex := strconv.Itoa(int(*rJob.Template.Spec.Completions - 1))
 			// Add 5 char suffix to the deterministic part of the pod name to validate the full pod name is compliant.
-			longestPodName := placement.GenPodName(js.Name, rJob.Name, maxJobIndex, maxPodIndex) + "-abcde"
+			longestPodName := placement.GenPodName(jobSetNameForValidation, rJob.Name, maxJobIndex, maxPodIndex) + "-abcde"
 			for _, errMessage := range validation.IsDNS1035Label(longestPodName) {
 				if strings.Contains(errMessage, dns1035MaxLengthExceededErrorMsg) {
 					errMessage = podNameTooLongErrorMsg
@@ -297,12 +299,12 @@ func (j *jobSetWebhook) ValidateCreate(ctx context.Context, js *jobset.JobSet) (
 	// Validate coordinator, if set.
 	if js.Spec.Coordinator != nil {
 		allErrs = append(allErrs, validateCoordinator(js))
-		allErrs = append(allErrs, validateCoordinatorLabelValue(js))
+		allErrs = append(allErrs, validateCoordinatorLabelValue(js, jobSetNameForValidation))
 	}
 
 	// Validate VolumeClaimPolicies, if set.
 	if len(js.Spec.VolumeClaimPolicies) > 0 {
-		allErrs = append(allErrs, j.validateVolumeClaimPolicies(ctx, js, js.Spec.VolumeClaimPolicies)...)
+		allErrs = append(allErrs, j.validateVolumeClaimPolicies(ctx, js, jobSetNameForValidation, js.Spec.VolumeClaimPolicies)...)
 	}
 
 	return nil, invalidError(js.Name, allErrs)
@@ -523,8 +525,11 @@ func validateCoordinator(js *jobset.JobSet) error {
 
 // If spec will lead to invalid coordinator label value, return error
 // This usually happens when the JobSet name is too long
-func validateCoordinatorLabelValue(js *jobset.JobSet) error {
-	labelValue := controllers.CoordinatorEndpoint(js)
+func validateCoordinatorLabelValue(js *jobset.JobSet, jobSetName string) error {
+	jsForValidation := js.DeepCopy()
+	jsForValidation.Name = jobSetName
+
+	labelValue := controllers.CoordinatorEndpoint(jsForValidation)
 	errs := validation.IsValidLabelValue(labelValue)
 	if len(errs) > 0 {
 		return fmt.Errorf("spec will lead to invalid label value %q for coordinator label %q (long JobSet / ReplicatedJob / SubDomain name?): %s", labelValue, jobset.CoordinatorKey, strings.Join(errs, ", "))
@@ -533,7 +538,7 @@ func validateCoordinatorLabelValue(js *jobset.JobSet) error {
 }
 
 // validateVolumeClaimPolicies validates the volume claim policies for the JobSet.
-func (j *jobSetWebhook) validateVolumeClaimPolicies(ctx context.Context, js *jobset.JobSet, volumeClaimPolicies []jobset.VolumeClaimPolicy) []error {
+func (j *jobSetWebhook) validateVolumeClaimPolicies(ctx context.Context, js *jobset.JobSet, jobSetName string, volumeClaimPolicies []jobset.VolumeClaimPolicy) []error {
 	var allErrs []error
 	claimNames := sets.New[string]()
 
@@ -558,7 +563,7 @@ func (j *jobSetWebhook) validateVolumeClaimPolicies(ctx context.Context, js *job
 			}
 
 			// Validate PVC name length limits
-			pvcName := controllers.GeneratePVCName(js.Name, template.Name)
+			pvcName := controllers.GeneratePVCName(jobSetName, template.Name)
 			if len(pvcName) > maxVolumeClaimLength {
 				allErrs = append(allErrs, field.Invalid(
 					templateFieldPath.Child("name"),
@@ -673,6 +678,16 @@ func replicatedJobByName(js *jobset.JobSet, replicatedJob string) *jobset.Replic
 		}
 	}
 	return nil
+}
+
+func getJobSetNameForValidation(js *jobset.JobSet) string {
+	if js.Name != "" {
+		return js.Name
+	}
+	if js.GenerateName != "" {
+		return names.SimpleNameGenerator.GenerateName(js.GenerateName)
+	}
+	return ""
 }
 
 // toFieldErrorList converts a slice of errors (which may contain a mix of

--- a/pkg/webhooks/jobset_webhook_test.go
+++ b/pkg/webhooks/jobset_webhook_test.go
@@ -860,6 +860,96 @@ func TestValidateCreate(t *testing.T) {
 
 	uncategorizedTests := []validationTestCase{
 		{
+			name: "generateName that produces overlong child job names is rejected",
+			js: &jobset.JobSet{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "JobSet",
+					APIVersion: "jobset.x-k8s.io/v1alpha2",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: strings.Repeat("a", 49) + "-",
+				},
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:      "worker",
+							GroupName: "default",
+							Replicas:  1,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Template: validPodTemplateSpec,
+								},
+							},
+						},
+					},
+					SuccessPolicy: &jobset.SuccessPolicy{
+						Operator: jobset.OperatorAll,
+					},
+				},
+			},
+			want: errors.Join(
+				errors.New(jobNameTooLongErrorMsg),
+			),
+		},
+		{
+			name: "generateName that produces overlong PVC names is rejected",
+			js: &jobset.JobSet{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "JobSet",
+					APIVersion: "jobset.x-k8s.io/v1alpha2",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: strings.Repeat("a", 49) + "-",
+				},
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:      "worker",
+							GroupName: "default",
+							Replicas:  1,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Template: corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name:  "test",
+													Image: "bash:latest",
+													VolumeMounts: []corev1.VolumeMount{
+														{
+															Name:      "datasets",
+															MountPath: "/mnt/data",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					SuccessPolicy: &jobset.SuccessPolicy{
+						Operator: jobset.OperatorAll,
+					},
+					VolumeClaimPolicies: []jobset.VolumeClaimPolicy{
+						{
+							Templates: []corev1.PersistentVolumeClaim{
+								{
+									ObjectMeta: metav1.ObjectMeta{
+										Name: "datasets",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: errors.Join(
+				errors.New("VolumeClaimPolicies template name is too long"),
+			),
+		},
+		{
 			name: "number of pods exceeds the limit",
 			js: &jobset.JobSet{
 				TypeMeta: metav1.TypeMeta{
@@ -3103,6 +3193,36 @@ func TestValidateCreate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetJobSetNameForValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("name is used directly", func(t *testing.T) {
+		got := getJobSetNameForValidation(&jobset.JobSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "jobset-name",
+			},
+		})
+
+		assert.Equal(t, "jobset-name", got)
+	})
+
+	t.Run("generateName uses apiserver truncation rules", func(t *testing.T) {
+		got := getJobSetNameForValidation(&jobset.JobSet{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: strings.Repeat("a", 60),
+			},
+		})
+
+		assert.Len(t, got, 63)
+		assert.True(t, strings.HasPrefix(got, strings.Repeat("a", 58)))
+	})
+
+	t.Run("empty metadata returns empty name", func(t *testing.T) {
+		got := getJobSetNameForValidation(&jobset.JobSet{})
+		assert.Empty(t, got)
+	})
 }
 
 func TestValidateUpdate(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind regression

#### What this PR does / why we need it:
Sneaky little gap in `ValidateCreate`: it validated derived Job, Pod, coordinator, and PVC names with `js.Name`, but `js.Name` is still empty on create requests that use `metadata.generateName`.

That means an overlong `generateName` prefix can slip through admission, then blow up later when the controller creates child resources. This patch validates against the effective generated JobSet name instead, using the apiserver's own truncation and 5 char suffix behavior. Added regression tests for child Job and PVC names too.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
Used AI assistance to help prepare and validate this change.

Repro:

```yaml
apiVersion: jobset.x-k8s.io/v1alpha2
kind: JobSet
metadata:
  generateName: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-
spec:
  successPolicy:
    operator: All
  replicatedJobs:
  - name: worker
    groupName: default
    replicas: 1
    template:
      spec:
        template:
          spec:
            restartPolicy: Never
            containers:
            - name: test
              image: bash:latest
```

Before this fix, `kubectl apply -f repro.yaml` gets through admission. Then the apiserver adds the suffix, and the controller tries to create an invalid child Job name. Kinda rough.

#### Does this PR introduce a user-facing change?
```release-note
JobSet creation now rejects `metadata.generateName` prefixes that would produce invalid child Job or PVC names after the apiserver assigns the final JobSet name.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for resources created with generated names, ensuring name-length checks work correctly even when the main name is not set.
  * Added stricter checks to reject configurations that would produce overly long child job or PVC names.
  * Improved consistency in coordinator label and volume claim policy validation when names are derived from generated prefixes.

* **Tests**
  * Added coverage for generated-name validation behavior and overlong derived resource names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->