### PR TITLE
Populate headless service ports from container ports

### DIFF
--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -23,6 +23,7 @@ import (
 	"slices"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 
 	"k8s.io/utils/clock"
@@ -34,6 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
@@ -785,6 +787,49 @@ func (r *JobSetReconciler) deleteJobs(ctx context.Context, jobsForDeletion []*ba
 
 // TODO: look into adopting service and updating the selector
 // if it is not matching the job selector.
+// headlessSvcPorts collects the unique container ports declared across all
+// replicatedJobs' pod templates, so service meshes like Istio (which only
+// route to ports declared on the Service) can reach headless service pods.
+// Ports with a zero container port are skipped, an empty protocol defaults to
+// TCP, and entries are deduplicated by port number and protocol. If no
+// container declares a port, this returns nil and the service is created
+// without ports, preserving the previous behavior.
+func headlessSvcPorts(js *jobset.JobSet) []corev1.ServicePort {
+	seen := make(map[string]bool)
+	var ports []corev1.ServicePort
+	for i := range js.Spec.ReplicatedJobs {
+		podSpec := js.Spec.ReplicatedJobs[i].Template.Spec.Template.Spec
+		for c := range podSpec.Containers {
+			for _, p := range podSpec.Containers[c].Ports {
+				if p.ContainerPort == 0 {
+					continue
+				}
+				proto := p.Protocol
+				if proto == "" {
+					proto = corev1.ProtocolTCP
+				}
+				key := fmt.Sprintf("%d/%s", p.ContainerPort, proto)
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+				ports = append(ports, corev1.ServicePort{
+					// Name is <transport>-<port> (e.g. tcp-8080) to give each port a
+					// unique, deterministic identifier within the 15 character limit
+					// Kubernetes enforces on port names. This is a naming scheme only;
+					// meshes select L7 protocols via the name prefix (http-/grpc-/...)
+					// or appProtocol, which this does not set.
+					Name:       fmt.Sprintf("%s-%d", strings.ToLower(string(proto)), p.ContainerPort),
+					Port:       p.ContainerPort,
+					TargetPort: intstr.FromInt32(p.ContainerPort),
+					Protocol:   proto,
+				})
+			}
+		}
+	}
+	return ports
+}
+
 func (r *JobSetReconciler) createHeadlessSvcIfNecessary(ctx context.Context, js *jobset.JobSet) error {
 	log := ctrl.LoggerFrom(ctx)
 
@@ -814,6 +859,7 @@ func (r *JobSetReconciler) createHeadlessSvcIfNecessary(ctx context.Context, js 
 					jobset.JobSetNameKey: js.Name,
 				},
 				PublishNotReadyAddresses: ptr.Deref(js.Spec.Network.PublishNotReadyAddresses, true),
+				Ports:                    headlessSvcPorts(js),
 			},
 		}
 
@@ -828,6 +874,19 @@ func (r *JobSetReconciler) createHeadlessSvcIfNecessary(ctx context.Context, js 
 			return err
 		}
 		log.V(2).Info("successfully created headless service", "service", klog.KObj(&headlessSvc))
+		return nil
+	}
+
+	// Service already exists. If we own it, keep its ports in sync with the
+	// declared container ports (e.g. after an upgrade that adds port propagation
+	// to a headless service created without ports).
+	desiredPorts := headlessSvcPorts(js)
+	if metav1.IsControlledBy(&headlessSvc, js) && !apiequality.Semantic.DeepEqual(headlessSvc.Spec.Ports, desiredPorts) {
+		headlessSvc.Spec.Ports = desiredPorts
+		if err := r.Update(ctx, &headlessSvc); err != nil {
+			return err
+		}
+		log.V(2).Info("updated headless service ports", "service", klog.KObj(&headlessSvc))
 	}
 	return nil
 }

