### PR TITLE
Add DRA integration doc for workload-aware scheduling

### DIFF
--- a/site/content/en/docs/workload-aware-scheduling/_index.md
+++ b/site/content/en/docs/workload-aware-scheduling/_index.md
@@ -43,3 +43,4 @@ Pods in the JobSet are associated with a PodGroup through the `schedulingGroup.p
 - [Gang Scheduling](./gang_scheduling): Configure gang scheduling so that all pods in a JobSet must be schedulable before any are admitted.
 - [Preemption](./preemption): Enable workload-aware preemption to preempt entire pod groups rather than individual pods.
 - [Topology Aware Scheduling](./tas): Co-locate all pods in a gang within the same network topology domain for low-latency communication.
+- [DRA Integration](./dra): Share DRA devices across a gang-scheduled JobSet using PodGroup-level ResourceClaims.

--- a/site/content/en/docs/workload-aware-scheduling/dra.md
+++ b/site/content/en/docs/workload-aware-scheduling/dra.md
@@ -12,7 +12,7 @@ When the `DRAWorkloadResourceClaims` feature gate is enabled, you can associate 
 
 ## Prerequisites
 
-In addition to the [general WAS prerequisites](../), you must:
+In addition to the [general WAS prerequisites](/docs/workload-aware-scheduling/), you must:
 
 **Enable an additional feature gate.** Add `DRAWorkloadResourceClaims` to your cluster configuration:
 

--- a/site/content/en/docs/workload-aware-scheduling/dra.md
+++ b/site/content/en/docs/workload-aware-scheduling/dra.md
@@ -1,0 +1,90 @@
+---
+title: "DRA Integration"
+linkTitle: "DRA Integration"
+weight: 4
+date: 2026-07-15
+description: >
+    Share DRA devices across a gang-scheduled JobSet using PodGroup-level ResourceClaims
+no_list: true
+---
+
+When the `DRAWorkloadResourceClaims` feature gate is enabled, you can associate [Dynamic Resource Allocation](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/) (DRA) ResourceClaims with a PodGroup. This creates a single ResourceClaim that is shared across all pods in the gang i.e. the claim is reserved for the PodGroup rather than for individual pods.
+
+## Prerequisites
+
+In addition to the [general WAS prerequisites](../), you must:
+
+**Enable an additional feature gate.** Add `DRAWorkloadResourceClaims` to your cluster configuration:
+
+{{< include file="/examples/workload-aware-scheduling/dra/kind.yaml" lang="yaml" >}}
+
+```bash
+kind create cluster --image=kindest/node:latest --config kind.yaml
+```
+
+## How It Works
+
+Without DRA PodGroup integration, each pod creates its own ResourceClaim. With `DRAWorkloadResourceClaims` enabled, you can declare **`resourceClaims`** on both the Workload's `podGroupTemplates` and the PodGroup's `spec`. When a pod's `resourceClaims` entry matches a PodGroup's entry (same name and same template), the scheduler reserves the resulting ResourceClaim for the **PodGroup** instead of the individual pod.
+
+This means:
+
+- **One claim, many pods**: A single ResourceClaim is created from the template and shared across all pods in the gang.
+- **PodGroup-level reservation**: The claim's `status.reservedFor` references the PodGroup, not individual pods — avoiding the 256-entry reservation limit.
+- **Lifecycle management**: Claims created from templates are owned by the PodGroup and cleaned up when the PodGroup is deleted.
+
+## Step 1: Create the ResourceClaimTemplate
+
+The [ResourceClaimTemplate](https://github.com/kubernetes-sigs/jobset/blob/main/site/static/examples/workload-aware-scheduling/dra/resourceclaimtemplate.yaml) defines the device request. This example requests a single GPU from the `gpu.example.com` DeviceClass:
+
+{{< include file="/examples/workload-aware-scheduling/dra/resourceclaimtemplate.yaml" lang="yaml" >}}
+
+## Step 2: Create the Workload
+
+The [Workload](https://github.com/kubernetes-sigs/jobset/blob/main/site/static/examples/workload-aware-scheduling/dra/workload.yaml) references the JobSet and defines a pod group template with gang scheduling and a ResourceClaim:
+
+{{< include file="/examples/workload-aware-scheduling/dra/workload.yaml" lang="yaml" >}}
+
+The key addition compared to basic gang scheduling is **`resourceClaims`** in the `podGroupTemplates` entry. This declares that pods in this group share a GPU claim created from `gpu-claim-template`.
+
+## Step 3: Create the PodGroup
+
+The [PodGroup](https://github.com/kubernetes-sigs/jobset/blob/main/site/static/examples/workload-aware-scheduling/dra/podgroup.yaml) references the Workload's pod group template and carries the same `resourceClaims`:
+
+{{< include file="/examples/workload-aware-scheduling/dra/podgroup.yaml" lang="yaml" >}}
+
+When the PodGroup is created, Kubernetes generates a ResourceClaim from the template. The claim name appears in `status.resourceClaimStatuses`.
+
+## Step 4: Create the JobSet
+
+The [JobSet](https://github.com/kubernetes-sigs/jobset/blob/main/site/static/examples/workload-aware-scheduling/dra/jobset.yaml) creates 6 pods (3 replicas × 2 completions). Each pod references the PodGroup through `schedulingGroup.podGroupName` and declares the same `resourceClaims` entry:
+
+{{< include file="/examples/workload-aware-scheduling/dra/jobset.yaml" lang="yaml" >}}
+
+Because the pod's `resourceClaims` entry matches the PodGroup's entry, this triggers PodGroup-level reservation as described above.
+
+## Verify
+
+Check that the PodGroup is scheduled and the ResourceClaim is allocated:
+
+```bash
+kubectl get podgroup training-workers
+kubectl get resourceclaim
+```
+
+The ResourceClaim should show `allocated,reserved`. Verify that the reservation targets the PodGroup:
+
+```bash
+kubectl get resourceclaim -o jsonpath='{.items[0].status.reservedFor[0]}'
+```
+
+The output should reference `podgroups` rather than `pods`:
+
+```json
+{"apiGroup":"scheduling.k8s.io","name":"training-workers","resource":"podgroups","uid":"..."}
+```
+
+Check that all 6 pods are running:
+
+```bash
+kubectl get pods -l jobset.sigs.k8s.io/jobset-name=training-job
+```

--- a/site/content/en/docs/workload-aware-scheduling/tas.md
+++ b/site/content/en/docs/workload-aware-scheduling/tas.md
@@ -12,9 +12,9 @@ Topology Aware Scheduling (TAS) ensures that all pods in a gang are placed withi
 
 ## Prerequisites
 
-In addition to the [general WAS prerequisites](../), you must:
+In addition to the [general WAS prerequisites](/docs/workload-aware-scheduling/), you must:
 
-1. **Enable the `TopologyAwareWorkloadScheduling` feature gate.** This feature gate is included in the [kind cluster configuration](../) and is required for topology-aware placement.
+1. **Enable the `TopologyAwareWorkloadScheduling` feature gate.** This feature gate is included in the [kind cluster configuration](/docs/workload-aware-scheduling/) and is required for topology-aware placement.
 
 2. **Label your nodes with topology keys.** The scheduler uses node labels to determine topology domains. Apply labels that represent your topology hierarchy — for example, rack, block, or zone:
 

--- a/site/static/examples/workload-aware-scheduling/dra/jobset.yaml
+++ b/site/static/examples/workload-aware-scheduling/dra/jobset.yaml
@@ -1,0 +1,28 @@
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: training-job
+spec:
+  replicatedJobs:
+  - name: workers
+    replicas: 3
+    template:
+      spec:
+        completions: 2
+        parallelism: 2
+        backoffLimit: 0
+        template:
+          spec:
+            terminationGracePeriodSeconds: 0
+            schedulingGroup:
+              podGroupName: training-workers
+            resourceClaims:
+            - name: shared-gpu
+              resourceClaimTemplateName: gpu-claim-template
+            containers:
+            - name: worker
+              image: busybox
+              command: ["/bin/sh", "-c", "sleep infinity"]
+              resources:
+                claims:
+                - name: shared-gpu

--- a/site/static/examples/workload-aware-scheduling/dra/kind.yaml
+++ b/site/static/examples/workload-aware-scheduling/dra/kind.yaml
@@ -1,0 +1,20 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+featureGates:
+  GenericWorkload: true
+  GangScheduling: true
+  TopologyAwareWorkloadScheduling: true
+  WorkloadAwarePreemption: true
+  DRAWorkloadResourceClaims: true   # Enables PodGroup-level ResourceClaims
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      extraArgs:
+        runtime-config: "api/alpha=true"
+- role: worker
+- role: worker
+- role: worker
+- role: worker

--- a/site/static/examples/workload-aware-scheduling/dra/podgroup.yaml
+++ b/site/static/examples/workload-aware-scheduling/dra/podgroup.yaml
@@ -1,0 +1,16 @@
+apiVersion: scheduling.k8s.io/v1alpha2
+kind: PodGroup
+metadata:
+  name: training-workers
+  namespace: default
+spec:
+  podGroupTemplateRef:
+    workload:
+      workloadName: training-workload
+      podGroupTemplateName: workers
+  schedulingPolicy:
+    gang:
+      minCount: 6
+  resourceClaims:
+  - name: shared-gpu
+    resourceClaimTemplateName: gpu-claim-template

--- a/site/static/examples/workload-aware-scheduling/dra/resourceclaimtemplate.yaml
+++ b/site/static/examples/workload-aware-scheduling/dra/resourceclaimtemplate.yaml
@@ -1,0 +1,12 @@
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: gpu-claim-template
+  namespace: default
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.example.com

--- a/site/static/examples/workload-aware-scheduling/dra/workload.yaml
+++ b/site/static/examples/workload-aware-scheduling/dra/workload.yaml
@@ -1,0 +1,17 @@
+apiVersion: scheduling.k8s.io/v1alpha2
+kind: Workload
+metadata:
+  name: training-workload
+spec:
+  controllerRef:
+    apiGroup: jobset.x-k8s.io
+    kind: JobSet
+    name: training-job
+  podGroupTemplates:
+  - name: workers
+    schedulingPolicy:
+      gang:
+        minCount: 6
+    resourceClaims:
+    - name: shared-gpu
+      resourceClaimTemplateName: gpu-claim-template


### PR DESCRIPTION
Document how to use PodGroup-level ResourceClaims with JobSet via the `DRAWorkloadResourceClaims` feature gate

/kind documentation

/cc @kannon92 

### Following are the steps along with the configs to verify this integration on a Kind cluster using dra-example-driver
- `kind-config.yaml` is derived from `dra-example-driver` repository along with a few more featuregates as mentioned in the prerequisite section of workload aware scheduling page
Ref: https://github.com/kubernetes-sigs/dra-example-driver/blob/main/demo/scripts/kind-cluster-config.yaml 
```
svanka@svanka-thinkpadp16vgen1:~/ramesh/dra/jobset-dra-integration$ cat kind-config.yaml 
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
featureGates:
  DynamicResourceAllocation: true
  DRAAdminAccess: true
  DRAWorkloadResourceClaims: true
  DRAExtendedResource: true
  DRADeviceBindingConditions: true
  DRANodeAllocatableResources: true
  DRAConsumableCapacity: true
  GangScheduling: true
  GenericWorkload: true
  TopologyAwareWorkloadScheduling: true
  WorkloadAwarePreemption: true
