### PR TITLE
fix: reject negative replicated job replicas

### DIFF
--- a/api/jobset/v1alpha2/jobset_types.go
+++ b/api/jobset/v1alpha2/jobset_types.go
@@ -332,6 +332,7 @@ type ReplicatedJob struct {
 	// replicas is the number of jobs that will be created from this ReplicatedJob's template.
 	// Jobs names will be in the format: <jobSet.name>-<spec.replicatedJob.name>-<job-index>
 	// +kubebuilder:default=1
+	// +kubebuilder:validation:Minimum=0
 	Replicas int32 `json:"replicas,omitempty"`
 
 	// dependsOn is an optional list that specifies the preceding ReplicatedJobs upon which

--- a/charts/jobset/crds/jobset.x-k8s.io_jobsets.yaml
+++ b/charts/jobset/crds/jobset.x-k8s.io_jobsets.yaml
@@ -278,6 +278,7 @@ spec:
                         replicas is the number of jobs that will be created from this ReplicatedJob's template.
                         Jobs names will be in the format: <jobSet.name>-<spec.replicatedJob.name>-<job-index>
                       format: int32
+                      minimum: 0
                       type: integer
                     template:
                       description: template defines the template of the Job that will

--- a/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
+++ b/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
@@ -278,6 +278,7 @@ spec:
                         replicas is the number of jobs that will be created from this ReplicatedJob's template.
                         Jobs names will be in the format: <jobSet.name>-<spec.replicatedJob.name>-<job-index>
                       format: int32
+                      minimum: 0
                       type: integer
                     template:
                       description: template defines the template of the Job that will

--- a/hack/python-sdk/swagger.json
+++ b/hack/python-sdk/swagger.json
@@ -129,7 +129,7 @@
         "metadata": {
           "description": "metadata is the object metadata for JobSet",
           "default": {},
-          "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.36.0/api/openapi-spec/swagger.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+          "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.36.2/api/openapi-spec/swagger.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
         },
         "spec": {
           "description": "spec is the specification for jobset",
@@ -166,7 +166,7 @@
         },
         "metadata": {
           "default": {},
-          "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.36.0/api/openapi-spec/swagger.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+          "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.36.2/api/openapi-spec/swagger.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
         }
       }
     },
@@ -238,7 +238,7 @@
           "description": "conditions track status",
           "type": "array",
           "items": {
-            "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.36.0/api/openapi-spec/swagger.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
+            "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.36.2/api/openapi-spec/swagger.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
           },
           "x-kubernetes-list-map-keys": [
             "type"
@@ -341,7 +341,7 @@
         "template": {
           "description": "template defines the template of the Job that will be created.",
           "default": {},
-          "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.36.0/api/openapi-spec/swagger.json#/definitions/io.k8s.api.batch.v1.JobTemplateSpec"
+          "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.36.2/api/openapi-spec/swagger.json#/definitions/io.k8s.api.batch.v1.JobTemplateSpec"
         }
       }
     },
@@ -458,7 +458,7 @@
           "description": "templates is a list of shared PVC claims that ReplicatedJobs are allowed to reference. The JobSet controller is responsible for creating shared PVCs that can be mounted by multiple ReplicatedJobs. Every claim in this list must have a matching (by name) volumeMount in one container or initContainer in at least one ReplicatedJob template. ReplicatedJob template must not have volumes with the same name as defined in this template. PVC template must not have the namespace parameter. Generated PVC naming convention: \u003cclaim-name\u003e-\u003cjobset-name\u003e Example: \"model-cache-trainjob\" (shared volume across all ReplicatedJobs).",
           "type": "array",
           "items": {
-            "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.36.0/api/openapi-spec/swagger.json#/definitions/io.k8s.api.core.v1.PersistentVolumeClaim"
+            "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.36.2/api/openapi-spec/swagger.json#/definitions/io.k8s.api.core.v1.PersistentVolumeClaim"
           },
           "x-kubernetes-list-type": "atomic"
         }

--- a/test/integration/webhook/jobset_webhook_test.go
+++ b/test/integration/webhook/jobset_webhook_test.go
@@ -279,6 +279,31 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 			},
 			jobSetCreationShouldFail: true,
 		}),
+		ginkgo.Entry("negative replicated job replicas are rejected", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("negative-replicas", ns.Name).
+					EnableDNSHostnames(true).
+					ReplicatedJob(testing.MakeReplicatedJob("negative-replicas").
+						Replicas(-1).
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							PodSpec(testing.TestPodSpec).
+							CompletionMode(batchv1.IndexedCompletion).Obj()).
+						Obj())
+			},
+			jobSetCreationShouldFail: true,
+		}),
+		ginkgo.Entry("zero replicated job replicas are accepted", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("zero-replicas", ns.Name).
+					EnableDNSHostnames(true).
+					ReplicatedJob(testing.MakeReplicatedJob("zero-replicas").
+						Replicas(0).
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							PodSpec(testing.TestPodSpec).
+							CompletionMode(batchv1.IndexedCompletion).Obj()).
+						Obj())
+			},
+		}),
 		ginkgo.Entry("suspend jobset", &testCase{
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
 				return testing.MakeJobSet("js-hostnames-non-indexed", ns.Name).


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Rejects negative replicated job replicas at admission. Negative replicas create no Jobs, so the JobSet can stay stuck. Zero replicas remain supported.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

Repro: apply a JobSet with `replicas: -1`. Before this fix it is admitted but creates no Jobs.

small AI assistance was used for this PR

#### Does this PR introduce a user-facing change?

```release-note
Reject JobSets with negative replicated job replicas.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Replicated job replica counts can no longer be set to negative values.
  * Replica count validation now consistently rejects invalid configurations while allowing zero replicas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->