--- a/pkg/controllers/jobset_controller_test.go
+++ b/pkg/controllers/jobset_controller_test.go
@@ -28,15 +28,20 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/klog/v2/ktesting"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
@@ -1860,6 +1865,124 @@ func TestCreateHeadlessSvcIfNecessary(t *testing.T) {
 			}
 			if tc.expectServiceCreate && servicesCreated != 1 {
 				t.Errorf("expected 1 service to be created, got %d created services", servicesCreated)
+			}
+		})
+	}
+}
+
+func TestCreateHeadlessSvcIfNecessaryUpdatesExistingPorts(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	scheme := runtime.NewScheme()
+	utilruntime.Must(jobset.AddToScheme(scheme))
+	utilruntime.Must(corev1.AddToScheme(scheme))
+
+	js := testutils.MakeJobSet("test-jobset", "default").EnableDNSHostnames(true).Obj()
+	js.Spec.ReplicatedJobs = []jobset.ReplicatedJob{{
+		Name: "rjob",
+		Template: batchv1.JobTemplateSpec{Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{Containers: []corev1.Container{
+				{Name: "c", Ports: []corev1.ContainerPort{{ContainerPort: 8080}}},
+			}},
+		}}},
+	}}
+
+	// Existing controller-owned headless service created without ports (pre-upgrade).
+	existing := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-jobset", Namespace: "default"},
+		Spec:       corev1.ServiceSpec{ClusterIP: corev1.ClusterIPNone},
+	}
+	require.NoError(t, ctrl.SetControllerReference(js, existing, scheme))
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+	r := &JobSetReconciler{Client: fakeClient, Scheme: scheme, Record: events.NewFakeRecorder(32)}
+
+	require.NoError(t, r.createHeadlessSvcIfNecessary(ctx, js))
+
+	var got corev1.Service
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: "test-jobset", Namespace: "default"}, &got))
+	want := []corev1.ServicePort{
+		{Name: "tcp-8080", Port: 8080, TargetPort: intstr.FromInt32(8080), Protocol: corev1.ProtocolTCP},
+	}
+	assert.Empty(t, cmp.Diff(want, got.Spec.Ports), "unexpected service ports")
+}
+
+func TestHeadlessSvcPorts(t *testing.T) {
+	container := func(ports ...corev1.ContainerPort) corev1.Container {
+		return corev1.Container{Name: "c", Ports: ports}
+	}
+	jsWith := func(containers ...corev1.Container) *jobset.JobSet {
+		return &jobset.JobSet{
+			Spec: jobset.JobSetSpec{
+				ReplicatedJobs: []jobset.ReplicatedJob{
+					{Template: batchv1.JobTemplateSpec{
+						Spec: batchv1.JobSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{Containers: containers},
+							},
+						},
+					}},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name   string
+		jobSet *jobset.JobSet
+		want   []corev1.ServicePort
+	}{
+		{
+			name:   "no container ports",
+			jobSet: jsWith(container()),
+			want:   nil,
+		},
+		{
+			name: "single port defaults to TCP",
+			jobSet: jsWith(container(
+				corev1.ContainerPort{ContainerPort: 8080},
+			)),
+			want: []corev1.ServicePort{
+				{Name: "tcp-8080", Port: 8080, TargetPort: intstr.FromInt32(8080), Protocol: corev1.ProtocolTCP},
+			},
+		},
+		{
+			name: "duplicate port and protocol are deduplicated",
+			jobSet: jsWith(
+				container(corev1.ContainerPort{ContainerPort: 8080, Protocol: corev1.ProtocolTCP}),
+				container(corev1.ContainerPort{ContainerPort: 8080, Protocol: corev1.ProtocolTCP}),
+			),
+			want: []corev1.ServicePort{
+				{Name: "tcp-8080", Port: 8080, TargetPort: intstr.FromInt32(8080), Protocol: corev1.ProtocolTCP},
+			},
+		},
+		{
+			name: "same port number with different protocols are kept",
+			jobSet: jsWith(container(
+				corev1.ContainerPort{ContainerPort: 53, Protocol: corev1.ProtocolTCP},
+				corev1.ContainerPort{ContainerPort: 53, Protocol: corev1.ProtocolUDP},
+			)),
+			want: []corev1.ServicePort{
+				{Name: "tcp-53", Port: 53, TargetPort: intstr.FromInt32(53), Protocol: corev1.ProtocolTCP},
+				{Name: "udp-53", Port: 53, TargetPort: intstr.FromInt32(53), Protocol: corev1.ProtocolUDP},
+			},
+		},
+		{
+			name: "zero container port is skipped",
+			jobSet: jsWith(container(
+				corev1.ContainerPort{ContainerPort: 0},
+				corev1.ContainerPort{ContainerPort: 9090},
+			)),
+			want: []corev1.ServicePort{
+				{Name: "tcp-9090", Port: 9090, TargetPort: intstr.FromInt32(9090), Protocol: corev1.ProtocolTCP},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := headlessSvcPorts(tc.jobSet)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("unexpected ports (-want/+got): %s", diff)
 			}
 		})
 	}

--- a/test/integration/controller/jobset_controller_test.go
+++ b/test/integration/controller/jobset_controller_test.go
@@ -34,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -3060,6 +3061,73 @@ var _ = ginkgo.Describe("JobSet controller", func() {
 				}
 				return !fresh1.DeletionTimestamp.IsZero() && fresh2.DeletionTimestamp.IsZero()
 			}, timeout, interval).Should(gomega.BeTrue())