runtimeConfig:
  resource.k8s.io/v1beta1: "true"
  scheduling.k8s.io/v1alpha2: "true"
containerdConfigPatches:
# Enable CDI as described in
# https://tags.cncf.io/container-device-interface#containerd-configuration
- |-
  [plugins."io.containerd.grpc.v1.cri"]
    enable_cdi = true
nodes:
- role: control-plane
  kubeadmConfigPatches:
  - |
    kind: ClusterConfiguration
    apiServer:
      extraArgs:
        runtime-config: "api/alpha=true"
    scheduler:
      extraArgs:
        v: "1"
    controllerManager:
      extraArgs:
        v: "1"
  - |
    kind: InitConfiguration
    nodeRegistration:
      kubeletExtraArgs:
        v: "1"
- role: worker
  kubeadmConfigPatches:
  - |
    kind: JoinConfiguration
    nodeRegistration:
      kubeletExtraArgs:
        v: "1"
- role: worker
  kubeadmConfigPatches:
  - |
    kind: JoinConfiguration
    nodeRegistration:
      kubeletExtraArgs:
        v: "1"
```

- The kind image tag used is `v1.36.1` 
```
svanka@svanka-thinkpadp16vgen1:~/ramesh/dra/jobset-dra-integration$ kind create cluster --config kind-config.yaml 
enabling experimental podman provider
Creating cluster "kind" ...
 ✓ Ensuring node image (kindest/node:v1.36.1) 🖼 
 ✓ Preparing nodes 📦 📦 📦  
 ✓ Writing configuration 📜 
 ✓ Starting control-plane 🕹️ 
 ✓ Installing CNI 🔌 
 ✓ Installing StorageClass 💾 
 ✓ Joining worker nodes 🚜 
