### PR TITLE
fix: skip invalid negative priority label on JobSet pods

### DIFF
--- a/pkg/webhooks/pod_webhook.go
+++ b/pkg/webhooks/pod_webhook.go
@@ -64,7 +64,9 @@ func (p *podWebhook) Default(ctx context.Context, pod *corev1.Pod) error {
 	// Add the priority label to make sure the Pod is compatible with other pods using the exclusive
 	// placement feature.
 	// See https://github.com/kubernetes-sigs/jobset/issues/1057 for more details.
-	if pod.Spec.Priority != nil {
+	// Negative priorities are valid in Kubernetes (e.g. overprovisioning PriorityClasses),
+	// but label values cannot start with '-'. Only set the label for non-negative priorities.
+	if pod.Spec.Priority != nil && *pod.Spec.Priority >= 0 {
 		if pod.Labels == nil {
 			pod.Labels = make(map[string]string)
 		}

--- a/pkg/webhooks/pod_webhook_test.go
+++ b/pkg/webhooks/pod_webhook_test.go
@@ -126,6 +126,31 @@ func TestDefault(t *testing.T) {
 			},
 		},
 		{
+			name: "jobset pod, no exclusive placement, with negative priority",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "p",
+					Annotations: map[string]string{
+						"jobset.sigs.k8s.io/jobset-name": "js",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Priority: ptr.To(int32(-1)),
+				},
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "p",
+					Annotations: map[string]string{
+						"jobset.sigs.k8s.io/jobset-name": "js",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Priority: ptr.To(int32(-1)),
+				},
+			},
+		},
+		{
 			name: "leader pod with exclusive placement",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The pod mutating webhook copies `pod.Spec.Priority` into the `jobset.sigs.k8s.io/priority` label via `fmt.Sprint`. When Priority is negative (valid in Kubernetes, e.g. overprovisioning PriorityClasses with `value: -1`), the resulting label value (e.g. `"-1"`) is rejected by the API server because label values cannot start with `-`. Child Pods never get created and the JobSet stays stuck.

This change only sets the priority label when priority is non-negative, which is a valid Kubernetes label value.

#### Which issue(s) this PR fixes:

Fixes #1280

#### Special notes for your reviewer:

Added a unit test covering negative priority so the label is not injected.

#### Does this PR introduce a user-facing change?

```release-note
Fix JobSet pods failing admission when using a negative-value PriorityClass by not injecting an invalid jobset.sigs.k8s.io/priority label.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed handling of pods with negative priority values.
  - Negative priorities are now preserved without adding an invalid priority label.
  - Existing annotations and pod configuration remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->