### PR TITLE
fix: ignore terminal leader pods in webhook to prevent deadlock on retry

### DIFF
--- a/pkg/webhooks/pod_webhook.go
+++ b/pkg/webhooks/pod_webhook.go
@@ -274,7 +274,7 @@ func (p *podWebhook) leaderPodForFollower(ctx context.Context, pod *corev1.Pod) 
 		return nil, err
 	}
 	podList.Items = slices.DeleteFunc(podList.Items, func(p corev1.Pod) bool {
-		return !p.DeletionTimestamp.IsZero()
+		return !p.DeletionTimestamp.IsZero() || p.Status.Phase == corev1.PodFailed || p.Status.Phase == corev1.PodSucceeded
 	})
 
 	// Validate there is only 1 leader pod for this job.

--- a/pkg/webhooks/pod_webhook_test.go
+++ b/pkg/webhooks/pod_webhook_test.go
@@ -599,6 +599,34 @@ func TestLeaderPodForFollower(t *testing.T) {
 			wantErr: "expected 1 leader pod (js-rjob-0-0), but got 0",
 		},
 		{
+			name:        "active leader alongside failed leader pod",
+			followerPod: followerPod,
+			existingPods: []runtime.Object{
+				leaderPod,
+				func() *corev1.Pod {
+					p := leaderPod.DeepCopy()
+					p.Name = "js-rjob-0-0-failed"
+					p.Status.Phase = corev1.PodFailed
+					return p
+				}(),
+			},
+			wantLeaderPod: leaderPod,
+		},
+		{
+			name:        "active leader alongside succeeded leader pod",
+			followerPod: followerPod,
+			existingPods: []runtime.Object{
+				leaderPod,
+				func() *corev1.Pod {
+					p := leaderPod.DeepCopy()
+					p.Name = "js-rjob-0-0-succeeded"
+					p.Status.Phase = corev1.PodSucceeded
+					return p
+				}(),
+			},
+			wantLeaderPod: leaderPod,
+		},
+		{
 			name:        "leader and follower owned by different jobs",
 			followerPod: followerPod,
 			existingPods: []runtime.Object{
@@ -675,4 +703,136 @@ func makeTestPod(name string, owner *metav1.OwnerReference, annotations map[stri
 		pod.OwnerReferences = []metav1.OwnerReference{*owner}
 	}
 	return pod
+}
+
+func TestPodWebhook_DuplicateLeaderPods(t *testing.T) {
+	// 1. Setup scheme and register resources
+	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("failed to add corev1 to scheme: %v", err)
+	}
+
+	// Define common metadata labels for JobSet pods
+	baseLabels := map[string]string{
+		"jobset.sigs.k8s.io/jobset-name":        "test-jobset",
+		"jobset.sigs.k8s.io/replicatedjob-name": "slice",
+		"jobset.sigs.k8s.io/job-index":          "0",
+		"jobset.sigs.k8s.io/restart-attempt":    "0",
+	}
+
+	cloneLabels := func() map[string]string {
+		m := make(map[string]string)
+		for k, v := range baseLabels {
+			m[k] = v
+		}
+		return m
+	}
+
+	// 2. Define the Mock Pods
+
+	// Old leader pod that failed (still in system, no deletion timestamp)
+	oldLeader := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-jobset-slice-0-0-oldhash",
+			Namespace: "default",
+			Labels:    cloneLabels(),
+			Annotations: map[string]string{
+				"alpha.jobset.sigs.k8s.io/exclusive-topology": "topology.kubernetes.io/zone",
+				"jobset.sigs.k8s.io/jobset-name":              "test-jobset",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "batch/v1",
+					Kind:       "Job",
+					Name:       "test-jobset-slice-0",
+					UID:        "uid-123",
+					Controller: ptr.To(true),
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodFailed,
+		},
+	}
+	oldLeader.Labels["batch.kubernetes.io/job-completion-index"] = "0"
+	oldLeader.Labels["batch.kubernetes.io/controller-uid"] = "uid-123"
+
+	// New leader pod created by Job controller as a retry
+	newLeader := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-jobset-slice-0-0-newhash",
+			Namespace: "default",
+			Labels:    cloneLabels(),
+			Annotations: map[string]string{
+				"alpha.jobset.sigs.k8s.io/exclusive-topology": "topology.kubernetes.io/zone",
+				"jobset.sigs.k8s.io/jobset-name":              "test-jobset",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "batch/v1",
+					Kind:       "Job",
+					Name:       "test-jobset-slice-0",
+					UID:        "uid-123",
+					Controller: ptr.To(true),
+				},
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node-a", // Scheduled, otherwise ValidateCreate fails with "not scheduled"
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+		},
+	}
+	newLeader.Labels["batch.kubernetes.io/job-completion-index"] = "0"
+	newLeader.Labels["batch.kubernetes.io/controller-uid"] = "uid-123"
+
+	// New follower pod (index 1) that is attempting admission
+	follower := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-jobset-slice-0-1-randomhash",
+			Namespace: "default",
+			Labels:    cloneLabels(),
+			Annotations: map[string]string{
+				"alpha.jobset.sigs.k8s.io/exclusive-topology": "topology.kubernetes.io/zone",
+				"jobset.sigs.k8s.io/jobset-name":              "test-jobset",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "batch/v1",
+					Kind:       "Job",
+					Name:       "test-jobset-slice-0",
+					UID:        "uid-123",
+					Controller: ptr.To(true),
+				},
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeSelector: map[string]string{
+				"topology.kubernetes.io/zone": "zone-a", // Required for validation
+			},
+		},
+	}
+	follower.Labels["batch.kubernetes.io/job-completion-index"] = "1"
+
+	// 3. Initialize Fake Client and register Field Indexer
+	fc := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(oldLeader, newLeader, follower).
+		WithIndex(&corev1.Pod{}, controllers.PodNameKey, controllers.IndexPodName).
+		Build()
+
+	// 4. Instantiate Webhook
+	webhook := &podWebhook{
+		client: fc,
+	}
+
+	// 5. Execute Validation
+	_, err := webhook.ValidateCreate(context.Background(), follower)
+
+	// EXPECTED BEHAVIOR WITH THE FIX:
+	// The validation should PASS because the oldLeader (PodFailed phase) is ignored.
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
**Problem**:
In an Indexed Job managed by JobSet, when a Pod fails, the built-in Kubernetes Job controller replaces it by spinning up a new pod with the same index. By default, Kubernetes preserves the old failed pod in the Failed phase (without a DeletionTimestamp set) to allow developers to inspect logs.