Set kubectl context to "kind-kind"
You can now use your cluster with:

kubectl cluster-info --context kind-kind

Have a nice day! 👋
```

- Installed the `dra-example-driver` from the `helm` command as follows:
```
svanka@svanka-thinkpadp16vgen1:~/ramesh/dra/jobset-dra-integration$ helm install --create-namespace --namespace dra-example-driver dra-example-driver \
    /home/svanka/go/src/dra-example-driver/deployments/helm/dra-example-driver/ \
    --set kubeletPlugin.containers.plugin.securityContext.privileged=false
NAME: dra-example-driver
LAST DEPLOYED: Thu Jul 16 21:09:02 2026
NAMESPACE: dra-example-driver
STATUS: deployed
REVISION: 1
TEST SUITE: None
svanka@svanka-thinkpadp16vgen1:~/ramesh/dra/jobset-dra-integration$ 
svanka@svanka-thinkpadp16vgen1:~/ramesh/dra/jobset-dra-integration$ kubectl get pods -n dra-example-driver
NAME                                     READY   STATUS    RESTARTS   AGE
dra-example-driver-kubeletplugin-jtfp6   1/1     Running   0          15s
dra-example-driver-kubeletplugin-ncl58   1/1     Running   0          15s
svanka@svanka-thinkpadp16vgen1:~/ramesh/dra/jobset-dra-integration$ 
svanka@svanka-thinkpadp16vgen1:~/ramesh/dra/jobset-dra-integration$ kubectl get resourceslices.resource.k8s.io 
NAME                                       NODE           DRIVER            POOL           AGE
00000-gpu.example.com-kind-worker-wptvd    kind-worker    gpu.example.com   kind-worker    22s
00000-gpu.example.com-kind-worker2-2sb44   kind-worker2   gpu.example.com   kind-worker2   22s
svanka@svanka-thinkpadp16vgen1:~/ramesh/dra/jobset-dra-integration$ 
svanka@svanka-thinkpadp16vgen1:~/ramesh/dra/jobset-dra-integration$ kubectl get deviceclasses.resource.k8s.io 
NAME              AGE
gpu.example.com   61s
```
- Created `ResouceClaimTemplate` object
```
svanka@svanka-thinkpadp16vgen1:~/ramesh/dra/jobset-dra-integration$ kubectl create -f ~/go/src/jobset/site/static/examples/workload-aware-scheduling/dra/resourceclaimtemplate.yaml 
resourceclaimtemplate.resource.k8s.io/gpu-claim-template created
svanka@svanka-thinkpadp16vgen1:~/ramesh/dra/jobset-dra-integration$ 
svanka@svanka-thinkpadp16vgen1:~/ramesh/dra/jobset-dra-integration$ kubectl get resourceclaimtemplates.resource.k8s.io -oyaml
apiVersion: v1
items:
- apiVersion: resource.k8s.io/v1
  kind: ResourceClaimTemplate
  metadata:
    creationTimestamp: "2026-07-16T15:46:38Z"
    name: gpu-claim-template
    namespace: default
    resourceVersion: "2079"
    uid: 6cc03413-50d2-432d-83f7-0a5e88ce1edb
  spec:
    metadata: {}
    spec:
      devices:
        requests:
        - exactly:
            allocationMode: ExactCount
            count: 1
            deviceClassName: gpu.example.com
          name: gpu
