### PR TITLE
Rebuild child Job scheduling directives on resume instead of merging

### DIFF
--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -651,8 +651,8 @@ func (r *JobSetReconciler) resumeJob(ctx context.Context, job *batchv1.Job, repl
 		// Certain fields on the Job pod template may be mutated while a JobSet is suspended,
 		// for integration with Kueue. Ensure these updates are propagated to the child Jobs
 		// when the JobSet is resumed.
-		// Merge values rather than overwriting them, since a different controller
-		// (e.g., the Job controller) may have added labels/annotations/etc to the
+		// Labels and annotations are merged rather than overwritten, since a different
+		// controller (e.g., the Job controller) may have added labels/annotations to the
 		// Job that do not exist in the ReplicatedJob pod template.
 		job.Spec.Template.Labels = collections.MergeMaps(
 			job.Spec.Template.Labels,
@@ -662,18 +662,20 @@ func (r *JobSetReconciler) resumeJob(ctx context.Context, job *batchv1.Job, repl
 			job.Spec.Template.Annotations,
 			replicatedJobPodTemplate.Annotations,
 		)
-		job.Spec.Template.Spec.NodeSelector = collections.MergeMaps(
-			job.Spec.Template.Spec.NodeSelector,
-			replicatedJobPodTemplate.Spec.NodeSelector,
-		)
-		job.Spec.Template.Spec.Tolerations = collections.MergeSlices(
-			job.Spec.Template.Spec.Tolerations,
-			replicatedJobPodTemplate.Spec.Tolerations,
-		)
-		job.Spec.Template.Spec.SchedulingGates = collections.MergeSlices(
-			job.Spec.Template.Spec.SchedulingGates,
-			replicatedJobPodTemplate.Spec.SchedulingGates,
-		)
+		// Scheduling directives are rebuilt from the pod template rather than merged:
+		// no other controller adds entries to them on the Job, and merging would keep
+		// directives injected for a previous admission (e.g., by Kueue for a different
+		// ResourceFlavor), leaving pods unschedulable or placed on the wrong nodes.
+		// JobSet-owned entries added by constructJob are re-applied below.
+		job.Spec.Template.Spec.NodeSelector = maps.Clone(replicatedJobPodTemplate.Spec.NodeSelector)
+		job.Spec.Template.Spec.Tolerations = slices.Clone(replicatedJobPodTemplate.Spec.Tolerations)
+		job.Spec.Template.Spec.SchedulingGates = slices.Clone(replicatedJobPodTemplate.Spec.SchedulingGates)
+		_, exclusivePlacement := job.Annotations[jobset.ExclusiveKey]
+		_, nodeSelectorStrategy := job.Annotations[jobset.NodeSelectorStrategyKey]
+		if exclusivePlacement && nodeSelectorStrategy {
+			addNamespacedJobNodeSelector(job)
+			addTaintToleration(job)
+		}
 	} else {
 		log.Error(nil, "job missing ReplicatedJobName label")
 	}

--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -146,6 +146,26 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 				Operator: corev1.TolerationOpExists,
 			},
 		},
+		schedulingGates: []corev1.PodSchedulingGate{
+			{Name: "example.com/gate-a"},
+		},
+	}
+
+	// Second set of scheduling directives, disjoint from podTemplateUpdates,
+	// simulating re-admission by Kueue on a different ResourceFlavor.
+	var podTemplateUpdatesFlavorB = &updatePodTemplateOpts{
+		labels:       map[string]string{"label": "value-b"},
+		annotations:  map[string]string{"annotation": "value-b"},
+		nodeSelector: map[string]string{"node-selector-test-b": "node-selector-test-b"},
+		tolerations: []corev1.Toleration{
+			{
+				Key:      "key-b",
+				Operator: corev1.TolerationOpExists,
+			},
+		},
+		schedulingGates: []corev1.PodSchedulingGate{
+			{Name: "example.com/gate-b"},
+		},
 	}
 
 	ginkgo.DescribeTable("jobset is created and its jobs go through a series of updates",
@@ -1517,6 +1537,75 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 							},
 						})
 					},
