### PR TITLE
fix flake for elastic job by using standard feature gate toggling

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -17,7 +17,6 @@ limitations under the License.
 package features
 
 import (
-	"fmt"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -82,11 +81,4 @@ func SetFeatureGateDuringTest(tb testing.TB, f featuregate.Feature, value bool) 
 // Enabled is helper for `utilfeature.DefaultFeatureGate.Enabled()`
 func Enabled(f featuregate.Feature) bool {
 	return utilfeature.DefaultFeatureGate.Enabled(f)
-}
-
-// SetEnable helper function that can be used to set the enabled value of a feature gate,
-// it should only be used in integration test pending the merge of
-// https://github.com/kubernetes/kubernetes/pull/118346
-func SetEnable(f featuregate.Feature, v bool) error {
-	return utilfeature.DefaultMutableFeatureGate.Set(fmt.Sprintf("%s=%v", f, v))
 }

--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -791,7 +791,7 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 		}),
 		ginkgo.Entry("[failure policy] jobset restarts with RestartJobSet failure policy action (with RestartJob feature gate).", &testCase{
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
-				gomega.Expect(features.SetEnable(features.RestartJob, true)).To(gomega.Succeed())
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.RestartJob, true)
 				return testJobSet(ns).
 					FailurePolicy(&jobset.FailurePolicy{
 						MaxRestarts: 1,
@@ -826,7 +826,8 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 		}),
 		ginkgo.Entry("[failure policy] jobset restarts with RestartJob failure policy action.", &testCase{
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
-				gomega.Expect(features.SetEnable(features.RestartJob, true)).To(gomega.Succeed())
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.RestartJob, true)
+
 				return testJobSet(ns).
 					FailurePolicy(&jobset.FailurePolicy{
 						MaxRestarts: 1,
@@ -861,7 +862,7 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 		}),
 		ginkgo.Entry("[failure policy] jobset restarts with RestartJobAndIgnoreMaxRestarts failure policy action.", &testCase{
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
-				gomega.Expect(features.SetEnable(features.RestartJob, true)).To(gomega.Succeed())
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.RestartJob, true)
 				return testJobSet(ns).
 					FailurePolicy(&jobset.FailurePolicy{
 						MaxRestarts: 1,
@@ -1084,7 +1085,7 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 		}),
 		ginkgo.Entry("[failure policy] jobset restarts with RestartJobSetAndIgnoreMaxRestarts failure policy action (with RestartJob feature gate).", &testCase{
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
-				gomega.Expect(features.SetEnable(features.RestartJob, true)).To(gomega.Succeed())
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.RestartJob, true)
 				return testJobSet(ns).
 					FailurePolicy(&jobset.FailurePolicy{
 						MaxRestarts: 1,
@@ -3132,18 +3133,9 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 
 	ginkgo.When("the ElasticJobSet feature gate is enabled", func() {
 
-		ginkgo.BeforeEach(func() {
-			err := features.SetEnable(features.ElasticJobSet, true)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		})
-
-		ginkgo.AfterEach(func() {
-			err := features.SetEnable(features.ElasticJobSet, false)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		})
-
 		ginkgo.DescribeTable("Elastic scaling behavior",
 			func(tc *testCase) {
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobSet, true)
 				ctx := context.Background()
 				// Create test namespace for each entry.
 				ns := &corev1.Namespace{
@@ -3281,15 +3273,11 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 
 	ginkgo.When("the ElasticJobSet feature gate is disabled", func() {
 
-		ginkgo.BeforeEach(func() {
-			// Explicitly turn the feature gate OFF
-			err := features.SetEnable(features.ElasticJobSet, false)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		})
-
 		ginkgo.DescribeTable("Elastic scaling behavior is blocked",
 			func(tc *testCase) {
 				ctx := context.Background()
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobSet, false)
+
 				ns := &corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "jobset-ns-",

--- a/test/integration/webhook/jobset_webhook_test.go
+++ b/test/integration/webhook/jobset_webhook_test.go
@@ -48,8 +48,7 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 	ginkgo.BeforeEach(func() {
 
 		// Ensure feature gate is off by default for all standard tests
-		err := features.SetEnable(features.ElasticJobSet, false)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobSet, false)
 
 		// Create test namespace before each test.
 		ns = &corev1.Namespace{
@@ -777,8 +776,7 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 			},
 			updateJobSet: func(js *jobset.JobSet) {
 				// Turn the feature gate ON just before we hit the update webhook
-				err := features.SetEnable(features.ElasticJobSet, true)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobSet, true)
 
 				js.Spec.ReplicatedJobs[0].Template.Spec.Parallelism = ptr.To[int32](4)
 				js.Spec.ReplicatedJobs[0].Template.Spec.Completions = ptr.To[int32](4)
@@ -797,8 +795,7 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 						Obj())
 			},
 			updateJobSet: func(js *jobset.JobSet) {
-				err := features.SetEnable(features.ElasticJobSet, true)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobSet, true)
 
 				js.Spec.ReplicatedJobs[0].Template.Spec.Parallelism = ptr.To[int32](4)
 				js.Spec.ReplicatedJobs[0].Template.Spec.Completions = ptr.To[int32](5) // Mismatched values
@@ -818,8 +815,7 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 						Obj())
 			},
 			updateJobSet: func(js *jobset.JobSet) {
-				err := features.SetEnable(features.ElasticJobSet, true)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobSet, true)
 
 				js.Spec.ReplicatedJobs[0].Template.Spec.Parallelism = ptr.To[int32](4)
 				js.Spec.ReplicatedJobs[0].Template.Spec.Completions = ptr.To[int32](4)
@@ -839,8 +835,7 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 						Obj())
 			},
 			updateJobSet: func(js *jobset.JobSet) {
-				err := features.SetEnable(features.ElasticJobSet, true)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobSet, true)
 
 				js.Spec.ReplicatedJobs[0].Template.Spec.Parallelism = ptr.To[int32](0) // Invalid scale
 				js.Spec.ReplicatedJobs[0].Template.Spec.Completions = ptr.To[int32](0)
@@ -861,8 +856,7 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 			},
 			updateJobSet: func(js *jobset.JobSet) {
 				// Ensure the feature gate is OFF (testing the default behavior)
-				err := features.SetEnable(features.ElasticJobSet, false)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobSet, false)
 
 				js.Spec.ReplicatedJobs[0].Template.Spec.Parallelism = ptr.To[int32](4)
 				js.Spec.ReplicatedJobs[0].Template.Spec.Completions = ptr.To[int32](4)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix flake for elastic jobs.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1258 

#### Special notes for your reviewer:

A little boy scouting but the SetEnabled was an odd pattern.

Tests should not have side effects.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated integration and webhook tests to configure feature gates per test case using the dedicated test-only gate helper.
  * Ensures “RestartJob” and “ElasticJobSet” scenarios enable/disable the feature at the start of each relevant table entry, improving isolation and reliability for elastic scaling and webhook behavior coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->