### PR TITLE
KEP-1150: Enable MutablePod resources with JobSet

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -124,6 +124,12 @@ const (
 	// The event uses the error(s) as the message.
 	PVCCreationFailedReason = "PVCCreationFailed"
 
+	// Event reason used when propagating mutated container/initContainer resources from a
+	// suspended ReplicatedJob's pod template to a child Job fails on resume, e.g. because
+	// the Kubernetes MutablePodResourcesForSuspendedJobs feature gate is not enabled.
+	// The event uses the error(s) as the message.
+	FailedResourcePropagationReason = "FailedResourcePropagation"
+
 	// Event reason and message related to applying the RestartJob failure policy action.
 	RestartJobActionReason  = "RestartJobFailurePolicyAction"
 	RestartJobActionMessage = "applying RestartJob failure policy action"

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -674,11 +674,50 @@ func (r *JobSetReconciler) resumeJob(ctx context.Context, job *batchv1.Job, repl
 			job.Spec.Template.Spec.SchedulingGates,
 			replicatedJobPodTemplate.Spec.SchedulingGates,
 		)
+		// Container/InitContainer resource requests/limits may also be mutated while the
+		// JobSet is suspended (e.g., by Kueue/DWS for right-sizing). Propagate the latest
+		// values from the ReplicatedJob's pod template to the child Job's containers,
+		// matched by container name, when the Job is resumed.
+		if features.Enabled(features.SuspendedJobResourceMutation) {
+			job.Spec.Template.Spec.Containers = mergeContainerResources(
+				job.Spec.Template.Spec.Containers,
+				replicatedJobPodTemplate.Spec.Containers,
+			)
+			job.Spec.Template.Spec.InitContainers = mergeContainerResources(
+				job.Spec.Template.Spec.InitContainers,
+				replicatedJobPodTemplate.Spec.InitContainers,
+			)
+		}
 	} else {
 		log.Error(nil, "job missing ReplicatedJobName label")
 	}
 	job.Spec.Suspend = ptr.To(false)
 	return r.Update(ctx, job)
+}
+
+// mergeContainerResources returns a copy of jobContainers where the Resources field
+// (requests/limits) of each container is replaced with the Resources of the container
+// with the same name in templateContainers, if one exists. This is used to propagate
+// resource mutations made to the ReplicatedJob's pod template while the JobSet was
+// suspended to the child Job's containers when the Job is resumed.
+func mergeContainerResources(jobContainers, templateContainers []corev1.Container) []corev1.Container {
+	if len(jobContainers) == 0 {
+		return jobContainers
+	}
+
+	templateResourcesByName := make(map[string]corev1.ResourceRequirements, len(templateContainers))
+	for _, container := range templateContainers {
+		templateResourcesByName[container.Name] = container.Resources
+	}
+
+	merged := make([]corev1.Container, len(jobContainers))
+	copy(merged, jobContainers)
+	for i := range merged {
+		if resources, exists := templateResourcesByName[merged[i].Name]; exists {
+			merged[i].Resources = resources
+		}
+	}
+	return merged
 }
 
 func (r *JobSetReconciler) reconcileReplicatedJobs(ctx context.Context, js *jobset.JobSet, ownedJobs *childJobs, replicatedJobStatuses []jobset.ReplicatedJobStatus, updateStatusOpts *statusUpdateOpts) error {

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -791,11 +791,64 @@ func (r *JobSetReconciler) resumeJob(ctx context.Context, js *jobset.JobSet, job
 			}
 			job.Annotations[constants.ExecutionAttemptsKey] = attemptsStr
 		}
+
+		// Container/InitContainer resource requests/limits may also be mutated while the
+		// JobSet is suspended (e.g., by Kueue/DWS for right-sizing). Propagate the latest
+		// values from the ReplicatedJob's pod template to the child Job's containers,
+		// matched by container name, when the Job is resumed.
+		if features.Enabled(features.MutablePodResourcesForSuspendedJobSets) {
+			job.Spec.Template.Spec.Containers = mergeContainerResources(
+				job.Spec.Template.Spec.Containers,
+				replicatedJobPodTemplate.Spec.Containers,
+			)
+			job.Spec.Template.Spec.InitContainers = mergeContainerResources(
+				job.Spec.Template.Spec.InitContainers,
+				replicatedJobPodTemplate.Spec.InitContainers,
+			)
+		}
 	} else {
 		log.Error(nil, "job missing ReplicatedJobName label")
 	}
 	job.Spec.Suspend = ptr.To(false)
-	return r.Update(ctx, job)
+	if err := r.Update(ctx, job); err != nil {
+		// If container/initContainer resources were mutated while suspended, a rejected
+		// update here likely means the Kubernetes MutablePodResourcesForSuspendedJobs
+		// feature gate is not enabled on the API server. Surface this via a Warning event
+		// rather than only retrying silently in the reconcile backoff.
+		if features.Enabled(features.MutablePodResourcesForSuspendedJobSets) {
+			r.Record.Eventf(js, nil, corev1.EventTypeWarning, constants.FailedResourcePropagationReason, "Reconciling",
+				"Failed to propagate mutated resources to child Job %s: %v. Ensure MutablePodResourcesForSuspendedJobs is enabled on the API server.", job.Name, err)
+		}
+		return err
+	}
+	return nil
+}
+
+// mergeContainerResources returns a copy of jobContainers where the Requests and Limits
+// of each container's Resources are replaced with those of the container with the same
+// name in templateContainers, if one exists. resources.claims is left untouched, since it
+// is not a mutable field. This is used to propagate resource mutations made to the
+// ReplicatedJob's pod template while the JobSet was suspended to the child Job's
+// containers when the Job is resumed.
+func mergeContainerResources(jobContainers, templateContainers []corev1.Container) []corev1.Container {
+	if len(jobContainers) == 0 {
+		return jobContainers
+	}
+
+	templateResourcesByName := make(map[string]corev1.ResourceRequirements, len(templateContainers))
+	for _, container := range templateContainers {
+		templateResourcesByName[container.Name] = container.Resources
+	}
+
+	merged := make([]corev1.Container, len(jobContainers))
+	copy(merged, jobContainers)
+	for i := range merged {
+		if resources, exists := templateResourcesByName[merged[i].Name]; exists {
+			merged[i].Resources.Requests = resources.Requests
+			merged[i].Resources.Limits = resources.Limits
+		}
+	}
+	return merged
 }
 
 func (r *JobSetReconciler) reconcileReplicatedJobs(ctx context.Context, js *jobset.JobSet, ownedJobs *childJobs, replicatedJobStatuses []jobset.ReplicatedJobStatus, updateStatusOpts *statusUpdateOpts) error {

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -2930,3 +2930,81 @@ func TestSyncExecutionAttempts(t *testing.T) {
 		})
 	}
 }