+		})
+	})
+
+	ginkgo.When("A JobSet with container ports and DNS hostnames is created", func() {
+		var ns *corev1.Namespace
+		wantPorts := []corev1.ServicePort{
+			{Name: "tcp-8080", Port: 8080, TargetPort: intstr.FromInt32(8080), Protocol: corev1.ProtocolTCP},
+		}
+
+		makeJS := func() *jobset.JobSet {
+			podSpec := *testing.TestPodSpec.DeepCopy()
+			podSpec.Containers[0].Ports = []corev1.ContainerPort{{ContainerPort: 8080}}
+			return testing.MakeJobSet("test-js", ns.Name).
+				SuccessPolicy(&jobset.SuccessPolicy{Operator: jobset.OperatorAll, TargetReplicatedJobs: []string{}}).
+				EnableDNSHostnames(true).
+				ReplicatedJob(testing.MakeReplicatedJob("replicated-job-a").
+					Job(testing.MakeJobTemplate("test-job-A", ns.Name).PodSpec(podSpec).Obj()).
+					Replicas(1).
+					Obj()).
+				Obj()
+		}
+
+		ginkgo.BeforeEach(func() {
+			ns = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "jobset-ns-"}}
+			gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+		})
+		ginkgo.AfterEach(func() {
+			gomega.Expect(testutil.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		})
+
+		ginkgo.It("creates the headless service with ports derived from container ports", func() {
+			js := makeJS()
+			gomega.Expect(k8sClient.Create(ctx, js)).To(gomega.Succeed())
+			gomega.Eventually(func(g gomega.Gomega) {
+				var svc corev1.Service
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: controllers.GetSubdomain(js), Namespace: ns.Name}, &svc)).To(gomega.Succeed())
+				g.Expect(svc.Spec.Ports).To(gomega.BeComparableTo(wantPorts))
+			}, timeout, interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("reconciles ports on an existing owned headless service that lost them", func() {
+			js := makeJS()
+			gomega.Expect(k8sClient.Create(ctx, js)).To(gomega.Succeed())
+			subdomain := controllers.GetSubdomain(js)
+			key := types.NamespacedName{Name: subdomain, Namespace: ns.Name}
+
+			ginkgo.By("waiting for the headless service to be created with ports")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var svc corev1.Service
+				g.Expect(k8sClient.Get(ctx, key, &svc)).To(gomega.Succeed())
+				g.Expect(svc.Spec.Ports).To(gomega.BeComparableTo(wantPorts))
+			}, timeout, interval).Should(gomega.Succeed())
+
+			ginkgo.By("clearing the ports to simulate a service created before port propagation")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var svc corev1.Service
+				g.Expect(k8sClient.Get(ctx, key, &svc)).To(gomega.Succeed())
+				svc.Spec.Ports = nil
+				g.Expect(k8sClient.Update(ctx, &svc)).To(gomega.Succeed())
+			}, timeout, interval).Should(gomega.Succeed())
+
+			ginkgo.By("expecting the controller to re-add the ports")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var svc corev1.Service
+				g.Expect(k8sClient.Get(ctx, key, &svc)).To(gomega.Succeed())
+				g.Expect(svc.Spec.Ports).To(gomega.BeComparableTo(wantPorts))
+			}, timeout, interval).Should(gomega.Succeed())
 		})
 	})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The headless service that JobSet creates for pod DNS does not declare any ports today. That is fine for plain pod to pod traffic, since requests go straight to the pod IPs which accept traffic on every port. It breaks down with a service mesh though. Istio only matches traffic on ports that are declared on the Service, so pods sitting behind the headless service cannot be reached through the mesh.

This change reads the container ports already declared in the pod templates and copies them onto the headless service. Ports are deduplicated by number and protocol, an empty protocol defaults to TCP, and a container port of zero is skipped. When no container declares a port the service is created exactly as before, so existing JobSets keep working unchanged.

No API change is needed because the container ports already carry all the information required.

#### Which issue(s) this PR fixes:

Fixes #1128

#### Special notes for your reviewer:

Added a focused unit test that covers the default TCP case, deduplication, the same port number on both TCP and UDP, and skipping a zero port.

#### Does this PR introduce a user-facing change?

```release-note
The headless service created for JobSet pod DNS now declares the ports found in the pod containers, so service meshes such as Istio can route traffic to those pods.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Headless Services now expose unique, declared container ports when DNS hostnames are enabled.
  - Existing owned Headless Services update automatically when their container ports change.
  - Empty protocols default to TCP, while zero-valued ports are excluded.
  - Duplicate ports are consolidated while distinct protocols remain supported.
  - Services without declared ports continue to omit port configuration.

- **Bug Fixes**
  - Improves traffic routing to pods behind Headless Services when container ports are configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->