### PR TITLE
fix: reject non-indexed exclusive placement

### DIFF
--- a/pkg/webhooks/jobset_webhook.go
+++ b/pkg/webhooks/jobset_webhook.go
@@ -437,8 +437,11 @@ func usesPodWebhookExclusivePlacement(js *jobset.JobSet, rJob jobset.ReplicatedJ
 	_, replicatedJobExclusive := rJob.Template.Annotations[jobset.ExclusiveKey]
 	_, replicatedJobNodeSelectorStrategy := rJob.Template.Annotations[jobset.NodeSelectorStrategyKey]
 
-	usesNodeSelectorStrategy := (jobSetExclusive && jobSetNodeSelectorStrategy) ||
-		(replicatedJobExclusive && replicatedJobNodeSelectorStrategy)
+	// The controller propagates the node selector strategy only when it is set
+	// alongside exclusive placement at the same scope.
+	jobSetUsesNodeSelectorStrategy := jobSetExclusive && jobSetNodeSelectorStrategy
+	replicatedJobUsesNodeSelectorStrategy := replicatedJobExclusive && replicatedJobNodeSelectorStrategy
+	usesNodeSelectorStrategy := jobSetUsesNodeSelectorStrategy || replicatedJobUsesNodeSelectorStrategy
 	return (jobSetExclusive || replicatedJobExclusive) && !usesNodeSelectorStrategy
 }
 

--- a/pkg/webhooks/jobset_webhook.go
+++ b/pkg/webhooks/jobset_webhook.go
@@ -211,6 +211,10 @@ func (j *jobSetWebhook) ValidateCreate(ctx context.Context, js *jobset.JobSet) (
 		}
 	}
 
+	for _, err := range validateExclusivePlacementCompletionMode(js) {
+		allErrs = append(allErrs, err)
+	}
+
 	rJobNames := sets.New[string]()
 
 	// Validate each replicatedJob.
@@ -313,7 +317,7 @@ func (j *jobSetWebhook) ValidateCreate(ctx context.Context, js *jobset.JobSet) (
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (j *jobSetWebhook) ValidateUpdate(ctx context.Context, oldJs, newJs *jobset.JobSet) (admission.Warnings, error) {
 	mungedSpec := newJs.Spec.DeepCopy()
-	var errs field.ErrorList
+	errs := validateExclusivePlacementCompletionMode(newJs)
 
 	// Create a map of old ReplicatedJobs by name for safe lookup
 	oldJobsMap := make(map[string]*jobset.ReplicatedJob)
@@ -411,6 +415,31 @@ func (j *jobSetWebhook) ValidateUpdate(ctx context.Context, oldJs, newJs *jobset
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (j *jobSetWebhook) ValidateDelete(ctx context.Context, js *jobset.JobSet) (admission.Warnings, error) {
 	return nil, nil
+}
+
+func validateExclusivePlacementCompletionMode(js *jobset.JobSet) field.ErrorList {
+	var errs field.ErrorList
+	for rJobIdx, rJob := range js.Spec.ReplicatedJobs {
+		if !usesPodWebhookExclusivePlacement(js, rJob) || rJob.Template.Spec.CompletionMode == nil || *rJob.Template.Spec.CompletionMode != batchv1.NonIndexedCompletion {
+			continue
+		}
+		errs = append(errs, field.Forbidden(
+			field.NewPath("spec", "replicatedJobs").Index(rJobIdx).Child("template", "spec", "completionMode"),
+			"NonIndexed completion mode is not supported with exclusive placement unless the node selector strategy is enabled",
+		))
+	}
+	return errs
+}
+
+func usesPodWebhookExclusivePlacement(js *jobset.JobSet, rJob jobset.ReplicatedJob) bool {
+	_, jobSetExclusive := js.Annotations[jobset.ExclusiveKey]
+	_, jobSetNodeSelectorStrategy := js.Annotations[jobset.NodeSelectorStrategyKey]
+	_, replicatedJobExclusive := rJob.Template.Annotations[jobset.ExclusiveKey]
+	_, replicatedJobNodeSelectorStrategy := rJob.Template.Annotations[jobset.NodeSelectorStrategyKey]
+
+	usesNodeSelectorStrategy := (jobSetExclusive && jobSetNodeSelectorStrategy) ||
+		(replicatedJobExclusive && replicatedJobNodeSelectorStrategy)
+	return (jobSetExclusive || replicatedJobExclusive) && !usesNodeSelectorStrategy
 }
 
 // Failure policy constants.

--- a/pkg/webhooks/jobset_webhook_test.go
+++ b/pkg/webhooks/jobset_webhook_test.go
@@ -3195,6 +3195,64 @@ func TestValidateCreate(t *testing.T) {
 	}
 }
 
+func TestValidateExclusivePlacementCompletionMode(t *testing.T) {
+	t.Parallel()
+
+	makeJobSet := func(jobSetAnnotations, replicatedJobAnnotations map[string]string, completionMode batchv1.CompletionMode) *jobset.JobSet {
+		return &jobset.JobSet{
+			ObjectMeta: metav1.ObjectMeta{Annotations: jobSetAnnotations},
+			Spec: jobset.JobSetSpec{ReplicatedJobs: []jobset.ReplicatedJob{{
+				Name: "workers",
+				Template: batchv1.JobTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Annotations: replicatedJobAnnotations},
+					Spec:       batchv1.JobSpec{CompletionMode: ptr.To(completionMode)},
+				},
+			}}},
+		}
+	}
+
+	testCases := map[string]struct {
+		jobSetAnnotations        map[string]string
+		replicatedJobAnnotations map[string]string
+		completionMode           batchv1.CompletionMode
+		wantErr                  bool
+	}{
+		"rejects non-indexed JobSet exclusive placement": {
+			jobSetAnnotations: map[string]string{jobset.ExclusiveKey: "topology.kubernetes.io/zone"},
+			completionMode:    batchv1.NonIndexedCompletion,
+			wantErr:           true,
+		},
+		"rejects non-indexed replicated job exclusive placement": {
+			replicatedJobAnnotations: map[string]string{jobset.ExclusiveKey: "topology.kubernetes.io/zone"},
+			completionMode:           batchv1.NonIndexedCompletion,
+			wantErr:                  true,
+		},
+		"allows indexed exclusive placement": {
+			jobSetAnnotations: map[string]string{jobset.ExclusiveKey: "topology.kubernetes.io/zone"},
+			completionMode:    batchv1.IndexedCompletion,
+		},
+		"allows non-indexed node selector strategy": {
+			jobSetAnnotations: map[string]string{
+				jobset.ExclusiveKey:            "topology.kubernetes.io/zone",
+				jobset.NodeSelectorStrategyKey: "true",
+			},
+			completionMode: batchv1.NonIndexedCompletion,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			errs := validateExclusivePlacementCompletionMode(makeJobSet(tc.jobSetAnnotations, tc.replicatedJobAnnotations, tc.completionMode))
+			if tc.wantErr {
+				require.Len(t, errs, 1)
+				assert.Contains(t, errs[0].Error(), "NonIndexed completion mode")
+			} else {
+				assert.Empty(t, errs)
+			}
+		})
+	}
+}
+
 func TestGetJobSetNameForValidation(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/webhooks/jobset_webhook_test.go
+++ b/pkg/webhooks/jobset_webhook_test.go
@@ -3238,6 +3238,33 @@ func TestValidateExclusivePlacementCompletionMode(t *testing.T) {
 			},
 			completionMode: batchv1.NonIndexedCompletion,
 		},