kind: List
metadata:
  resourceVersion: ""
```

- Created `Workload`, `PodGroup` objects
```
svanka@svanka-thinkpadp16vgen1:~/ramesh/dra/jobset-dra-integration$ kubectl create -f ~/go/src/jobset/site/static/examples/workload-aware-scheduling/dra/workload.yaml 
workload.scheduling.k8s.io/training-workload created
svanka@svanka-thinkpadp16vgen1:~/ramesh/dra/jobset-dra-integration$ kubectl create -f ~/go/src/jobset/site/static/examples/workload-aware-scheduling/dra/podgroup.yaml 
podgroup.scheduling.k8s.io/training-workers created
svanka@svanka-thinkpadp16vgen1:~/ramesh/dra/jobset-dra-integration$ kubectl get workloads.scheduling.k8s.io -oyaml
apiVersion: v1
items:
- apiVersion: scheduling.k8s.io/v1alpha2
  kind: Workload
  metadata:
    creationTimestamp: "2026-07-16T15:48:34Z"
    name: training-workload
    namespace: default
    resourceVersion: "2274"
    uid: ba9130dd-facd-4f20-b2d4-e8e2493f1ac5
  spec:
    controllerRef:
      apiGroup: jobset.x-k8s.io
      kind: JobSet
      name: training-job
    podGroupTemplates:
    - name: workers
      resourceClaims:
      - name: shared-gpu
        resourceClaimTemplateName: gpu-claim-template
      schedulingConstraints: null
      schedulingPolicy:
        gang:
          minCount: 6