+
+func TestMergeContainerResources(t *testing.T) {
+	cpu1 := corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")}
+	cpu2 := corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")}
+	claims := []corev1.ResourceClaim{{Name: "original-claim"}}
+
+	tests := []struct {
+		name               string
+		jobContainers      []corev1.Container
+		templateContainers []corev1.Container
+		want               []corev1.Container
+	}{
+		{
+			name:               "no job containers is a no-op",
+			jobContainers:      nil,
+			templateContainers: []corev1.Container{{Name: "c", Resources: corev1.ResourceRequirements{Requests: cpu2}}},
+			want:               nil,
+		},
+		{
+			name: "resources updated for container matched by name",
+			jobContainers: []corev1.Container{
+				{Name: "c", Image: "image:v1", Resources: corev1.ResourceRequirements{Requests: cpu1}},
+			},
+			templateContainers: []corev1.Container{
+				{Name: "c", Resources: corev1.ResourceRequirements{Requests: cpu2}},
+			},
+			want: []corev1.Container{
+				{Name: "c", Image: "image:v1", Resources: corev1.ResourceRequirements{Requests: cpu2}},
+			},
+		},
+		{
+			name: "resources.claims are preserved from the job container, not overwritten by the template",
+			jobContainers: []corev1.Container{
+				{Name: "c", Resources: corev1.ResourceRequirements{Requests: cpu1, Claims: claims}},
+			},
+			templateContainers: []corev1.Container{
+				{Name: "c", Resources: corev1.ResourceRequirements{Requests: cpu2}},
+			},
+			want: []corev1.Container{
+				{Name: "c", Resources: corev1.ResourceRequirements{Requests: cpu2, Claims: claims}},
+			},
+		},
+		{
+			name: "container with no match in template is left unchanged",
+			jobContainers: []corev1.Container{
+				{Name: "c", Resources: corev1.ResourceRequirements{Requests: cpu1}},
+			},
+			templateContainers: []corev1.Container{
+				{Name: "other", Resources: corev1.ResourceRequirements{Requests: cpu2}},
+			},
+			want: []corev1.Container{
+				{Name: "c", Resources: corev1.ResourceRequirements{Requests: cpu1}},
+			},
+		},
+		{
+			name: "only containers matched by name are updated, others are left as-is",
+			jobContainers: []corev1.Container{
+				{Name: "init", Resources: corev1.ResourceRequirements{Requests: cpu1}},
+				{Name: "c", Resources: corev1.ResourceRequirements{Requests: cpu1}},
+			},
+			templateContainers: []corev1.Container{
+				{Name: "c", Resources: corev1.ResourceRequirements{Requests: cpu2}},
+			},
+			want: []corev1.Container{
+				{Name: "init", Resources: corev1.ResourceRequirements{Requests: cpu1}},
+				{Name: "c", Resources: corev1.ResourceRequirements{Requests: cpu2}},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeContainerResources(tc.jobContainers, tc.templateContainers)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("mergeContainerResources() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -52,6 +52,16 @@ const (
 	// ElasticJobSet enables the mutation of parallelism and completions for ReplicatedJobs
 	// to support dynamic horizontal pod-level scaling.
 	ElasticJobSet featuregate.Feature = "ElasticJobSet"
+
+	// owner: @kannon92
+	// kep: https://kep.k8s.io/5440
+	//
+	// SuspendedJobResourceMutation enables mutation of container/initContainer resource
+	// requests/limits on a ReplicatedJob's pod template while the JobSet is suspended (or
+	// getting suspended), so that integrators (e.g., Kueue/DWS) can right-size Pods before
+	// the JobSet is resumed. This relies on the Kubernetes `MutablePodResourcesForSuspendedJobs`
+	// feature gate, which was introduced as alpha (disabled by default) in Kubernetes 1.35.
+	SuspendedJobResourceMutation featuregate.Feature = "SuspendedJobResourceMutation"
 )
 
 func init() {
@@ -72,6 +82,8 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	RestartJob: {Default: false, PreRelease: featuregate.Alpha},
 
 	ElasticJobSet: {Default: false, PreRelease: featuregate.Alpha},
+
+	SuspendedJobResourceMutation: {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func SetFeatureGateDuringTest(tb testing.TB, f featuregate.Feature, value bool) {

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -54,7 +54,6 @@ const (
 	ElasticJobSet featuregate.Feature = "ElasticJobSet"
 
 	// owner: @kannon92
-	// kep: https://kep.k8s.io/5440
 	//
 	// SuspendedJobResourceMutation enables mutation of container/initContainer resource
 	// requests/limits on a ReplicatedJob's pod template while the JobSet is suspended (or

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -59,6 +59,15 @@ const (
 	//
 	// Enables tracking and propagating JobSet execution attempts as a monotonic counter.
 	ExecutionAttemptsTracking featuregate.Feature = "ExecutionAttemptsTracking"
+
+	// owner: @kannon92
+	//
+	// MutablePodResourcesForSuspendedJobSets enables mutation of container/initContainer resource
+	// requests/limits on a ReplicatedJob's pod template while the JobSet is suspended (or
+	// getting suspended), so that integrators (e.g., Kueue/DWS) can right-size Pods before
+	// the JobSet is resumed. This relies on the Kubernetes `MutablePodResourcesForSuspendedJobs`
+	// feature gate, which was introduced as alpha (disabled by default) in Kubernetes 1.35.
+	MutablePodResourcesForSuspendedJobSets featuregate.Feature = "MutablePodResourcesForSuspendedJobSets"
 )
 
 func init() {
@@ -81,6 +90,8 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ElasticJobSet: {Default: false, PreRelease: featuregate.Alpha},
 
 	ExecutionAttemptsTracking: {Default: false, PreRelease: featuregate.Alpha},
+
+	MutablePodResourcesForSuspendedJobSets: {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func SetFeatureGateDuringTest(tb testing.TB, f featuregate.Feature, value bool) {

--- a/pkg/webhooks/jobset_webhook.go
+++ b/pkg/webhooks/jobset_webhook.go
@@ -390,6 +390,22 @@ func (j *jobSetWebhook) ValidateUpdate(ctx context.Context, oldJs, newJs *jobset
 
 			// Pod Scheduling Gates can be updated for batch/v1 Job: https://github.com/kubernetes/kubernetes/blob/ceb58a4dbc671b9d0a2de6d73a1616bc0c299863/pkg/apis/batch/validation/validation.go#L662
 			mungedSpec.ReplicatedJobs[index].Template.Spec.Template.Spec.SchedulingGates = oldRJob.Template.Spec.Template.Spec.SchedulingGates
+
+			// Allow container/initContainer resource requests/limits to be mutated while suspended,
+			// so that integrators (e.g., Kueue/DWS) can right-size Pods before the JobSet is resumed.
+			// Gated behind SuspendedJobResourceMutation since it relies on the Kubernetes
+			// `MutablePodResourcesForSuspendedJobs` feature gate, which is alpha (disabled by
+			// default) as of Kubernetes 1.35.
+			if features.Enabled(features.SuspendedJobResourceMutation) {
+				mungedSpec.ReplicatedJobs[index].Template.Spec.Template.Spec.Containers = mungeContainerResources(
+					newRJob.Template.Spec.Template.Spec.Containers,
+					oldRJob.Template.Spec.Template.Spec.Containers,
+				)
+				mungedSpec.ReplicatedJobs[index].Template.Spec.Template.Spec.InitContainers = mungeContainerResources(
+					newRJob.Template.Spec.Template.Spec.InitContainers,
+					oldRJob.Template.Spec.Template.Spec.InitContainers,
+				)
+			}
 		}
 	}
 
@@ -667,6 +683,32 @@ func hasVolumeMount(volumeMounts []corev1.VolumeMount, volumeMountName string) b
 		}
 	}
 	return false
+}
+
+// mungeContainerResources returns a copy of newContainers where the Resources field
+// (requests/limits) of each container is replaced with the Resources of the container
+// with the same name in oldContainers, if one exists. This allows JobSet to permit
+// mutation of container resource requests/limits while a JobSet is suspended (needed
+// for integration with Kueue/DWS), without bypassing immutability checks for any other
+// container field, such as image or command.
+func mungeContainerResources(newContainers, oldContainers []corev1.Container) []corev1.Container {
+	if len(newContainers) == 0 {
+		return newContainers
+	}
+
+	oldResourcesByName := make(map[string]corev1.ResourceRequirements, len(oldContainers))
+	for _, container := range oldContainers {
+		oldResourcesByName[container.Name] = container.Resources
+	}
+
+	munged := make([]corev1.Container, len(newContainers))
+	copy(munged, newContainers)
+	for i := range munged {
+		if oldResources, exists := oldResourcesByName[munged[i].Name]; exists {
+			munged[i].Resources = oldResources
+		}
+	}
+	return munged
 }
 
 // replicatedJobByName fetches the replicatedJob spec from the JobSet by name.

--- a/pkg/webhooks/jobset_webhook.go
+++ b/pkg/webhooks/jobset_webhook.go
@@ -390,6 +390,22 @@ func (j *jobSetWebhook) ValidateUpdate(ctx context.Context, oldJs, newJs *jobset
 
 			// Pod Scheduling Gates can be updated for batch/v1 Job: https://github.com/kubernetes/kubernetes/blob/ceb58a4dbc671b9d0a2de6d73a1616bc0c299863/pkg/apis/batch/validation/validation.go#L662
 			mungedSpec.ReplicatedJobs[index].Template.Spec.Template.Spec.SchedulingGates = oldRJob.Template.Spec.Template.Spec.SchedulingGates
+
+			// Allow container/initContainer resource requests/limits to be mutated while suspended,
+			// so that integrators (e.g., Kueue/DWS) can right-size Pods before the JobSet is resumed.
+			// Gated behind MutablePodResourcesForSuspendedJobSets since it relies on the Kubernetes
+			// `MutablePodResourcesForSuspendedJobs` feature gate, which is alpha (disabled by
+			// default) as of Kubernetes 1.35.
+			if features.Enabled(features.MutablePodResourcesForSuspendedJobSets) {
+				mungedSpec.ReplicatedJobs[index].Template.Spec.Template.Spec.Containers = mungeContainerResources(
+					newRJob.Template.Spec.Template.Spec.Containers,
+					oldRJob.Template.Spec.Template.Spec.Containers,
+				)
+				mungedSpec.ReplicatedJobs[index].Template.Spec.Template.Spec.InitContainers = mungeContainerResources(
+					newRJob.Template.Spec.Template.Spec.InitContainers,
+					oldRJob.Template.Spec.Template.Spec.InitContainers,
+				)
+			}
 		}
 	}
 
@@ -667,6 +683,33 @@ func hasVolumeMount(volumeMounts []corev1.VolumeMount, volumeMountName string) b
 		}
 	}
 	return false
+}
+
+// mungeContainerResources returns a copy of newContainers where the Requests and Limits
+// of each container's Resources are replaced with those of the container with the same
+// name in oldContainers, if one exists. This allows JobSet to permit mutation of container
+// resource requests/limits while a JobSet is suspended (needed for integration with
+// Kueue/DWS), without bypassing immutability checks for any other container field, such
+// as image, command, or resources.claims.
+func mungeContainerResources(newContainers, oldContainers []corev1.Container) []corev1.Container {
+	if len(newContainers) == 0 {
+		return newContainers
+	}
+
+	oldResourcesByName := make(map[string]corev1.ResourceRequirements, len(oldContainers))
+	for _, container := range oldContainers {
+		oldResourcesByName[container.Name] = container.Resources
+	}
+
+	munged := make([]corev1.Container, len(newContainers))
+	copy(munged, newContainers)
+	for i := range munged {
+		if oldResources, exists := oldResourcesByName[munged[i].Name]; exists {
+			munged[i].Resources.Requests = oldResources.Requests
+			munged[i].Resources.Limits = oldResources.Limits
+		}
+	}
+	return munged
 }
 
 // replicatedJobByName fetches the replicatedJob spec from the JobSet by name.

--- a/pkg/webhooks/jobset_webhook_test.go
+++ b/pkg/webhooks/jobset_webhook_test.go
@@ -3250,11 +3250,12 @@ func TestValidateUpdate(t *testing.T) {
 		},
 	}
 	testCases := []struct {
-		name                string
-		oldJs               *jobset.JobSet
-		js                  *jobset.JobSet
-		want                error
-		enableElasticJobSet bool
+		name                            string
+		oldJs                           *jobset.JobSet
+		js                              *jobset.JobSet
+		want                            error
+		enableElasticJobSet             bool
+		enableSuspendedResourceMutation bool
 	}{
 		{
 			name: "update suspend",
@@ -3530,6 +3531,210 @@ func TestValidateUpdate(t *testing.T) {
 			want: field.ErrorList{
 				field.Invalid(field.NewPath("spec").Child("replicatedJobs"), "", "field is immutable"),
 			}.ToAggregate(),
+		},
+		{
+			name: "container resource requests/limits can be updated for suspended JobSet",
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](2),
+									Template: corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name: "c",
+													// Updated resource requests/limits.
+													Resources: corev1.ResourceRequirements{
+														Requests: corev1.ResourceList{
+															corev1.ResourceCPU: resource.MustParse("2"),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			oldJs: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					Suspend: ptr.To(true),
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](2),
+									Template: corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name: "c",
+													Resources: corev1.ResourceRequirements{
+														Requests: corev1.ResourceList{
+															corev1.ResourceCPU: resource.MustParse("1"),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			enableSuspendedResourceMutation: true,
+		},
+		{
+			name: "container resource requests/limits cannot be updated for suspended JobSet when feature gate is disabled",
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](2),
+									Template: corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name: "c",
+													// Updated resource requests/limits.
+													Resources: corev1.ResourceRequirements{
+														Requests: corev1.ResourceList{
+															corev1.ResourceCPU: resource.MustParse("2"),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			oldJs: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					Suspend: ptr.To(true),
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](2),
+									Template: corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name: "c",
+													Resources: corev1.ResourceRequirements{
+														Requests: corev1.ResourceList{
+															corev1.ResourceCPU: resource.MustParse("1"),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: field.ErrorList{
+				field.Invalid(field.NewPath("spec").Child("replicatedJobs"), "", "field is immutable"),
+			}.ToAggregate(),
+			// enableSuspendedResourceMutation intentionally left false (default) to verify the
+			// mutation is rejected when the feature gate is disabled.
+		},
+		{
+			name: "container resource requests/limits cannot be updated for running JobSet",
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](2),
+									Template: corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name: "c",
+													// Updated resource requests/limits.
+													Resources: corev1.ResourceRequirements{
+														Requests: corev1.ResourceList{
+															corev1.ResourceCPU: resource.MustParse("2"),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			oldJs: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](2),
+									Template: corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name: "c",
+													Resources: corev1.ResourceRequirements{
+														Requests: corev1.ResourceList{
+															corev1.ResourceCPU: resource.MustParse("1"),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: field.ErrorList{
+				field.Invalid(field.NewPath("spec").Child("replicatedJobs"), "", "field is immutable"),
+			}.ToAggregate(),
+			enableSuspendedResourceMutation: true,
 		},
 		{
 			name: "replicated job name cannot be updated",
@@ -4032,6 +4237,7 @@ func TestValidateUpdate(t *testing.T) {
 			fakeClient := fake.NewFakeClient()
 			webhook := &jobSetWebhook{client: fakeClient}
 			features.SetFeatureGateDuringTest(t, features.ElasticJobSet, tc.enableElasticJobSet)
+			features.SetFeatureGateDuringTest(t, features.SuspendedJobResourceMutation, tc.enableSuspendedResourceMutation)
 			newObj := tc.js.DeepCopy()
 			oldObj := tc.oldJs.DeepCopy()
 			_, err := webhook.ValidateUpdate(context.TODO(), oldObj, newObj)

--- a/pkg/webhooks/jobset_webhook_test.go
+++ b/pkg/webhooks/jobset_webhook_test.go
@@ -3250,11 +3250,12 @@ func TestValidateUpdate(t *testing.T) {
 		},
 	}
 	testCases := []struct {
-		name                string
-		oldJs               *jobset.JobSet
-		js                  *jobset.JobSet
-		want                error
-		enableElasticJobSet bool
+		name                            string
+		oldJs                           *jobset.JobSet
+		js                              *jobset.JobSet
+		want                            error
+		enableElasticJobSet             bool
+		enableSuspendedResourceMutation bool
 	}{
 		{
 			name: "update suspend",
@@ -3530,6 +3531,356 @@ func TestValidateUpdate(t *testing.T) {
 			want: field.ErrorList{
 				field.Invalid(field.NewPath("spec").Child("replicatedJobs"), "", "field is immutable"),
 			}.ToAggregate(),
+		},
+		{
+			name: "container resource requests/limits can be updated for suspended JobSet",
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](2),
+									Template: corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name: "c",
+													// Updated resource requests/limits.
+													Resources: corev1.ResourceRequirements{
+														Requests: corev1.ResourceList{
+															corev1.ResourceCPU: resource.MustParse("2"),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			oldJs: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					Suspend: ptr.To(true),
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](2),
+									Template: corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name: "c",
+													Resources: corev1.ResourceRequirements{
+														Requests: corev1.ResourceList{
+															corev1.ResourceCPU: resource.MustParse("1"),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			enableSuspendedResourceMutation: true,
+		},
+		{
+			name: "container resource requests/limits cannot be updated for suspended JobSet when feature gate is disabled",
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](2),
+									Template: corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name: "c",
+													// Updated resource requests/limits.
+													Resources: corev1.ResourceRequirements{
+														Requests: corev1.ResourceList{
+															corev1.ResourceCPU: resource.MustParse("2"),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			oldJs: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					Suspend: ptr.To(true),
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](2),
+									Template: corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name: "c",
+													Resources: corev1.ResourceRequirements{
+														Requests: corev1.ResourceList{
+															corev1.ResourceCPU: resource.MustParse("1"),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: field.ErrorList{
+				field.Invalid(field.NewPath("spec").Child("replicatedJobs"), "", "field is immutable"),
+			}.ToAggregate(),
+			// enableSuspendedResourceMutation intentionally left false (default) to verify the
+			// mutation is rejected when the feature gate is disabled.
+		},
+		{
+			name: "container resource requests/limits cannot be updated for running JobSet",
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](2),
+									Template: corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name: "c",
+													// Updated resource requests/limits.
+													Resources: corev1.ResourceRequirements{
+														Requests: corev1.ResourceList{
+															corev1.ResourceCPU: resource.MustParse("2"),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			oldJs: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](2),
+									Template: corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name: "c",
+													Resources: corev1.ResourceRequirements{
+														Requests: corev1.ResourceList{
+															corev1.ResourceCPU: resource.MustParse("1"),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: field.ErrorList{
+				field.Invalid(field.NewPath("spec").Child("replicatedJobs"), "", "field is immutable"),
+			}.ToAggregate(),
+			enableSuspendedResourceMutation: true,
+		},
+		{
+			name: "container resource claims cannot be updated for suspended JobSet even when feature gate is enabled",
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](2),
+									Template: corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name: "c",
+													Resources: corev1.ResourceRequirements{
+														Requests: corev1.ResourceList{
+															corev1.ResourceCPU: resource.MustParse("1"),
+														},
+														// Attempting to change claims, which must remain immutable.
+														Claims: []corev1.ResourceClaim{
+															{Name: "new-claim"},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			oldJs: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					Suspend: ptr.To(true),
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](2),
+									Template: corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name: "c",
+													Resources: corev1.ResourceRequirements{
+														Requests: corev1.ResourceList{
+															corev1.ResourceCPU: resource.MustParse("1"),
+														},
+														Claims: []corev1.ResourceClaim{
+															{Name: "original-claim"},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: field.ErrorList{
+				field.Invalid(field.NewPath("spec").Child("replicatedJobs"), "", "field is immutable"),
+			}.ToAggregate(),
+			enableSuspendedResourceMutation: true,
+		},
+		{
+			name: "adding a container while mutating resources for suspended JobSet is not allowed",
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](2),
+									Template: corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name: "c",
+													Resources: corev1.ResourceRequirements{
+														Requests: corev1.ResourceList{
+															corev1.ResourceCPU: resource.MustParse("2"),
+														},
+													},
+												},
+												{
+													Name: "new-sidecar",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			oldJs: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					Suspend: ptr.To(true),
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:     "test-jobset-replicated-job-0",
+							Replicas: 2,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Parallelism: ptr.To[int32](2),
+									Template: corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name: "c",
+													Resources: corev1.ResourceRequirements{
+														Requests: corev1.ResourceList{
+															corev1.ResourceCPU: resource.MustParse("1"),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: field.ErrorList{
+				field.Invalid(field.NewPath("spec").Child("replicatedJobs"), "", "field is immutable"),
+			}.ToAggregate(),
+			enableSuspendedResourceMutation: true,
 		},
 		{
 			name: "replicated job name cannot be updated",
@@ -4032,6 +4383,7 @@ func TestValidateUpdate(t *testing.T) {
 			fakeClient := fake.NewFakeClient()
 			webhook := &jobSetWebhook{client: fakeClient}
 			features.SetFeatureGateDuringTest(t, features.ElasticJobSet, tc.enableElasticJobSet)
+			features.SetFeatureGateDuringTest(t, features.MutablePodResourcesForSuspendedJobSets, tc.enableSuspendedResourceMutation)
 			newObj := tc.js.DeepCopy()
 			oldObj := tc.oldJs.DeepCopy()
 			_, err := webhook.ValidateUpdate(context.TODO(), oldObj, newObj)

--- a/test/e2e/customconfigs/suspendedjobresourcemutation_test.go
+++ b/test/e2e/customconfigs/suspendedjobresourcemutation_test.go
@@ -1,0 +1,303 @@
+/*
+Copyright The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customconfigs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configv1alpha1 "sigs.k8s.io/jobset/api/config/v1alpha1"
+	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+	"sigs.k8s.io/jobset/pkg/features"
+	testingutil "sigs.k8s.io/jobset/pkg/util/testing"
+	"sigs.k8s.io/jobset/test/util"
+)
+
+// This test verifies that container resource requests/limits can be mutated
+// on a suspended JobSet, and that the mutated values are propagated to the
+// child Jobs (while still suspended) and eventually to the Pods once the
+// JobSet is resumed. This is needed for integration with Kueue/DWS to
+// right-size Pods before a workload is admitted.
+//
+// This relies on two feature gates being enabled:
+//  1. JobSet's own `SuspendedJobResourceMutation` feature gate (toggled below).
+//  2. The Kubernetes `MutablePodResourcesForSuspendedJobs` feature gate
+//     (KEP 5440), which must be enabled on the cluster's kube-apiserver.
+//     This feature gate was introduced as alpha (disabled by default) in
+//     Kubernetes 1.35. Without it enabled cluster-wide, kube-apiserver will
+//     reject the container resource mutation on the child Job object with an
+//     "field is immutable" error, regardless of the JobSet-side feature gate.
+var _ = ginkgo.Describe("SuspendedJobResourceMutation", ginkgo.Ordered, func() {
+	var ns *corev1.Namespace
+
+	ginkgo.BeforeAll(func() {
+		if !clusterSupportsMutablePodResources(ctx, k8sClient) {
+			ginkgo.Skip("cluster does not support MutablePodResourcesForSuspendedJobs (requires Kubernetes >= 1.35 with the alpha feature gate enabled)")
+		}
+
+		util.UpdateJobSetConfigurationAndRestart(ctx, k8sClient, defaultCfg, func(cfg *configv1alpha1.Configuration) {
+			cfg.FeatureGates = map[string]bool{string(features.SuspendedJobResourceMutation): true}
+		})
+	})
+
+	ginkgo.BeforeEach(func() {
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "e2e-customconfigs-",
+			},
+		}
+		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+
+		gomega.Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Namespace, Name: ns.Name}, ns)
+		}, timeout, interval).Should(gomega.Succeed())
+	})
+
+	ginkgo.AfterEach(func() {
+		if util.ShouldDumpNamespace() {
+			var printer printers.YAMLPrinter
+
+			ginkgo.By(fmt.Sprintf("dumping relevant resources in namespace %s", ns.Name))
+
+			var jobsets jobset.JobSetList
+			gomega.Expect(k8sClient.List(ctx, &jobsets, client.InNamespace(ns.Name))).To(gomega.Succeed())
+			for _, js := range jobsets.Items {
+				gomega.Expect(printer.PrintObj(&js, ginkgo.GinkgoWriter)).To(gomega.Succeed())
+			}
+
+			var jobs batchv1.JobList
+			gomega.Expect(k8sClient.List(ctx, &jobs, client.InNamespace(ns.Name))).To(gomega.Succeed())
+			for _, job := range jobs.Items {
+				job.SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   batchv1.SchemeGroupVersion.Group,
+					Version: batchv1.SchemeGroupVersion.Version,
+					Kind:    "Job",
+				})
+				gomega.Expect(printer.PrintObj(&job, ginkgo.GinkgoWriter)).To(gomega.Succeed())
+			}
+		}
+
+		gomega.Expect(k8sClient.Delete(ctx, ns)).To(gomega.Succeed())
+	})
+
+	ginkgo.When("JobSet is suspended", func() {
+		ginkgo.It("should allow mutating container resource requests and propagate them once resumed", func() {
+			const containerName = "test-container"
+			initialRequest := resource.MustParse("10m")
+			updatedRequest := resource.MustParse("20m")
+
+			js := suspendedResourceMutationTestJobSet(ns, containerName, initialRequest)
+			jsKey := types.NamespacedName{Name: js.Name, Namespace: js.Namespace}
+
+			ginkgo.By("creating a suspended JobSet with an initial resource request", func() {
+				gomega.Expect(k8sClient.Create(ctx, js)).To(gomega.Succeed())
+			})
+
+			ginkgo.By("waiting for the child Jobs to report Suspended=True and Active=0", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					var jobList batchv1.JobList
+					g.Expect(k8sClient.List(ctx, &jobList, client.InNamespace(ns.Name))).To(gomega.Succeed())
+					g.Expect(jobList.Items).To(gomega.HaveLen(util.NumExpectedJobs(js)))
+					for _, job := range jobList.Items {
+						g.Expect(job.Status.Active).To(gomega.Equal(int32(0)))
+						g.Expect(jobConditionStatus(&job, batchv1.JobSuspended)).To(gomega.Equal(corev1.ConditionTrue))
+					}
+				}, timeout, interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("mutating the container resource requests while the JobSet is suspended", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, jsKey, js)).To(gomega.Succeed())
+					containers := js.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Containers
+					for i := range containers {
+						containers[i].Resources.Requests = corev1.ResourceList{
+							corev1.ResourceCPU: updatedRequest,
+						}
+					}
+					g.Expect(k8sClient.Update(ctx, js)).To(gomega.Succeed())
+				}, timeout, interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("checking the JobSet spec reflects the mutated resource request while still suspended", func() {
+				// Note: the mutated value is only propagated down to the child Jobs/Pods
+				// when the JobSet is resumed (see resumeJob in the JobSet controller),
+				// mirroring the existing behavior for annotations/labels/nodeSelector/
+				// tolerations/schedulingGates. At this point we only confirm the JobSet
+				// API object itself accepted the mutation while suspended.
+				gomega.Expect(k8sClient.Get(ctx, jsKey, js)).To(gomega.Succeed())
+				container := findContainer(js.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Containers, containerName)
+				gomega.Expect(container).NotTo(gomega.BeNil())
+				gomega.Expect(container.Resources.Requests[corev1.ResourceCPU]).To(gomega.Equal(updatedRequest))
+			})
+
+			ginkgo.By("resuming the JobSet", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, jsKey, js)).To(gomega.Succeed())
+					js.Spec.Suspend = ptr.To(false)
+					g.Expect(k8sClient.Update(ctx, js)).To(gomega.Succeed())
+				}, timeout, interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("checking the running Pods use the updated resource requests", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					var podList corev1.PodList
+					g.Expect(k8sClient.List(ctx, &podList, client.InNamespace(ns.Name))).To(gomega.Succeed())
+					g.Expect(podList.Items).NotTo(gomega.BeEmpty())
+					for _, pod := range podList.Items {
+						container := findContainer(pod.Spec.Containers, containerName)
+						g.Expect(container).NotTo(gomega.BeNil())
+						g.Expect(container.Resources.Requests[corev1.ResourceCPU]).To(gomega.Equal(updatedRequest))
+					}
+				}, timeout, interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("checking the jobset completes successfully", func() {
+				util.JobSetCompleted(ctx, k8sClient, js, timeout)
+			})
+		})
+	})
+})
+
+// jobConditionStatus returns the status of the given Job condition type, or
+// corev1.ConditionUnknown if the condition is not present.
+func jobConditionStatus(job *batchv1.Job, conditionType batchv1.JobConditionType) corev1.ConditionStatus {
+	for _, cond := range job.Status.Conditions {
+		if cond.Type == conditionType {
+			return cond.Status
+		}
+	}
+	return corev1.ConditionUnknown
+}
+
+// findContainer returns a pointer to the container with the given name, or
+// nil if no such container exists.
+func findContainer(containers []corev1.Container, name string) *corev1.Container {
+	for i := range containers {
+		if containers[i].Name == name {
+			return &containers[i]
+		}
+	}
+	return nil
+}
+
+// clusterSupportsMutablePodResources probes whether the cluster's kube-apiserver
+// allows mutating container resources on a suspended Job. This requires the
+// Kubernetes MutablePodResourcesForSuspendedJobs feature gate (KEP 5440),
+// which is alpha (disabled by default) as of Kubernetes 1.35.
+func clusterSupportsMutablePodResources(ctx context.Context, c client.Client) bool {
+	probeNs := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{GenerateName: "probe-mutable-resources-"},
+	}
+	if err := c.Create(ctx, probeNs); err != nil {
+		return false
+	}
+	defer func() {
+		_ = c.Delete(ctx, probeNs)
+	}()
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "probe-mutable-resources",
+			Namespace: probeNs.Name,
+		},
+		Spec: batchv1.JobSpec{
+			Suspend: ptr.To(true),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					Containers: []corev1.Container{{
+						Name:  "probe",
+						Image: "busybox",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("10m"),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	if err := c.Create(ctx, job); err != nil {
+		return false
+	}
+	defer func() {
+		_ = c.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground))
+	}()
+
+	// Wait for the Job's Suspended condition to be set by the Job controller.
+	// The apiserver only allows pod template resource mutation on Jobs that
+	// have the Suspended condition, not merely spec.suspend=true.
+	jobKey := types.NamespacedName{Name: job.Name, Namespace: job.Namespace}
+	suspendedConditionReady := false
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect(c.Get(ctx, jobKey, job)).To(gomega.Succeed())
+		g.Expect(jobConditionStatus(job, batchv1.JobSuspended)).To(gomega.Equal(corev1.ConditionTrue))
+		suspendedConditionReady = true
+	}, timeout, interval).Should(gomega.Succeed())
+
+	if !suspendedConditionReady {
+		return false
+	}
+
+	// Try mutating the container resources. If the apiserver rejects this,
+	// the MutablePodResourcesForSuspendedJobs gate is not enabled.
+	job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("20m")
+	return c.Update(ctx, job) == nil
+}
+
+func suspendedResourceMutationTestJobSet(ns *corev1.Namespace, containerName string, initialCPURequest resource.Quantity) *jobset.JobSet {
+	jsName := "js-suspended-resource-mutation"
+	rjobName := "rjob"
+	replicas := 2
+
+	js := testingutil.MakeJobSet(jsName, ns.Name).
+		ReplicatedJob(testingutil.MakeReplicatedJob(rjobName).
+			Job(testingutil.MakeJobTemplate("job", ns.Name).
+				PodSpec(corev1.PodSpec{
+					RestartPolicy: "Never",
+					Containers: []corev1.Container{
+						{
+							Name:    containerName,
+							Image:   "docker.io/library/bash:latest",
+							Command: []string{"bash", "-c"},
+							Args:    []string{"sleep 1"},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: initialCPURequest,
+								},
+							},
+						},
+					},
+				}).Obj()).
+			Replicas(int32(replicas)).
+			Obj()).
+		Obj()
+
+	// Create the JobSet already suspended.
+	js.Spec.Suspend = ptr.To(true)
+	return js
+}

--- a/test/e2e/customconfigs/suspendedjobresourcemutation_test.go
+++ b/test/e2e/customconfigs/suspendedjobresourcemutation_test.go
@@ -1,0 +1,303 @@
+/*
+Copyright The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customconfigs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configv1alpha1 "sigs.k8s.io/jobset/api/config/v1alpha1"
+	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+	"sigs.k8s.io/jobset/pkg/features"
+	testingutil "sigs.k8s.io/jobset/pkg/util/testing"
+	"sigs.k8s.io/jobset/test/util"
+)
+
+// This test verifies that container resource requests/limits can be mutated
+// on a suspended JobSet, and that the mutated values are propagated to the
+// child Jobs (while still suspended) and eventually to the Pods once the
+// JobSet is resumed. This is needed for integration with Kueue/DWS to
+// right-size Pods before a workload is admitted.
+//
+// This relies on two feature gates being enabled:
+//  1. JobSet's own `MutablePodResourcesForSuspendedJobSets` feature gate (toggled below).
+//  2. The Kubernetes `MutablePodResourcesForSuspendedJobs` feature gate
+//     (KEP 5440), which must be enabled on the cluster's kube-apiserver.
+//     This feature gate was introduced as alpha (disabled by default) in
+//     Kubernetes 1.35. Without it enabled cluster-wide, kube-apiserver will
+//     reject the container resource mutation on the child Job object with an
+//     "field is immutable" error, regardless of the JobSet-side feature gate.
+var _ = ginkgo.Describe("MutablePodResourcesForSuspendedJobSets", ginkgo.Ordered, func() {
+	var ns *corev1.Namespace
+
+	ginkgo.BeforeAll(func() {
+		if !clusterSupportsMutablePodResources(ctx, k8sClient) {
+			ginkgo.Skip("cluster does not support MutablePodResourcesForSuspendedJobs (requires Kubernetes >= 1.35 with the alpha feature gate enabled)")
+		}
+
+		util.UpdateJobSetConfigurationAndRestart(ctx, k8sClient, defaultCfg, func(cfg *configv1alpha1.Configuration) {
+			cfg.FeatureGates = map[string]bool{string(features.MutablePodResourcesForSuspendedJobSets): true}
+		})
+	})
+
+	ginkgo.BeforeEach(func() {
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "e2e-customconfigs-",
+			},
+		}
+		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+
+		gomega.Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Namespace, Name: ns.Name}, ns)
+		}, timeout, interval).Should(gomega.Succeed())
+	})
+
+	ginkgo.AfterEach(func() {
+		if util.ShouldDumpNamespace() {
+			var printer printers.YAMLPrinter
+
+			ginkgo.By(fmt.Sprintf("dumping relevant resources in namespace %s", ns.Name))
+
+			var jobsets jobset.JobSetList
+			gomega.Expect(k8sClient.List(ctx, &jobsets, client.InNamespace(ns.Name))).To(gomega.Succeed())
+			for _, js := range jobsets.Items {
+				gomega.Expect(printer.PrintObj(&js, ginkgo.GinkgoWriter)).To(gomega.Succeed())
+			}
+
+			var jobs batchv1.JobList
+			gomega.Expect(k8sClient.List(ctx, &jobs, client.InNamespace(ns.Name))).To(gomega.Succeed())
+			for _, job := range jobs.Items {
+				job.SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   batchv1.SchemeGroupVersion.Group,
+					Version: batchv1.SchemeGroupVersion.Version,
+					Kind:    "Job",
+				})
+				gomega.Expect(printer.PrintObj(&job, ginkgo.GinkgoWriter)).To(gomega.Succeed())
+			}
+		}
+
+		gomega.Expect(k8sClient.Delete(ctx, ns)).To(gomega.Succeed())
+	})
+
+	ginkgo.When("JobSet is suspended", func() {
+		ginkgo.It("should allow mutating container resource requests and propagate them once resumed", func() {
+			const containerName = "test-container"
+			initialRequest := resource.MustParse("10m")
+			updatedRequest := resource.MustParse("20m")
+
+			js := suspendedResourceMutationTestJobSet(ns, containerName, initialRequest)
+			jsKey := types.NamespacedName{Name: js.Name, Namespace: js.Namespace}
+
+			ginkgo.By("creating a suspended JobSet with an initial resource request", func() {
+				gomega.Expect(k8sClient.Create(ctx, js)).To(gomega.Succeed())
+			})
+
+			ginkgo.By("waiting for the child Jobs to report Suspended=True and Active=0", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					var jobList batchv1.JobList
+					g.Expect(k8sClient.List(ctx, &jobList, client.InNamespace(ns.Name))).To(gomega.Succeed())
+					g.Expect(jobList.Items).To(gomega.HaveLen(util.NumExpectedJobs(js)))
+					for _, job := range jobList.Items {
+						g.Expect(job.Status.Active).To(gomega.Equal(int32(0)))
+						g.Expect(jobConditionStatus(&job, batchv1.JobSuspended)).To(gomega.Equal(corev1.ConditionTrue))
+					}
+				}, timeout, interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("mutating the container resource requests while the JobSet is suspended", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, jsKey, js)).To(gomega.Succeed())
+					containers := js.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Containers
+					for i := range containers {
+						containers[i].Resources.Requests = corev1.ResourceList{
+							corev1.ResourceCPU: updatedRequest,
+						}
+					}
+					g.Expect(k8sClient.Update(ctx, js)).To(gomega.Succeed())
+				}, timeout, interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("checking the JobSet spec reflects the mutated resource request while still suspended", func() {
+				// Note: the mutated value is only propagated down to the child Jobs/Pods
+				// when the JobSet is resumed (see resumeJob in the JobSet controller),
+				// mirroring the existing behavior for annotations/labels/nodeSelector/
+				// tolerations/schedulingGates. At this point we only confirm the JobSet
+				// API object itself accepted the mutation while suspended.
+				gomega.Expect(k8sClient.Get(ctx, jsKey, js)).To(gomega.Succeed())
+				container := findContainer(js.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Containers, containerName)
+				gomega.Expect(container).NotTo(gomega.BeNil())
+				gomega.Expect(container.Resources.Requests[corev1.ResourceCPU]).To(gomega.Equal(updatedRequest))
+			})
+
+			ginkgo.By("resuming the JobSet", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, jsKey, js)).To(gomega.Succeed())
+					js.Spec.Suspend = ptr.To(false)
+					g.Expect(k8sClient.Update(ctx, js)).To(gomega.Succeed())
+				}, timeout, interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("checking the running Pods use the updated resource requests", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					var podList corev1.PodList
+					g.Expect(k8sClient.List(ctx, &podList, client.InNamespace(ns.Name))).To(gomega.Succeed())
+					g.Expect(podList.Items).NotTo(gomega.BeEmpty())
+					for _, pod := range podList.Items {
+						container := findContainer(pod.Spec.Containers, containerName)
+						g.Expect(container).NotTo(gomega.BeNil())
+						g.Expect(container.Resources.Requests[corev1.ResourceCPU]).To(gomega.Equal(updatedRequest))
+					}
+				}, timeout, interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("checking the jobset completes successfully", func() {
+				util.JobSetCompleted(ctx, k8sClient, js, timeout)
+			})
+		})
+	})
+})
+
+// jobConditionStatus returns the status of the given Job condition type, or
+// corev1.ConditionUnknown if the condition is not present.
+func jobConditionStatus(job *batchv1.Job, conditionType batchv1.JobConditionType) corev1.ConditionStatus {
+	for _, cond := range job.Status.Conditions {
+		if cond.Type == conditionType {
+			return cond.Status
+		}
+	}
+	return corev1.ConditionUnknown
+}
+
+// findContainer returns a pointer to the container with the given name, or
+// nil if no such container exists.
+func findContainer(containers []corev1.Container, name string) *corev1.Container {
+	for i := range containers {
+		if containers[i].Name == name {
+			return &containers[i]
+		}
+	}
+	return nil
+}
+
+// clusterSupportsMutablePodResources probes whether the cluster's kube-apiserver
+// allows mutating container resources on a suspended Job. This requires the
+// Kubernetes MutablePodResourcesForSuspendedJobs feature gate (KEP 5440),
+// which is alpha (disabled by default) as of Kubernetes 1.35.
+func clusterSupportsMutablePodResources(ctx context.Context, c client.Client) bool {
+	probeNs := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{GenerateName: "probe-mutable-resources-"},
+	}
+	if err := c.Create(ctx, probeNs); err != nil {
+		return false
+	}
+	defer func() {
+		_ = c.Delete(ctx, probeNs)
+	}()
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "probe-mutable-resources",
+			Namespace: probeNs.Name,
+		},
+		Spec: batchv1.JobSpec{
+			Suspend: ptr.To(true),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					Containers: []corev1.Container{{
+						Name:  "probe",
+						Image: "busybox",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("10m"),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	if err := c.Create(ctx, job); err != nil {
+		return false
+	}
+	defer func() {
+		_ = c.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground))
+	}()
+
+	// Wait for the Job's Suspended condition to be set by the Job controller.
+	// The apiserver only allows pod template resource mutation on Jobs that
+	// have the Suspended condition, not merely spec.suspend=true.
+	jobKey := types.NamespacedName{Name: job.Name, Namespace: job.Namespace}
+	suspendedConditionReady := false
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect(c.Get(ctx, jobKey, job)).To(gomega.Succeed())
+		g.Expect(jobConditionStatus(job, batchv1.JobSuspended)).To(gomega.Equal(corev1.ConditionTrue))
+		suspendedConditionReady = true
+	}, timeout, interval).Should(gomega.Succeed())
+
+	if !suspendedConditionReady {
+		return false
+	}
+
+	// Try mutating the container resources. If the apiserver rejects this,
+	// the MutablePodResourcesForSuspendedJobs gate is not enabled.
+	job.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("20m")
+	return c.Update(ctx, job) == nil
+}
+
+func suspendedResourceMutationTestJobSet(ns *corev1.Namespace, containerName string, initialCPURequest resource.Quantity) *jobset.JobSet {
+	jsName := "js-suspended-resource-mutation"
+	rjobName := "rjob"
+	replicas := 2
+
+	js := testingutil.MakeJobSet(jsName, ns.Name).
+		ReplicatedJob(testingutil.MakeReplicatedJob(rjobName).
+			Job(testingutil.MakeJobTemplate("job", ns.Name).
+				PodSpec(corev1.PodSpec{
+					RestartPolicy: "Never",
+					Containers: []corev1.Container{
+						{
+							Name:    containerName,
+							Image:   "docker.io/library/bash:latest",
+							Command: []string{"bash", "-c"},
+							Args:    []string{"sleep 1"},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: initialCPURequest,
+								},
+							},
+						},
+					},
+				}).Obj()).
+			Replicas(int32(replicas)).
+			Obj()).
+		Obj()
+
+	// Create the JobSet already suspended.
+	js.Spec.Suspend = ptr.To(true)
+	return js
+}

--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -146,6 +146,11 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 				Operator: corev1.TolerationOpExists,
 			},
 		},
+		containerResources: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("2"),
+			},
+		},
 	}
 
 	ginkgo.DescribeTable("jobset is created and its jobs go through a series of updates",
@@ -1471,6 +1476,9 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 				},
 				{
 					jobSetUpdateFn: func(js *jobset.JobSet) {
+						// Container resource mutation for suspended JobSets is gated behind the
+						// SuspendedJobResourceMutation feature gate.
+						features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.SuspendedJobResourceMutation, true)
 						updatePodTemplates(js, podTemplateUpdates)
 					},
 					checkJobSetState: func(js *jobset.JobSet) {
@@ -3627,6 +3635,9 @@ type updatePodTemplateOpts struct {
 	annotations  map[string]string
 	nodeSelector map[string]string
 	tolerations  []corev1.Toleration
+	// containerResources, if set, is applied to the resources of the container named
+	// "test-container" in each ReplicatedJob's pod template.
+	containerResources *corev1.ResourceRequirements
 }
 
 func updatePodTemplates(js *jobset.JobSet, opts *updatePodTemplateOpts) {
@@ -3648,6 +3659,15 @@ func updatePodTemplates(js *jobset.JobSet, opts *updatePodTemplateOpts) {
 
 			// Update tolerations.
 			podTemplate.Spec.Tolerations = opts.tolerations
+
+			// Update container resource requests/limits.
+			if opts.containerResources != nil {
+				for cIdx := range podTemplate.Spec.Containers {
+					if podTemplate.Spec.Containers[cIdx].Name == "test-container" {
+						podTemplate.Spec.Containers[cIdx].Resources = *opts.containerResources
+					}
+				}
+			}
 		}
 		return k8sClient.Update(ctx, &jsGet)
 	}, timeout, interval).Should(gomega.Succeed())
@@ -3704,6 +3724,22 @@ func checkPodTemplateUpdates(js *jobset.JobSet, podTemplateUpdates *updatePodTem
 		for _, toleration := range podTemplateUpdates.tolerations {
 			if !slices.Contains(job.Spec.Template.Spec.Tolerations, toleration) {
 				return false, fmt.Errorf("missing toleration %v", toleration)
+			}
+		}
+
+		// Check container resources were updated.
+		if podTemplateUpdates.containerResources != nil {
+			found := false
+			for _, container := range job.Spec.Template.Spec.Containers {
+				if container.Name == "test-container" {
+					found = true
+					if !apiequality.Semantic.DeepEqual(container.Resources, *podTemplateUpdates.containerResources) {
+						return false, fmt.Errorf("container resources %v != %v", container.Resources, *podTemplateUpdates.containerResources)
+					}
+				}
+			}
+			if !found {
+				return false, fmt.Errorf("container test-container not found")
 			}
 		}
 

--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -148,6 +148,11 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 				Operator: corev1.TolerationOpExists,
 			},
 		},
+		containerResources: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("2"),
+			},
+		},
 	}
 
 	ginkgo.DescribeTable("jobset is created and its jobs go through a series of updates",
@@ -1473,6 +1478,9 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 				},
 				{
 					jobSetUpdateFn: func(js *jobset.JobSet) {
+						// Container resource mutation for suspended JobSets is gated behind the
+						// MutablePodResourcesForSuspendedJobSets feature gate.
+						features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MutablePodResourcesForSuspendedJobSets, true)
 						updatePodTemplates(js, podTemplateUpdates)
 					},
 					checkJobSetState: func(js *jobset.JobSet) {
@@ -4026,6 +4034,9 @@ type updatePodTemplateOpts struct {
 	annotations  map[string]string
 	nodeSelector map[string]string
 	tolerations  []corev1.Toleration
+	// containerResources, if set, is applied to the resources of the container named
+	// "test-container" in each ReplicatedJob's pod template.
+	containerResources *corev1.ResourceRequirements
 }
 
 func updatePodTemplates(js *jobset.JobSet, opts *updatePodTemplateOpts) {
@@ -4047,6 +4058,15 @@ func updatePodTemplates(js *jobset.JobSet, opts *updatePodTemplateOpts) {
 
 			// Update tolerations.
 			podTemplate.Spec.Tolerations = opts.tolerations
+
+			// Update container resource requests/limits.
+			if opts.containerResources != nil {
+				for cIdx := range podTemplate.Spec.Containers {
+					if podTemplate.Spec.Containers[cIdx].Name == "test-container" {
+						podTemplate.Spec.Containers[cIdx].Resources = *opts.containerResources
+					}
+				}
+			}
 		}
 		return k8sClient.Update(ctx, &jsGet)
 	}, timeout, interval).Should(gomega.Succeed())
@@ -4103,6 +4123,22 @@ func checkPodTemplateUpdates(js *jobset.JobSet, podTemplateUpdates *updatePodTem
 		for _, toleration := range podTemplateUpdates.tolerations {
 			if !slices.Contains(job.Spec.Template.Spec.Tolerations, toleration) {
 				return false, fmt.Errorf("missing toleration %v", toleration)
+			}
+		}
+
+		// Check container resources were updated.
+		if podTemplateUpdates.containerResources != nil {
+			found := false
+			for _, container := range job.Spec.Template.Spec.Containers {
+				if container.Name == "test-container" {
+					found = true
+					if !apiequality.Semantic.DeepEqual(container.Resources, *podTemplateUpdates.containerResources) {
+						return false, fmt.Errorf("container resources %v != %v", container.Resources, *podTemplateUpdates.containerResources)
+					}
+				}
+			}
+			if !found {
+				return false, fmt.Errorf("container test-container not found")
 			}
 		}
 

--- a/test/integration/webhook/jobset_webhook_test.go
+++ b/test/integration/webhook/jobset_webhook_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -49,6 +50,7 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 
 		// Ensure feature gate is off by default for all standard tests
 		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobSet, false)
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.SuspendedJobResourceMutation, false)
 
 		// Create test namespace before each test.
 		ns = &corev1.Namespace{
@@ -406,6 +408,164 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 					},
 				}
 			},
+		}),
+		ginkgo.Entry("updating container resources in suspended jobset is allowed", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("suspended-resources", ns.Name).
+					Suspend(true).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob").
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							CompletionMode(batchv1.IndexedCompletion).
+							PodSpec(testing.TestPodSpec).
+							Obj()).
+						Obj())
+			},
+			defaultsApplied: func(js *jobset.JobSet) bool {
+				return true
+			},
+			updateJobSet: func(js *jobset.JobSet) {
+				// Container resource mutation for suspended JobSets is gated behind the
+				// SuspendedJobResourceMutation feature gate.
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.SuspendedJobResourceMutation, true)
+
+				containers := js.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Containers
+				for i := range containers {
+					containers[i].Resources = corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("2"),
+						},
+					}
+				}
+			},
+		}),
+		ginkgo.Entry("updating container resources in suspended jobset fails when feature gate is disabled", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("suspended-resources-disabled", ns.Name).
+					Suspend(true).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob").
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							CompletionMode(batchv1.IndexedCompletion).
+							PodSpec(testing.TestPodSpec).
+							Obj()).
+						Obj())
+			},
+			defaultsApplied: func(js *jobset.JobSet) bool {
+				return true
+			},
+			updateJobSet: func(js *jobset.JobSet) {
+				// Ensure the feature gate is OFF (testing the default behavior).
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.SuspendedJobResourceMutation, false)
+
+				containers := js.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Containers
+				for i := range containers {
+					containers[i].Resources = corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("2"),
+						},
+					}
+				}
+			},
+			updateShouldFail: true,
+		}),
+		ginkgo.Entry("updating initContainer resources in suspended jobset is allowed", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("suspended-initcontainer-resources", ns.Name).
+					Suspend(true).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob").
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							CompletionMode(batchv1.IndexedCompletion).
+							PodSpec(corev1.PodSpec{
+								RestartPolicy: "Never",
+								InitContainers: []corev1.Container{
+									{
+										Name:  "test-init-container",
+										Image: "busybox:latest",
+									},
+								},
+								Containers: testing.TestPodSpec.Containers,
+							}).
+							Obj()).
+						Obj())
+			},
+			defaultsApplied: func(js *jobset.JobSet) bool {
+				return true
+			},
+			updateJobSet: func(js *jobset.JobSet) {
+				// InitContainer resource mutation for suspended JobSets is gated behind the
+				// SuspendedJobResourceMutation feature gate.
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.SuspendedJobResourceMutation, true)
+
+				initContainers := js.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.InitContainers
+				for i := range initContainers {
+					initContainers[i].Resources = corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("2"),
+						},
+					}
+				}
+			},
+		}),
+		ginkgo.Entry("updating initContainer image in suspended jobset is not allowed even with feature gate enabled", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("suspended-initcontainer-image", ns.Name).
+					Suspend(true).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob").
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							CompletionMode(batchv1.IndexedCompletion).
+							PodSpec(corev1.PodSpec{
+								RestartPolicy: "Never",
+								InitContainers: []corev1.Container{
+									{
+										Name:  "test-init-container",
+										Image: "busybox:latest",
+									},
+								},
+								Containers: testing.TestPodSpec.Containers,
+							}).
+							Obj()).
+						Obj())
+			},
+			defaultsApplied: func(js *jobset.JobSet) bool {
+				return true
+			},
+			updateJobSet: func(js *jobset.JobSet) {
+				// Only resources are mutable for initContainers; other fields must remain immutable.
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.SuspendedJobResourceMutation, true)
+
+				initContainers := js.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.InitContainers
+				for i := range initContainers {
+					initContainers[i].Image = "alpine:latest"
+				}
+			},
+			updateShouldFail: true,
+		}),
+		ginkgo.Entry("updating container resources in running jobset is not allowed", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("running-resources", ns.Name).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob").
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							CompletionMode(batchv1.IndexedCompletion).
+							PodSpec(testing.TestPodSpec).
+							Obj()).
+						Obj())
+			},
+			defaultsApplied: func(js *jobset.JobSet) bool {
+				return true
+			},
+			updateJobSet: func(js *jobset.JobSet) {
+				// Even with the feature gate enabled, mutation is only allowed while suspended.
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.SuspendedJobResourceMutation, true)
+
+				containers := js.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Containers
+				for i := range containers {
+					containers[i].Resources = corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("2"),
+						},
+					}
+				}
+			},
+			updateShouldFail: true,
 		}),
 		ginkgo.Entry("updating pod template in running jobset is not allowed", &testCase{
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {

--- a/test/integration/webhook/jobset_webhook_test.go
+++ b/test/integration/webhook/jobset_webhook_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -49,6 +50,7 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 
 		// Ensure feature gate is off by default for all standard tests
 		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobSet, false)
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MutablePodResourcesForSuspendedJobSets, false)
 
 		// Create test namespace before each test.
 		ns = &corev1.Namespace{
@@ -431,6 +433,164 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 					},
 				}
 			},
+		}),
+		ginkgo.Entry("updating container resources in suspended jobset is allowed", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("suspended-resources", ns.Name).
+					Suspend(true).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob").
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							CompletionMode(batchv1.IndexedCompletion).
+							PodSpec(testing.TestPodSpec).
+							Obj()).
+						Obj())
+			},
+			defaultsApplied: func(js *jobset.JobSet) bool {
+				return true
+			},
+			updateJobSet: func(js *jobset.JobSet) {
+				// Container resource mutation for suspended JobSets is gated behind the
+				// MutablePodResourcesForSuspendedJobSets feature gate.
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MutablePodResourcesForSuspendedJobSets, true)
+
+				containers := js.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Containers
+				for i := range containers {
+					containers[i].Resources = corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("2"),
+						},
+					}
+				}
+			},
+		}),
+		ginkgo.Entry("updating container resources in suspended jobset fails when feature gate is disabled", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("suspended-resources-disabled", ns.Name).
+					Suspend(true).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob").
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							CompletionMode(batchv1.IndexedCompletion).
+							PodSpec(testing.TestPodSpec).
+							Obj()).
+						Obj())
+			},
+			defaultsApplied: func(js *jobset.JobSet) bool {
+				return true
+			},
+			updateJobSet: func(js *jobset.JobSet) {
+				// Ensure the feature gate is OFF (testing the default behavior).
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MutablePodResourcesForSuspendedJobSets, false)
+
+				containers := js.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Containers
+				for i := range containers {
+					containers[i].Resources = corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("2"),
+						},
+					}
+				}
+			},
+			updateShouldFail: true,
+		}),
+		ginkgo.Entry("updating initContainer resources in suspended jobset is allowed", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("suspended-initcontainer-resources", ns.Name).
+					Suspend(true).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob").
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							CompletionMode(batchv1.IndexedCompletion).
+							PodSpec(corev1.PodSpec{
+								RestartPolicy: "Never",
+								InitContainers: []corev1.Container{
+									{
+										Name:  "test-init-container",
+										Image: "busybox:latest",
+									},
+								},
+								Containers: testing.TestPodSpec.Containers,
+							}).
+							Obj()).
+						Obj())
+			},
+			defaultsApplied: func(js *jobset.JobSet) bool {
+				return true
+			},
+			updateJobSet: func(js *jobset.JobSet) {
+				// InitContainer resource mutation for suspended JobSets is gated behind the
+				// MutablePodResourcesForSuspendedJobSets feature gate.
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MutablePodResourcesForSuspendedJobSets, true)
+
+				initContainers := js.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.InitContainers
+				for i := range initContainers {
+					initContainers[i].Resources = corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("2"),
+						},
+					}
+				}
+			},
+		}),
+		ginkgo.Entry("updating initContainer image in suspended jobset is not allowed even with feature gate enabled", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("suspended-initcontainer-image", ns.Name).
+					Suspend(true).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob").
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							CompletionMode(batchv1.IndexedCompletion).
+							PodSpec(corev1.PodSpec{
+								RestartPolicy: "Never",
+								InitContainers: []corev1.Container{
+									{
+										Name:  "test-init-container",
+										Image: "busybox:latest",
+									},
+								},
+								Containers: testing.TestPodSpec.Containers,
+							}).
+							Obj()).
+						Obj())
+			},
+			defaultsApplied: func(js *jobset.JobSet) bool {
+				return true
+			},
+			updateJobSet: func(js *jobset.JobSet) {
+				// Only resources are mutable for initContainers; other fields must remain immutable.
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MutablePodResourcesForSuspendedJobSets, true)
+
+				initContainers := js.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.InitContainers
+				for i := range initContainers {
+					initContainers[i].Image = "alpine:latest"
+				}
+			},
+			updateShouldFail: true,
+		}),
+		ginkgo.Entry("updating container resources in running jobset is not allowed", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("running-resources", ns.Name).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob").
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							CompletionMode(batchv1.IndexedCompletion).
+							PodSpec(testing.TestPodSpec).
+							Obj()).
+						Obj())
+			},
+			defaultsApplied: func(js *jobset.JobSet) bool {
+				return true
+			},
+			updateJobSet: func(js *jobset.JobSet) {
+				// Even with the feature gate enabled, mutation is only allowed while suspended.
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MutablePodResourcesForSuspendedJobSets, true)
+
+				containers := js.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.Containers
+				for i := range containers {
+					containers[i].Resources = corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("2"),
+						},
+					}
+				}
+			},
+			updateShouldFail: true,
 		}),
 		ginkgo.Entry("updating pod template in running jobset is not allowed", &testCase{
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Allow the use of KEP-5440 with JobSet.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:



#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Allow for mutating pod resources from the jobset api while jobsets are suspended.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for updating resource requests and limits on suspended or suspending JobSets when enabled.
  * Propagated matching container and init-container resources to child workloads when a JobSet resumes.
  * Added execution-attempt tracking and promoted TLS options to generally available.

* **Bug Fixes**
  * Preserved other container settings and resource claims during updates.
  * Added warning events when resource propagation fails.

* **Tests**
  * Expanded unit, integration, webhook, and end-to-end coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->