+		"allows non-indexed replicated job node selector strategy": {
+			replicatedJobAnnotations: map[string]string{
+				jobset.ExclusiveKey:            "topology.kubernetes.io/zone",
+				jobset.NodeSelectorStrategyKey: "true",
+			},
+			completionMode: batchv1.NonIndexedCompletion,
+		},
+		"rejects non-indexed placement when exclusive placement and node selector strategy use different scopes": {
+			jobSetAnnotations: map[string]string{
+				jobset.ExclusiveKey: "topology.kubernetes.io/zone",
+			},
+			replicatedJobAnnotations: map[string]string{
+				jobset.NodeSelectorStrategyKey: "true",
+			},
+			completionMode: batchv1.NonIndexedCompletion,
+			wantErr:        true,
+		},
+		"rejects non-indexed placement when node selector strategy and exclusive placement use different scopes": {
+			jobSetAnnotations: map[string]string{
+				jobset.NodeSelectorStrategyKey: "true",
+			},
+			replicatedJobAnnotations: map[string]string{
+				jobset.ExclusiveKey: "topology.kubernetes.io/zone",
+			},
+			completionMode: batchv1.NonIndexedCompletion,
+			wantErr:        true,
+		},
 	}
 
 	for name, tc := range testCases {

--- a/test/integration/webhook/jobset_webhook_test.go
+++ b/test/integration/webhook/jobset_webhook_test.go
@@ -148,6 +148,19 @@ var _ = ginkgo.Describe("jobset webhook defaulting", func() {
 				return completionMode != nil && *completionMode == batchv1.NonIndexedCompletion
 			},
 		}),
+		ginkgo.Entry("non-indexed completion mode with exclusive placement is rejected", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testing.MakeJobSet("nonindexed-exclusive", ns.Name).
+					SetAnnotations(map[string]string{jobset.ExclusiveKey: "topology.kubernetes.io/zone"}).
+					EnableDNSHostnames(false).
+					ReplicatedJob(testing.MakeReplicatedJob("rjob").
+						Job(testing.MakeJobTemplate("job", ns.Name).
+							CompletionMode(batchv1.NonIndexedCompletion).
+							PodSpec(testing.TestPodSpec).Obj()).
+						Obj())
+			},
+			jobSetCreationShouldFail: true,
+		}),
 		ginkgo.Entry("enableDNSHostnames defaults to true if unset", &testCase{
 			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
 				return testing.MakeJobSet("enablednshostnames-unset", ns.Name).


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Rejects JobSets that combine `completionMode: NonIndexed` with webhook-based exclusive placement.

NonIndexed Pods have no completion index. The follower webhook rejects them, leaving the JobSet stuck

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

Repro: create a JobSet with `completionMode: NonIndexed` and `alpha.jobset.sigs.k8s.io/exclusive-topology`.

Tests: `make test`

The focused envtest integration test could not start locally: `too many open files`

small AI assistance was used

#### Does this PR introduce a user-facing change?

Reject JobSets that use NonIndexed completion mode with webhook-based exclusive placement