During the creation of the retried follower pods, the JobSet pod admission webhook validates the pod by counting the leader pods (index 0) for the Job. If the webhook counts anything other than exactly 1 leader pod, it rejects the follower pod.

Previously, the webhook only ignored leader pods that were actively being deleted (DeletionTimestamp != nil). Consequently, if the leader pod failed and was replaced, the webhook counted both the old Failed leader pod and the new active Pending/Running leader pod, resulting in a count of 2.

This caused the webhook to permanently reject all subsequent follower pod creation requests. Since the API requests were rejected at the admission gate, the Job controller got stuck in an infinite retry loop, leaving the Job in an Active state. Because the Job never transitioned to Failed, the JobSet controller was never notified of a failure, bypassing the JobSet failurePolicy.maxRestarts limit and leaving the workload permanently deadlocked.

**Solution**:
Updated the pod filtering logic in leaderPodForFollower (pkg/webhooks/pod_webhook.go) to explicitly ignore pods that are in a terminal phase (corev1.PodFailed or corev1.PodSucceeded), in addition to checking DeletionTimestamp. This ensures that the webhook only counts active (non-terminal) leader pods.
Also added comprehensive unit and integration test coverage for the webhook to prevent regressions.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Added new test cases to TestLeaderPodForFollower in pkg/webhooks/pod_webhook_test.go to cover scenarios where active leader pods co-exist with failed or succeeded leader pods, verifying that the webhook now correctly filters them out and validates successfully.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixes a bug where follower pods would fail admission (causing a deadlock) when a leader pod is recreated by the Job controller, by properly ignoring failed and succeeded leader pods during validation.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved leader pod selection to ignore pods that are being deleted and pods already in terminal states (failed or succeeded).
  * Webhook validation now succeeds when an active leader exists alongside an older failed/completed leader.
  * Duplicate leader pod scenarios are handled correctly by focusing on the active leader.
* **Tests**
  * Expanded webhook test coverage for duplicate leader pods and terminal-phase leader candidates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->