kind: List
metadata:
  resourceVersion: ""
svanka@svanka-thinkpadp16vgen1:~/ramesh/dra/jobset-dra-integration$ kubectl get podgroups.scheduling.k8s.io -oyaml
apiVersion: v1
items:
- apiVersion: scheduling.k8s.io/v1alpha2
  kind: PodGroup
  metadata:
    creationTimestamp: "2026-07-16T15:48:39Z"
    finalizers:
    - scheduling.k8s.io/podgroup-protection
    name: training-workers
    namespace: default
    resourceVersion: "2283"
    uid: d397819a-60e5-4bfa-b19a-ed5df39008ea
  spec:
    disruptionMode: Pod
    podGroupTemplateRef:
      workload:
        podGroupTemplateName: workers
        workloadName: training-workload
    priority: 0
    resourceClaims:
    - name: shared-gpu
      resourceClaimTemplateName: gpu-claim-template
    schedulingPolicy:
      gang:
        minCount: 6
  status:
    resourceClaimStatuses:
    - name: shared-gpu
      resourceClaimName: training-workers-shared-gpu-fsrxx
kind: List
metadata:
  resourceVersion: ""
svanka@svanka-thinkpadp16vgen1:~/ramesh/dra/jobset-dra-integration$ kubectl get resourceclaim
NAME                                STATE     AGE
training-workers-shared-gpu-fsrxx   pending   62s
```
- Installed the `JobSet` controller
```
svanka@svanka-thinkpadp16vgen1:~/go/src/dra-example-driver$ VERSION=v0.12.0
kubectl apply --server-side -f https://github.com/kubernetes-sigs/jobset/releases/download/$VERSION/manifests.yaml
namespace/jobset-system serverside-applied
customresourcedefinition.apiextensions.k8s.io/jobsets.jobset.x-k8s.io serverside-applied
serviceaccount/jobset-controller-manager serverside-applied
role.rbac.authorization.k8s.io/jobset-leader-election-role serverside-applied
role.rbac.authorization.k8s.io/jobset-manager-secrets-role serverside-applied
clusterrole.rbac.authorization.k8s.io/jobset-manager-role serverside-applied
clusterrole.rbac.authorization.k8s.io/jobset-metrics-reader serverside-applied
clusterrole.rbac.authorization.k8s.io/jobset-proxy-role serverside-applied
rolebinding.rbac.authorization.k8s.io/jobset-leader-election-rolebinding serverside-applied
rolebinding.rbac.authorization.k8s.io/jobset-manager-secrets-rolebinding serverside-applied
clusterrolebinding.rbac.authorization.k8s.io/jobset-manager-rolebinding serverside-applied
clusterrolebinding.rbac.authorization.k8s.io/jobset-metrics-reader-rolebinding serverside-applied
clusterrolebinding.rbac.authorization.k8s.io/jobset-proxy-rolebinding serverside-applied
configmap/jobset-manager-config serverside-applied
secret/jobset-webhook-server-cert serverside-applied
service/jobset-controller-manager-metrics-service serverside-applied
service/jobset-webhook-service serverside-applied
deployment.apps/jobset-controller-manager serverside-applied
mutatingwebhookconfiguration.admissionregistration.k8s.io/jobset-mutating-webhook-configuration serverside-applied
validatingwebhookconfiguration.admissionregistration.k8s.io/jobset-validating-webhook-configuration serverside-applied