+				},
+			},
+		}),
+		ginkgo.Entry("resuming twice with different scheduling directives does not leave stale directives on child jobs", &testCase{
+			makeJobSet: func(ns *corev1.Namespace) *testing.JobSetWrapper {
+				return testJobSet(ns).Suspend(true)
+			},
+			steps: []*step{
+				{
+					checkJobSetState: func(js *jobset.JobSet) {
+						ginkgo.By("checking all jobs are suspended")
+						gomega.Eventually(matchJobsSuspendState, timeout, interval).WithArguments(js, true).Should(gomega.Equal(true))
+					},
+					checkJobSetCondition: testutil.JobSetSuspended,
+				},
+				{
+					jobUpdateFn: setJobsSuspendedCondition,
+				},
+				{
+					// First admission: inject flavor A scheduling directives while suspended.
+					jobSetUpdateFn: func(js *jobset.JobSet) {
+						updatePodTemplates(js, podTemplateUpdates)
+					},
+				},
+				{
+					jobSetUpdateFn: func(js *jobset.JobSet) {
+						suspendJobSet(js, false)
+					},
+					checkJobSetState: func(js *jobset.JobSet) {
+						gomega.Eventually(matchJobsSuspendState, timeout, interval).WithArguments(js, false).Should(gomega.Equal(true))
+						ginkgo.By("checking jobs carry flavor A directives")
+						gomega.Eventually(checkPodTemplateUpdates, timeout, interval).WithArguments(js, podTemplateUpdates).Should(gomega.Equal(true))
+					},
+					checkJobSetCondition: testutil.JobSetResumed,
+				},
+				{
+					// Eviction: suspend the jobset again.
+					jobSetUpdateFn: func(js *jobset.JobSet) {
+						suspendJobSet(js, true)
+					},
+					checkJobSetState: func(js *jobset.JobSet) {
+						ginkgo.By("checking all jobs are suspended again")
+						gomega.Eventually(matchJobsSuspendState, timeout, interval).WithArguments(js, true).Should(gomega.Equal(true))
+					},
+					checkJobSetCondition: testutil.JobSetSuspended,
+				},
+				{
+					jobUpdateFn: setJobsSuspendedCondition,
+				},
+				{
+					// Second admission: the JobSet template now carries only flavor B
+					// directives (Kueue restores the template on eviction, then injects
+					// the directives of the newly assigned flavor).
+					jobSetUpdateFn: func(js *jobset.JobSet) {
+						updatePodTemplates(js, podTemplateUpdatesFlavorB)
+					},
+				},
+				{
+					jobSetUpdateFn: func(js *jobset.JobSet) {
+						suspendJobSet(js, false)
+					},
+					checkJobSetState: func(js *jobset.JobSet) {
+						gomega.Eventually(matchJobsSuspendState, timeout, interval).WithArguments(js, false).Should(gomega.Equal(true))
+						ginkgo.By("checking jobs carry flavor B directives")
+						gomega.Eventually(checkPodTemplateUpdates, timeout, interval).WithArguments(js, podTemplateUpdatesFlavorB).Should(gomega.Equal(true))
+						ginkgo.By("checking flavor A directives were removed from child jobs")
+						gomega.Eventually(checkStaleDirectivesRemoved, timeout, interval).WithArguments(js, podTemplateUpdates).Should(gomega.Equal(true))
+					},
+					checkJobSetCondition: testutil.JobSetResumed,
 				},
 			},
 		}),
@@ -3623,10 +3712,11 @@ func suspendJobSet(js *jobset.JobSet, suspend bool) {
 // which can be mutated on a ReplicatedJob template
 // while a JobSet is suspended.
 type updatePodTemplateOpts struct {
-	labels       map[string]string
-	annotations  map[string]string
-	nodeSelector map[string]string
-	tolerations  []corev1.Toleration
+	labels          map[string]string
+	annotations     map[string]string
+	nodeSelector    map[string]string
+	tolerations     []corev1.Toleration
+	schedulingGates []corev1.PodSchedulingGate
 }
 
 func updatePodTemplates(js *jobset.JobSet, opts *updatePodTemplateOpts) {
@@ -3648,6 +3738,9 @@ func updatePodTemplates(js *jobset.JobSet, opts *updatePodTemplateOpts) {
 
 			// Update tolerations.
 			podTemplate.Spec.Tolerations = opts.tolerations
+
+			// Update scheduling gates.
+			podTemplate.Spec.SchedulingGates = opts.schedulingGates
 		}
 		return k8sClient.Update(ctx, &jsGet)
 	}, timeout, interval).Should(gomega.Succeed())
@@ -3707,6 +3800,13 @@ func checkPodTemplateUpdates(js *jobset.JobSet, podTemplateUpdates *updatePodTem
 			}
 		}
 
