### PR TITLE
KEP-1282: Add Execution Attempts Tracking

### DIFF
--- a/keps/1282-execution-attempts/README.md
+++ b/keps/1282-execution-attempts/README.md
@@ -1,0 +1,114 @@
+# KEP-1282: Add Execution Attempts Tracking
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [Example](#example)
+- [Design Details](#design-details)
+  - [API Changes](#api-changes)
+  - [Controller Logic](#controller-logic)
+    - [1. Initialization](#1-initialization)
+    - [2. Increment on resume](#2-increment-on-resume)
+    - [3. Increment on restart](#3-increment-on-restart)
+    - [4. Data propagation](#4-data-propagation)
+- [Test Plan](#test-plan)
+  - [Unit Tests](#unit-tests)
+  - [Integration Tests](#integration-tests)
+<!-- /toc -->
+
+## Summary
+
+This KEP proposes adding an `ExecuteAttempts` counter to the JobSet status and propagating it as a pod annotation (`jobset.sigs.k8s.io/execute-attempt`). This allows external logging and telemetry systems to identify and isolate log streams for different execution cycles of a JobSet, especially when it is repeatedly suspended and resumed (e.g., by Kueue).
+
+## Motivation
+
+Logging deployment streams currently rely on the `jobset.sigs.k8s.io/restart-attempt` annotation to tag logs per execution cycle. However, when queueing workloads (e.g., via Kueue), JobSets are frequently evicted via suspension (terminating pods) and later resumed (spawning new pods).
+
+Because JobSet resumptions do not increment the `restart-attempt` counter (which only increments during failure policy evaluations), logs from multiple distinct execution phases share an identical identifier. Consequently, users cannot properly isolate log streams by their scheduling lifecycle, severely impeding debugging efforts (e.g., isolating logs to investigate node-level hardware failures during a specific execution pass).
+
+### Goals
+
+- Provide a persistent, monotonic counter that increments on **both** failure-triggered restarts and suspension-driven resumptions.  
+- Inject this new metric as a pod annotation to allow external logging systems (like FluentBit) to cleanly slice log iterations.
+
+### Non-Goals
+
+- Alter the lifecycle definitions for `jobset.sigs.k8s.io/restart-attempt`. The existing restart tracking acts strictly on failure conditions and will remain unchanged.
+
+## Proposal
+
+Introduce a new pod annotation (`jobset.sigs.k8s.io/execute-attempt`) to the JobSet API to track the total number of execution iterations a JobSet has undergone.
+
+To track this robustly across controller restarts, a new state field `executeAttempts` will be introduced within `JobSet.status`.
+
+### Example
+
+1. **Initial Scheduled Run:** A JobSet starts. Pods land on Nodepools A and B. Both `restart-attempt` and `execute-attempt` evaluate to `"0"`.  
+2. **Preemption (Eviction):** Kueue evicts the JobSet (`suspend: true`). Active pods are deleted.  
+3. **Resumed Execution:** Kueue readmits the JobSet (`suspend: false`). New pods land on Nodepools C and D.  
+   * Current state: `restart-attempt` remains `"0"`.  
+   * Proposed state: `execute-attempt` increments to `"1"`.
+
+The new annotation provides a distinct monotonic execution token to filter telemetry data accurately.
+
+## Design Details
+
+### API Changes
+
+Add `ExecuteAttempts` to `JobSetStatus` struct:
+
+```go
+type JobSetStatus struct {
+    ...
+	// executeAttempts tracks the number of execution lifecycles.
+	// +optional
+	ExecuteAttempts *int32 `json:"executeAttempts,omitempty"`
+    ...
+}
+```
+
+We use a pointer `*int32` to allow the field to be `nil` initially.
+*   `nil` indicates the JobSet has never run.
+*   `0` indicates the first run.
+*   `>0` indicates subsequent resumptions or restarts.
+
+Define a new constant for the annotation key:
+```go
+const (
+    ...
+	// ExecuteAttemptsKey is the annotation key for the execution attempt count.
+	ExecuteAttemptsKey = "jobset.sigs.k8s.io/execute-attempt"
+)
+```
+
+### Controller Logic
+
+#### 1. Initialization
+When the JobSet starts executing for the first time (either because it was created unsuspended, or when it is first resumed from an initially suspended state), the controller initializes `Status.ExecuteAttempts` to `0`.
+
+#### 2. Increment on resume
+When the JobSet transitions from suspended to unsuspended:
+*   If `Status.ExecuteAttempts` is not `nil`, it is incremented by 1.
+*   The suspended condition is updated to `false`.
+
+#### 3. Increment on restart
+When a failure policy triggers a recreate of all jobs (which is a restart):
+*   `Status.ExecuteAttempts` is incremented by 1.
+
+#### 4. Data propagation
+During child Job creation (in `constructJob`) and during Job resumption (in `resumeJob`), the controller injects the current `Status.ExecuteAttempts` value (defaulting to `0` if nil) into the Job's annotations and its Pod template annotations using the `jobset.sigs.k8s.io/execute-attempt` key.
+This ensures both newly created jobs and existing resumed jobs (which might have updated templates from Kueue) receive the correct annotation.
+
+## Test Plan
+
+### Unit Tests
+*   Verify `ExecuteAttempts` initialization and increment logic in controller unit tests (`pkg/controllers/jobset_controller_test.go`).
+*   Verify annotation propagation in job construction tests.
+
+### Integration Tests
+*   Verify suspend/resume cycles increment `ExecuteAttempts` and propagate annotations to child Jobs and Pods (`test/integration/controller/jobset_controller_test.go`).
+*   Verify failure-triggered restarts increment `ExecuteAttempts`.
+*   Verify that initially suspended JobSet starts with `ExecuteAttempts` unset and initializes to `0` on first resume.

--- a/keps/1282-execution-attempts/README.md
+++ b/keps/1282-execution-attempts/README.md
@@ -10,10 +10,11 @@
 - [Design Details](#design-details)
   - [API Changes](#api-changes)
   - [Controller Logic](#controller-logic)
-    - [1. Initialization](#1-initialization)
-    - [2. Increment on resume](#2-increment-on-resume)
-    - [3. Increment on restart](#3-increment-on-restart)
-    - [4. Data propagation](#4-data-propagation)
+    - [1. Initialization and Upgrade Migration](#1-initialization-and-upgrade-migration)
+    - [2. Increment on resume (with Idempotency)](#2-increment-on-resume-with-idempotency)
+    - [3. Increment on restart (with Idempotency)](#3-increment-on-restart-with-idempotency)
+    - [4. Atomicity of Updates on Resume and Data Propagation](#4-atomicity-of-updates-on-resume-and-data-propagation)
+    - [5. Feature Gate Disabled Behavior](#5-feature-gate-disabled-behavior)
 - [Test Plan](#test-plan)
   - [Unit Tests](#unit-tests)
   - [Integration Tests](#integration-tests)
@@ -21,7 +22,7 @@
 
 ## Summary
 
-This KEP proposes adding an `ExecuteAttempts` counter to the JobSet status and propagating it as a pod annotation (`jobset.sigs.k8s.io/execute-attempt`). This allows external logging and telemetry systems to identify and isolate log streams for different execution cycles of a JobSet, especially when it is repeatedly suspended and resumed (e.g., by Kueue).
+This KEP proposes adding an `ExecutionAttempts` counter to the JobSet status and propagating it as a pod annotation (`jobset.sigs.k8s.io/execution-attempt`). This allows external logging and telemetry systems to identify and isolate log streams for different execution cycles of a JobSet, especially when it is repeatedly suspended and resumed (e.g., by Kueue).
 
 ## Motivation
 
@@ -32,7 +33,8 @@ Because JobSet resumptions do not increment the `restart-attempt` counter (which
 ### Goals
 
 - Provide a persistent, monotonic counter that increments on **both** failure-triggered restarts and suspension-driven resumptions.  
-- Inject this new metric as a pod annotation to allow external logging systems (like FluentBit) to cleanly slice log iterations.
+- Inject this new metric as a pod annotation (`jobset.sigs.k8s.io/execution-attempt`) to allow external logging systems (like FluentBit) to cleanly slice log iterations.
+- Support seamless upgrades of the JobSet controller while JobSets are running in the cluster without resetting attempt counts.
 
 ### Non-Goals
 
@@ -40,17 +42,17 @@ Because JobSet resumptions do not increment the `restart-attempt` counter (which
 
 ## Proposal
 
-Introduce a new pod annotation (`jobset.sigs.k8s.io/execute-attempt`) to the JobSet API to track the total number of execution iterations a JobSet has undergone.
+Introduce a new pod annotation (`jobset.sigs.k8s.io/execution-attempt`) to the JobSet API to track the total number of execution iterations a JobSet has undergone.
 
-To track this robustly across controller restarts, a new state field `executeAttempts` will be introduced within `JobSet.status`.
+To track this robustly across controller restarts, a new state field `executionAttempts` will be introduced within `JobSet.status`.
 
 ### Example
 
-1. **Initial Scheduled Run:** A JobSet starts. Pods land on Nodepools A and B. Both `restart-attempt` and `execute-attempt` evaluate to `"0"`.  
+1. **Initial Scheduled Run:** A JobSet starts. Pods land on Nodepools A and B. Both `restart-attempt` and `execution-attempt` evaluate to `"0"`.  
 2. **Preemption (Eviction):** Kueue evicts the JobSet (`suspend: true`). Active pods are deleted.  
 3. **Resumed Execution:** Kueue readmits the JobSet (`suspend: false`). New pods land on Nodepools C and D.  
    * Current state: `restart-attempt` remains `"0"`.  
-   * Proposed state: `execute-attempt` increments to `"1"`.
+   * Proposed state: `execution-attempt` increments to `"1"`.
 
 The new annotation provides a distinct monotonic execution token to filter telemetry data accurately.
 
@@ -58,20 +60,20 @@ The new annotation provides a distinct monotonic execution token to filter telem
 
 ### API Changes
 
-Add `ExecuteAttempts` to `JobSetStatus` struct:
+Add `ExecutionAttempts` to `JobSetStatus` struct:
 
 ```go
 type JobSetStatus struct {
     ...
-	// executeAttempts tracks the number of execution lifecycles.
+	// executionAttempts tracks the number of execution lifecycles.
 	// +optional
-	ExecuteAttempts *int32 `json:"executeAttempts,omitempty"`
+	ExecutionAttempts *int32 `json:"executionAttempts,omitempty"`
     ...
 }
 ```
 
 We use a pointer `*int32` to allow the field to be `nil` initially.
-*   `nil` indicates the JobSet has never run.
+*   `nil` indicates the JobSet has never run, or the feature gate is disabled.
 *   `0` indicates the first run.
 *   `>0` indicates subsequent resumptions or restarts.
 
@@ -79,36 +81,47 @@ Define a new constant for the annotation key:
 ```go
 const (
     ...
-	// ExecuteAttemptsKey is the annotation key for the execution attempt count.
-	ExecuteAttemptsKey = "jobset.sigs.k8s.io/execute-attempt"
+	// ExecutionAttemptsKey is the annotation key for the execution attempt count.
+	ExecutionAttemptsKey = "jobset.sigs.k8s.io/execution-attempt"
 )
 ```
 
 ### Controller Logic
 
-#### 1. Initialization
-When the JobSet starts executing for the first time (either because it was created unsuspended, or when it is first resumed from an initially suspended state), the controller initializes `Status.ExecuteAttempts` to `0`.
+#### 1. Initialization and Upgrade Migration
+When the JobSet controller reconciles a JobSet where `Status.ExecutionAttempts` is `nil`, it distinguishes between a new JobSet and an existing running JobSet (e.g., during a controller upgrade while workloads are actively running in the cluster):
+*   **Upgrade Semantics for Running Workloads:** If `Status.ExecutionAttempts` is `nil` but the JobSet has already started executing (i.e., `Status.Restarts > 0` or active child Jobs exist), the controller initializes `Status.ExecutionAttempts` to the current `Status.Restarts` value. This migration rule ensures that existing workloads maintain the invariant `ExecutionAttempts >= Restarts` and prevents resetting the attempt count to `0` mid-run after a controller upgrade.
+*   **New Workloads:** If `Status.ExecutionAttempts` is `nil` and the JobSet has not started executing yet (new JobSet created unsuspended, or first resumed from an initially suspended state), the controller initializes `Status.ExecutionAttempts` to `0`.
 
-#### 2. Increment on resume
-When the JobSet transitions from suspended to unsuspended:
-*   If `Status.ExecuteAttempts` is not `nil`, it is incremented by 1.
+#### 2. Increment on resume (with Idempotency)
+When the JobSet transitions from suspended to unsuspended (`spec.suspend` transitions from `true` to `false`):
+*   If `Status.ExecutionAttempts` is not `nil`, it is incremented by 1.
 *   The suspended condition is updated to `false`.
+*   **Idempotency:** The increment operation is idempotent and occurs **exactly once per event** (once per suspend->unsuspend transition), regardless of the number of child Jobs or how many times reconciliation is retried due to transient conflicts or requeues.
 
-#### 3. Increment on restart
+#### 3. Increment on restart (with Idempotency)
 When a failure policy triggers a recreate of all jobs (which is a restart):
-*   `Status.ExecuteAttempts` is incremented by 1.
+*   `Status.ExecutionAttempts` is incremented by 1.
+*   **Idempotency:** The increment occurs **exactly once per failure restart event**, regardless of the number of child Jobs or reconciliation retries.
 
-#### 4. Data propagation
-During child Job creation (in `constructJob`) and during Job resumption (in `resumeJob`), the controller injects the current `Status.ExecuteAttempts` value (defaulting to `0` if nil) into the Job's annotations and its Pod template annotations using the `jobset.sigs.k8s.io/execute-attempt` key.
-This ensures both newly created jobs and existing resumed jobs (which might have updated templates from Kueue) receive the correct annotation.
+#### 4. Atomicity of Updates on Resume and Data Propagation
+*   **Atomicity on Resume:** When resuming a suspended JobSet, the controller MUST update the `jobset.sigs.k8s.io/execution-attempt` annotation on child Jobs and Pod templates **before or atomically with** clearing `spec.suspend` (`spec.suspend = false`). This prevents any race condition where child Pods are created with stale attempt annotations before the controller has updated them.
+*   **Data Propagation:** During child Job creation (in `constructJob`) and during Job resumption (in `resumeJob`), the controller injects the current `Status.ExecutionAttempts` value (defaulting to `0` if nil) into the Job's annotations and its Pod template annotations using the `jobset.sigs.k8s.io/execution-attempt` key. This ensures both newly created jobs and existing resumed jobs (which might have updated templates from Kueue) receive the correct annotation.
+
+#### 5. Feature Gate Disabled Behavior
+The execution attempts tracking feature is controlled by the `ExecutionAttemptsTracking` feature gate (alpha).
+*   When the `ExecutionAttemptsTracking` feature gate is **disabled**, the controller will leave `Status.ExecutionAttempts` unset (`nil`) and will not inject or update the `jobset.sigs.k8s.io/execution-attempt` annotation on child Jobs or Pods.
 
 ## Test Plan
 
 ### Unit Tests
-*   Verify `ExecuteAttempts` initialization and increment logic in controller unit tests (`pkg/controllers/jobset_controller_test.go`).
+*   Verify `ExecutionAttempts` initialization and upgrade migration logic (`nil` -> `restarts` when active jobs or restarts exist) in controller unit tests (`pkg/controllers/jobset_controller_test.go`).
+*   Verify increment idempotency across repeated reconciliation attempts.
 *   Verify annotation propagation in job construction tests.
+*   Verify feature gate disabled behavior (no status update, no annotation injection).
 
 ### Integration Tests
-*   Verify suspend/resume cycles increment `ExecuteAttempts` and propagate annotations to child Jobs and Pods (`test/integration/controller/jobset_controller_test.go`).
-*   Verify failure-triggered restarts increment `ExecuteAttempts`.
-*   Verify that initially suspended JobSet starts with `ExecuteAttempts` unset and initializes to `0` on first resume.
+*   Verify suspend/resume cycles increment `ExecutionAttempts` exactly once per cycle and propagate annotations to child Jobs and Pods (`test/integration/controller/jobset_controller_test.go`).
+*   Verify failure-triggered restarts increment `ExecutionAttempts`.
+*   Verify that an existing running JobSet with `nil` `ExecutionAttempts` initializes to `Status.Restarts` upon reconciliation.
+*   Verify that initially suspended JobSet starts with `ExecutionAttempts` unset and initializes to `0` on first resume.

--- a/keps/1282-execution-attempts/README.md
+++ b/keps/1282-execution-attempts/README.md
@@ -34,7 +34,7 @@ Because JobSet resumptions do not increment the `restart-attempt` counter (which
 
 - Provide a persistent, monotonic counter that increments on **both** failure-triggered restarts and suspension-driven resumptions.  
 - Inject this new metric as a pod annotation (`jobset.sigs.k8s.io/execution-attempt`) to allow external logging systems (like FluentBit) to cleanly slice log iterations.
-- Support seamless upgrades of the JobSet controller while JobSets are running in the cluster without resetting attempt counts.
+- Support seamless upgrades of the JobSet controller while JobSets are active in the cluster, preserving the `ExecutionAttempts >= Restarts` invariant.
 
 ### Non-Goals
 
@@ -67,6 +67,7 @@ type JobSetStatus struct {
     ...
 	// executionAttempts tracks the number of execution lifecycles.
 	// +optional
+	// +kubebuilder:validation:Minimum=0
 	ExecutionAttempts *int32 `json:"executionAttempts,omitempty"`
     ...
 }
@@ -91,7 +92,7 @@ const (
 #### 1. Initialization and Upgrade Migration
 When the JobSet controller reconciles a JobSet where `Status.ExecutionAttempts` is `nil`, it distinguishes between a new JobSet and an existing running JobSet (e.g., during a controller upgrade while workloads are actively running in the cluster):
 *   **Upgrade Semantics for Running Workloads:** If `Status.ExecutionAttempts` is `nil` but the JobSet has already started executing (i.e., `Status.Restarts > 0` or active child Jobs exist), the controller initializes `Status.ExecutionAttempts` to the current `Status.Restarts` value. This migration rule ensures that existing workloads maintain the invariant `ExecutionAttempts >= Restarts` and prevents resetting the attempt count to `0` mid-run after a controller upgrade.
-*   **New Workloads:** If `Status.ExecutionAttempts` is `nil` and the JobSet has not started executing yet (new JobSet created unsuspended, or first resumed from an initially suspended state), the controller initializes `Status.ExecutionAttempts` to `0`.
+*   **New Workloads & Pre-Upgrade Suspended Workloads:** If `Status.ExecutionAttempts` is `nil` and the JobSet has no active child Jobs and `Status.Restarts == 0` (e.g., newly created suspended JobSets, or JobSets suspended prior to upgrade without restart history), the controller initializes `Status.ExecutionAttempts` to `0` upon first resumption.
 
 #### 2. Increment on resume (with Idempotency)
 When the JobSet transitions from suspended to unsuspended (`spec.suspend` transitions from `true` to `false`):
@@ -105,12 +106,12 @@ When a failure policy triggers a recreate of all jobs (which is a restart):
 *   **Idempotency:** The increment occurs **exactly once per failure restart event**, regardless of the number of child Jobs or reconciliation retries.
 
 #### 4. Atomicity of Updates on Resume and Data Propagation
-*   **Atomicity on Resume:** When resuming a suspended JobSet, the controller MUST update the `jobset.sigs.k8s.io/execution-attempt` annotation on child Jobs and Pod templates **before or atomically with** clearing `spec.suspend` (`spec.suspend = false`). This prevents any race condition where child Pods are created with stale attempt annotations before the controller has updated them.
+*   **Atomicity on Resume:** When resuming a suspended JobSet, the controller synchronously persists the updated `Status.ExecutionAttempts` to etcd and updates the `jobset.sigs.k8s.io/execution-attempt` annotation on child Jobs and Pod templates **before** clearing each child Job's `spec.suspend` (`job.Spec.Suspend = false`). This prevents any race condition where child Pods are spawned with stale attempt annotations before metadata is committed.
 *   **Data Propagation:** During child Job creation (in `constructJob`) and during Job resumption (in `resumeJob`), the controller injects the current `Status.ExecutionAttempts` value (defaulting to `0` if nil) into the Job's annotations and its Pod template annotations using the `jobset.sigs.k8s.io/execution-attempt` key. This ensures both newly created jobs and existing resumed jobs (which might have updated templates from Kueue) receive the correct annotation.
 
 #### 5. Feature Gate Disabled Behavior
 The execution attempts tracking feature is controlled by the `ExecutionAttemptsTracking` feature gate (alpha).
-*   When the `ExecutionAttemptsTracking` feature gate is **disabled**, the controller will leave `Status.ExecutionAttempts` unset (`nil`) and will not inject or update the `jobset.sigs.k8s.io/execution-attempt` annotation on child Jobs or Pods.
+*   When the `ExecutionAttemptsTracking` feature gate is **disabled**, the controller will leave `Status.ExecutionAttempts` unset (`nil`) for new JobSets, preserve any existing values on already tracked JobSets without further updates, and will not inject or update the `jobset.sigs.k8s.io/execution-attempt` annotation on child Jobs or Pods. Upon re-enabling the feature gate, tracking resumes from the persisted `Status.ExecutionAttempts` value.
 
 ## Test Plan
 
@@ -118,7 +119,7 @@ The execution attempts tracking feature is controlled by the `ExecutionAttemptsT
 *   Verify `ExecutionAttempts` initialization and upgrade migration logic (`nil` -> `restarts` when active jobs or restarts exist) in controller unit tests (`pkg/controllers/jobset_controller_test.go`).
 *   Verify increment idempotency across repeated reconciliation attempts.
 *   Verify annotation propagation in job construction tests.
-*   Verify feature gate disabled behavior (no status update, no annotation injection).
+*   Verify feature gate disabled and re-enabled transitions.
 
 ### Integration Tests
 *   Verify suspend/resume cycles increment `ExecutionAttempts` exactly once per cycle and propagate annotations to child Jobs and Pods (`test/integration/controller/jobset_controller_test.go`).

--- a/keps/1282-execution-attempts/kep.yaml
+++ b/keps/1282-execution-attempts/kep.yaml
@@ -1,0 +1,18 @@
+title: Add Execution Attempts Tracking
+kep-number: 1282
+authors:
+  - "@jianqiaol"
+status: implementable
+creation-date: 2026-07-27
+reviewers:
+  - "@kannon92"
+approvers:
+  - "@andreyvelich"
+see-also:
+  - "NA"
+replaces:
+  - "NA"
+stage: alpha
+latest-milestone: "v0.13.0"
+milestone:
+  alpha: "v0.13.0"


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
This PR introduces **KEP-1282: Add Execution Attempts Tracking**. 

The KEP proposes adding a monotonic `ExecutionAttempts` counter to `JobSet.Status` and propagating it as a pod annotation (`jobset.sigs.k8s.io/execution-attempt`). 

**Why we need it:**
Currently, `jobset.sigs.k8s.io/restart-attempt` only tracks failure-triggered restarts. When queueing workloads (e.g., via Kueue), JobSets are frequently suspended (terminating pods) and later resumed (spawning new pods). These suspension/resumption cycles do not increment the restart counter, causing logs from different execution phases to share the same identifier. 

The proposed `execution-attempt` annotation will allow external logging and telemetry systems to cleanly identify and isolate log streams for different execution cycles of a JobSet.

#### Which issue(s) this PR fixes:
Issue [#1282](https://github.com/kubernetes-sigs/jobset/issues/1282)

#### Special notes for your reviewer:
This PR only contains the KEP design document. The implementation changes have been split into a separate PR ([#1283](https://github.com/kubernetes-sigs/jobset/pull/1283)).

**Key Design Updates in KEP:**
- **Upgrade Migration Logic**: The design has been updated to handle controller upgrades gracefully. For active JobSets with `nil` attempts, the controller will initialize `status.executionAttempts` to the current `status.restarts` value (instead of `0`) to preserve history and maintain the `executionAttempts >= restarts` invariant. New JobSets will initialize to `0`.

#### Does this PR introduce a user-facing change?
```release-note
NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a proposal to track JobSet execution attempts through status information.
  * Jobs and Pods will expose their execution attempt through annotations.
  * Defines behavior for retries, suspended execution resumes, upgrades, and feature-gate-disabled environments.
* **Documentation**
  * Added lifecycle, rollout, migration, and testing details for the proposed feature.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->