svanka@svanka-thinkpadp16vgen1:~/go/src/dra-example-driver$ kubectl get pods -n jobset-system 
NAME                                         READY   STATUS    RESTARTS   AGE
jobset-controller-manager-6f6f75f9cd-l62sk   1/1     Running   0          102s
```

- Created the `JobSet` 
```
svanka@svanka-thinkpadp16vgen1:~/ramesh/dra/jobset-dra-integration$ kubectl create -f ~/go/src/jobset/site/static/examples/workload-aware-scheduling/dra/jobset.yaml 
jobset.jobset.x-k8s.io/training-job created
svanka@svanka-thinkpadp16vgen1:~/ramesh/dra/jobset-dra-integration$ kubectl get jobset
NAME           TERMINALSTATE   RESTARTS   COMPLETED   SUSPENDED   AGE
training-job                   0                                  12s
svanka@svanka-thinkpadp16vgen1:~/ramesh/dra/jobset-dra-integration$ kubectl get pods
NAME                             READY   STATUS    RESTARTS   AGE
training-job-workers-0-0-skctn   1/1     Running   0          18s
training-job-workers-0-1-72lm2   1/1     Running   0          18s
training-job-workers-1-0-d7txz   1/1     Running   0          18s
training-job-workers-1-1-fw6bx   1/1     Running   0          18s
training-job-workers-2-0-fnvnx   1/1     Running   0          18s
training-job-workers-2-1-pt9bb   1/1     Running   0          18s

```
- Verified that the resourceclaim is `allocated, reserved` targeting the `PodGroup`. Also verified that the `PodGroup` is `Scheduled`
```
svanka@svanka-thinkpadp16vgen1:~/ramesh/dra/jobset-dra-integration$ kubectl get resourceclaim
NAME                                STATE                AGE
training-workers-shared-gpu-fsrxx   allocated,reserved   9m35s
svanka@svanka-thinkpadp16vgen1:~/ramesh/dra/jobset-dra-integration$ 
svanka@svanka-thinkpadp16vgen1:~/ramesh/dra/jobset-dra-integration$ 
svanka@svanka-thinkpadp16vgen1:~/ramesh/dra/jobset-dra-integration$ kubectl get resourceclaim -oyaml
apiVersion: v1
items:
- apiVersion: resource.k8s.io/v1
  kind: ResourceClaim
  metadata:
    annotations:
      resource.kubernetes.io/pod-claim-name: shared-gpu
    creationTimestamp: "2026-07-16T15:48:39Z"
    finalizers:
    - resource.kubernetes.io/delete-protection
    generateName: training-workers-shared-gpu-
    name: training-workers-shared-gpu-fsrxx
    namespace: default
    ownerReferences:
    - apiVersion: scheduling.k8s.io/v1alpha2
      controller: true
      kind: PodGroup
      name: training-workers
      uid: d397819a-60e5-4bfa-b19a-ed5df39008ea
    resourceVersion: "3313"
    uid: 9e687852-5b10-4e32-8949-cbb829aab815
  spec:
    devices:
      requests:
      - exactly:
          allocationMode: ExactCount
          count: 1
          deviceClassName: gpu.example.com
        name: gpu
  status:
    allocation:
      allocationTimestamp: "2026-07-16T15:57:01Z"
      devices:
        results:
        - device: gpu-0
          driver: gpu.example.com
          pool: kind-worker2
          request: gpu
      nodeSelector:
        nodeSelectorTerms:
        - matchFields:
          - key: metadata.name
            operator: In
            values:
            - kind-worker2
    reservedFor:
    - apiGroup: scheduling.k8s.io
      name: training-workers
      resource: podgroups
      uid: d397819a-60e5-4bfa-b19a-ed5df39008ea
kind: List
metadata:
  resourceVersion: ""

svanka@svanka-thinkpadp16vgen1:~/ramesh/dra/jobset-dra-integration$ kubectl get podgroups.scheduling.k8s.io 
NAME               POLICY   WORKLOAD            STATUS      AGE
training-workers   Gang     training-workload   Scheduled   10m

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for integrating Kubernetes Dynamic Resource Allocation (DRA) with gang-scheduled JobSets.
  * Documented sharing a single ResourceClaim across a PodGroup using the `DRAWorkloadResourceClaims` feature gate.
  * Included step-by-step verification steps for ResourceClaim allocation and pod readiness.
  * Updated TAS prerequisites link formatting.

* **Examples**
  * Added ready-to-use DRA manifests for a DRA-enabled cluster, workload, PodGroup, JobSet, and GPU ResourceClaim template.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->