+		// Check scheduling gates were updated.
+		for _, gate := range podTemplateUpdates.schedulingGates {
+			if !slices.Contains(job.Spec.Template.Spec.SchedulingGates, gate) {
+				return false, fmt.Errorf("missing scheduling gate %v", gate)
+			}
+		}
+
 		jobsUpdated++
 	}
 	// Calculate expected number of updated jobs
@@ -3715,6 +3815,36 @@ func checkPodTemplateUpdates(js *jobset.JobSet, podTemplateUpdates *updatePodTem
 		wantJobsUpdated += int(rjob.Replicas)
 	}
 	return wantJobsUpdated == jobsUpdated, nil
+}
+
+// checkStaleDirectivesRemoved verifies that no child job still carries scheduling
+// directives (nodeSelector keys, tolerations) from a previous resume cycle.
+func checkStaleDirectivesRemoved(js *jobset.JobSet, stale *updatePodTemplateOpts) (bool, error) {
+	var jobList batchv1.JobList
+	if err := k8sClient.List(ctx, &jobList, client.InNamespace(js.Namespace)); err != nil {
+		return false, err
+	}
+	if len(jobList.Items) != testutil.NumExpectedJobs(js) {
+		return false, nil
+	}
+	for _, job := range jobList.Items {
+		for label := range stale.nodeSelector {
+			if _, ok := job.Spec.Template.Spec.NodeSelector[label]; ok {
+				return false, fmt.Errorf("job %s still carries stale node selector key %q", job.Name, label)
+			}
+		}
+		for _, toleration := range stale.tolerations {
+			if slices.Contains(job.Spec.Template.Spec.Tolerations, toleration) {
+				return false, fmt.Errorf("job %s still carries stale toleration %v", job.Name, toleration)
+			}
+		}
+		for _, gate := range stale.schedulingGates {
+			if slices.Contains(job.Spec.Template.Spec.SchedulingGates, gate) {
+				return false, fmt.Errorf("job %s still carries stale scheduling gate %v", job.Name, gate)
+			}
+		}
+	}
+	return true, nil
 }
 
 func checkJobsRecreated(js *jobset.JobSet, expectedRestarts int) (bool, error) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When a JobSet is resumed, `resumeJob` propagates `nodeSelector`, `tolerations` and `schedulingGates` from the ReplicatedJob pod template into existing child Jobs by **merging** (`MergeMaps` / `MergeSlices`). Merging never removes entries, so directives injected during a previous suspended phase survive later suspend/resume cycles.

This breaks the Kueue integration whenever a workload is re-admitted with different scheduling directives: Kueue admits on flavor A (injects `nodeSelector {a: va}`), evicts (JobSet suspended, JobSet template restored — but the child Jobs keep `{a: va}`), then re-admits on flavor B (injects `{b: vb}`). After the second resume the child Jobs carry **both** selectors, so their pods require the intersection of both flavors' node labels — typically unschedulable, with no error surfaced anywhere; combined with `waitForPodsReady` this produces an endless evict/re-admit loop. Stale tolerations accumulate the same way.

The fix rebuilds these three fields from the pod template on resume (they are owned by the template — no other controller adds entries to them on the child Job), then re-applies the JobSet-owned exclusive-placement entries through the same helpers `constructJob` uses (`addNamespacedJobNodeSelector`, `addTaintToleration`). Labels and annotations keep merge semantics, since other controllers legitimately add entries to those.

#### Which issue(s) this PR fixes:

None filed; happy to open one if preferred.

#### Special notes for your reviewer:

- The new integration test drives the exact scenario (suspend → inject A → resume → suspend → replace with B → resume). Without the controller change it fails with: `job test-js-replicated-job-a-0 still carries stale node selector key "node-selector-test-a"`. Existing tests only asserted that new directives appear, never that stale ones are removed.
- Full integration suite (66 specs) and unit tests pass with the change.
- AI tooling (Claude Code) was used to assist with this contribution; the mechanism, repro and fix were verified manually.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where nodeSelector, tolerations and schedulingGates injected into child Jobs while a JobSet was suspended (e.g. by Kueue) were not removed on later suspend/resume cycles, leaving pods requiring stale node selectors and potentially unschedulable after re-admission.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resuming suspended Jobs now correctly refreshes scheduling directives, including node selectors, tolerations, scheduling gates, and exclusive placement settings.
  * Previous scheduling values are removed when new directives are applied, preventing stale configuration from persisting across resume cycles.

* **Tests**
  * Added integration coverage for suspending and resuming JobSets with changing scheduling directives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->