### PR TITLE
docs: document activeDeadlineSeconds interaction with managedBy in KEP-1186

### DIFF
--- a/keps/1186-active-deadline-seconds/README.md
+++ b/keps/1186-active-deadline-seconds/README.md
@@ -130,6 +130,18 @@ Notes).
   on suspend, and reset on resume, regardless of whether `activeDeadlineSeconds`
   is set. Ecosystem tools (CLI printers, dashboards) can rely on it as the
   JobSet's active-start time.
+- **Externally managed JobSets (`spec.managedBy`).** When `managedBy` names a
+  controller other than the built-in `jobset.sigs.k8s.io/jobset-controller`, the
+  built-in controller skips reconciliation entirely (it only runs
+  `ttlSecondsAfterFinished` cleanup once a terminal condition exists, matching
+  existing behavior). Both `.status.startTime` maintenance and the
+  `activeDeadlineSeconds` check run *after* that `managedByExternalController`
+  early-return in `Reconcile`, so the built-in controller neither sets
+  `startTime` nor enforces the deadline for an externally managed JobSet. The
+  managing controller (e.g. MultiKueue) owns `startTime` and deadline
+  enforcement, exactly as it already owns child-Job and status management. This
+  falls out of the existing skip; no extra gating code is added. An integration
+  test validates this assumption (see [Integration tests](#integration-tests)).
 
 ### Risks and Mitigations
 
@@ -330,7 +342,10 @@ policy, so an expired JobSet fails with `DeadlineExceeded` rather than being
 restarted by the failure policy (which would reset `startTime` via
 `RestartJobSet` or return early via `RestartJob`, bypassing the deadline).
 Because `jobSetFinished` short-circuits at the top of the loop, an
-already-finished JobSet is never re-failed by the deadline.
+already-finished JobSet is never re-failed by the deadline. All of this sits
+below the `managedByExternalController` early-return, so for an externally
+managed JobSet neither `startTime` maintenance nor the deadline check runs (see
+[Notes/Constraints/Caveats](#notesconstraintscaveats)).
 
 **`startTime` maintenance** is general and not gated by `activeDeadlineSeconds`
 or the feature gate: `.status.startTime` tracks the JobSet's active-start time
@@ -486,6 +501,12 @@ Added under `test/integration/` (envtest):
   per-attempt deadline, unbounded by `maxRestarts`).
 - Feature gate off: `activeDeadlineSeconds` is never enforced; enabling the gate
   on an already-running JobSet begins enforcement from that point.
+- Externally managed JobSet (`managedBy` set to a non-built-in controller):
+  validates the assumption that the built-in controller skips this feature for
+  externally managed JobSets. With the gate on and the deadline elapsed, the
+  built-in controller neither sets `.status.startTime` nor fails the JobSet,
+  confirming the behavior falls out of the existing `managedBy` skip with no
+  extra gating code.
 
 ### Graduation Criteria
 
@@ -510,6 +531,8 @@ Added under `test/integration/` (envtest):
 ## Implementation History
 
 - 2026-08-26: KEP drafted (provisional) from issue #1186 discussion.
+- 2026-09-05: Documented the activeDeadlineSeconds interaction with managedBy
+  (follow-up to the #1306 KEP review).
 
 ## Drawbacks
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Follow-up to the #1306 KEP review, where @kannon92 asked how `activeDeadlineSeconds` interacts with `spec.managedBy`.

Externally managed JobSets are skipped by the built-in controller before any `.status.startTime` maintenance or `activeDeadlineSeconds` enforcement, since both sit below the `managedByExternalController` early-return in `Reconcile`. The managing controller owns deadline enforcement, exactly as it already owns child-Job and status management; no extra gating code is needed.

Documents this in KEP-1186 under Notes/Constraints/Caveats, the design walkthrough, and the test plan. Docs-only; controller implementation and tests follow in a separate PR.

#### Which issue(s) this PR fixes:

Related to #1186

#### Special notes for your reviewer:

Docs-only KEP change.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified how `activeDeadlineSeconds` interacts with externally managed JobSets.
  - Documented that external controllers are responsible for maintaining job start time and enforcing deadlines when they manage the JobSet.
  - Added guidance describing the behavior and limitations when a controller other than the built-in JobSet controller manages the JobSet.

- **Tests**
  - Added integration coverage for JobSets managed by external controllers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->