### PR TITLE
Add activeDeadlineSeconds to bound JobSet active runtime

### DIFF
--- a/api/jobset/v1alpha2/jobset_types.go
+++ b/api/jobset/v1alpha2/jobset_types.go
@@ -191,6 +191,20 @@ type JobSetSpec struct {
 	// +optional
 	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
 
+	// activeDeadlineSeconds is the maximum duration in seconds, relative to
+	// status.startTime, that the JobSet may be continuously active before the
+	// JobSet controller marks it Failed and deletes its active Jobs.
+	//
+	// The timer does not accrue while the JobSet is suspended: startTime is
+	// cleared on suspend and reset when the JobSet resumes. The value must be a
+	// positive integer. The field is mutable: operators may raise or lower the
+	// deadline on a running JobSet, matching batch/v1.Job. The controller
+	// recomputes the remaining time from status.startTime on the next reconcile,
+	// so no timer state is reset on update.
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	ActiveDeadlineSeconds *int64 `json:"activeDeadlineSeconds,omitempty"`
+
 	// volumeClaimPolicies is a list of policies for persistent volume claims that pods are allowed
 	// to reference. JobSet controller automatically adds the required volume claims to the
 	// pod template. Every claim in this list must have at least one matching (by name)
@@ -211,6 +225,16 @@ type JobSetStatus struct {
 	// +listType=map
 	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+
+	// startTime is the timestamp from which activeDeadlineSeconds is measured, and
+	// also serves as the JobSet's active-start time. It is set when the JobSet
+	// first becomes active (unsuspended), cleared when the JobSet is suspended, and
+	// reset to the current time when the JobSet resumes, matching
+	// batch/v1.Job.status.startTime. It is maintained only while the
+	// JobSetActiveDeadlineSeconds feature gate is enabled, independent of whether
+	// activeDeadlineSeconds is set.
+	// +optional
+	StartTime *metav1.Time `json:"startTime,omitempty"`
 
 	// restarts tracks the number of times the JobSet has been globally restarted.
 	// That is, restarts is the number of times the restart action RestartJobSet or RestartJobSetAndIgnoreMaxRestarts have been executed and led to the recreation of all Jobs.
@@ -309,6 +333,7 @@ type ReplicatedJobStatus struct {
 // +kubebuilder:printcolumn:name="Restarts",JSONPath=".status.restarts",type=string,description="Number of restarts"
 // +kubebuilder:printcolumn:name="Completed",type="string",priority=0,JSONPath=".status.conditions[?(@.type==\"Completed\")].status"
 // +kubebuilder:printcolumn:name="Suspended",type="string",JSONPath=".spec.suspend",description="JobSet suspended"
+// +kubebuilder:printcolumn:name="StartTime",type=date,JSONPath=`.status.startTime`,description="Time the JobSet became active"
 // +kubebuilder:printcolumn:name="Age",JSONPath=".metadata.creationTimestamp",type=date,description="Time this JobSet was created"
 
 // JobSet is the Schema for the jobsets API

--- a/api/jobset/v1alpha2/openapi_generated.go
+++ b/api/jobset/v1alpha2/openapi_generated.go
@@ -408,6 +408,13 @@ func schema_jobset_api_jobset_v1alpha2_JobSetSpec(ref common.ReferenceCallback) 
 							Format:      "int32",
 						},
 					},
+					"activeDeadlineSeconds": {
+						SchemaProps: spec.SchemaProps{
+							Description: "activeDeadlineSeconds is the maximum duration in seconds, relative to status.startTime, that the JobSet may be continuously active before the JobSet controller marks it Failed and deletes its active Jobs.\n\nThe timer does not accrue while the JobSet is suspended: startTime is cleared on suspend and reset when the JobSet resumes. The value must be a positive integer. The field is mutable: operators may raise or lower the deadline on a running JobSet, matching batch/v1.Job. The controller recomputes the remaining time from status.startTime on the next reconcile, so no timer state is reset on update.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
 					"volumeClaimPolicies": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -462,6 +469,12 @@ func schema_jobset_api_jobset_v1alpha2_JobSetStatus(ref common.ReferenceCallback
 									},
 								},
 							},
+						},
+					},
+					"startTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "startTime is the timestamp from which activeDeadlineSeconds is measured, and also serves as the JobSet's active-start time. It is set when the JobSet first becomes active (unsuspended), cleared when the JobSet is suspended, and reset to the current time when the JobSet resumes, matching batch/v1.Job.status.startTime. It is maintained only while the JobSetActiveDeadlineSeconds feature gate is enabled, independent of whether activeDeadlineSeconds is set.",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
 					"restarts": {
@@ -534,7 +547,7 @@ func schema_jobset_api_jobset_v1alpha2_JobSetStatus(ref common.ReferenceCallback
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/apimachinery/pkg/apis/meta/v1.Condition", "sigs.k8s.io/jobset/api/jobset/v1alpha2.ReplicatedJobStatus"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.Condition", "k8s.io/apimachinery/pkg/apis/meta/v1.Time", "sigs.k8s.io/jobset/api/jobset/v1alpha2.ReplicatedJobStatus"},
 	}
 }
 

--- a/api/jobset/v1alpha2/zz_generated.deepcopy.go
+++ b/api/jobset/v1alpha2/zz_generated.deepcopy.go
@@ -217,6 +217,11 @@ func (in *JobSetSpec) DeepCopyInto(out *JobSetSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.ActiveDeadlineSeconds != nil {
+		in, out := &in.ActiveDeadlineSeconds, &out.ActiveDeadlineSeconds
+		*out = new(int64)
+		**out = **in
+	}
 	if in.VolumeClaimPolicies != nil {
 		in, out := &in.VolumeClaimPolicies, &out.VolumeClaimPolicies
 		*out = make([]VolumeClaimPolicy, len(*in))
@@ -245,6 +250,10 @@ func (in *JobSetStatus) DeepCopyInto(out *JobSetStatus) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.StartTime != nil {
+		in, out := &in.StartTime, &out.StartTime
+		*out = (*in).DeepCopy()
 	}
 	if in.ExecutionAttempts != nil {
 		in, out := &in.ExecutionAttempts, &out.ExecutionAttempts

--- a/charts/jobset/crds/jobset.x-k8s.io_jobsets.yaml
+++ b/charts/jobset/crds/jobset.x-k8s.io_jobsets.yaml
@@ -30,6 +30,10 @@ spec:
       jsonPath: .spec.suspend
       name: Suspended
       type: string
+    - description: Time the JobSet became active
+      jsonPath: .status.startTime
+      name: StartTime
+      type: date
     - description: Time this JobSet was created
       jsonPath: .metadata.creationTimestamp
       name: Age
@@ -59,6 +63,21 @@ spec:
           spec:
             description: spec is the specification for jobset
             properties:
+              activeDeadlineSeconds:
+                description: |-
+                  activeDeadlineSeconds is the maximum duration in seconds, relative to
+                  status.startTime, that the JobSet may be continuously active before the
+                  JobSet controller marks it Failed and deletes its active Jobs.
+
+                  The timer does not accrue while the JobSet is suspended: startTime is
+                  cleared on suspend and reset when the JobSet resumes. The value must be a
+                  positive integer. The field is mutable: operators may raise or lower the
+                  deadline on a running JobSet, matching batch/v1.Job. The controller
+                  recomputes the remaining time from status.startTime on the next reconcile,
+                  so no timer state is reset on update.
+                format: int64
+                minimum: 1
+                type: integer
               coordinator:
                 description: |-
                   coordinator can be used to assign a specific pod as the coordinator for
@@ -10717,6 +10736,17 @@ spec:
                   That is, restartsCountTowardsMax is the number of times the restart action RestartJobSet has been executed and led to the recreation of all Jobs.
                 format: int32
                 type: integer
+              startTime:
+                description: |-
+                  startTime is the timestamp from which activeDeadlineSeconds is measured, and
+                  also serves as the JobSet's active-start time. It is set when the JobSet
+                  first becomes active (unsuspended), cleared when the JobSet is suspended, and
+                  reset to the current time when the JobSet resumes, matching
+                  batch/v1.Job.status.startTime. It is maintained only while the
+                  JobSetActiveDeadlineSeconds feature gate is enabled, independent of whether
+                  activeDeadlineSeconds is set.
+                format: date-time
+                type: string
               terminalState:
                 description: |-
                   terminalState tracks the state of the JobSet when it finishes execution.

--- a/client-go/applyconfiguration/jobset/v1alpha2/jobsetspec.go
+++ b/client-go/applyconfiguration/jobset/v1alpha2/jobsetspec.go
@@ -72,6 +72,17 @@ type JobSetSpecApplyConfiguration struct {
 	// becomes eligible only after that controller records a terminal
 	// (Completed or Failed) condition.
 	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
+	// activeDeadlineSeconds is the maximum duration in seconds, relative to
+	// status.startTime, that the JobSet may be continuously active before the
+	// JobSet controller marks it Failed and deletes its active Jobs.
+	//
+	// The timer does not accrue while the JobSet is suspended: startTime is
+	// cleared on suspend and reset when the JobSet resumes. The value must be a
+	// positive integer. The field is mutable: operators may raise or lower the
+	// deadline on a running JobSet, matching batch/v1.Job. The controller
+	// recomputes the remaining time from status.startTime on the next reconcile,
+	// so no timer state is reset on update.
+	ActiveDeadlineSeconds *int64 `json:"activeDeadlineSeconds,omitempty"`
 	// volumeClaimPolicies is a list of policies for persistent volume claims that pods are allowed
 	// to reference. JobSet controller automatically adds the required volume claims to the
 	// pod template. Every claim in this list must have at least one matching (by name)
@@ -159,6 +170,14 @@ func (b *JobSetSpecApplyConfiguration) WithManagedBy(value string) *JobSetSpecAp
 // If called multiple times, the TTLSecondsAfterFinished field is set to the value of the last call.
 func (b *JobSetSpecApplyConfiguration) WithTTLSecondsAfterFinished(value int32) *JobSetSpecApplyConfiguration {
 	b.TTLSecondsAfterFinished = &value
+	return b
+}
+
+// WithActiveDeadlineSeconds sets the ActiveDeadlineSeconds field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ActiveDeadlineSeconds field is set to the value of the last call.
+func (b *JobSetSpecApplyConfiguration) WithActiveDeadlineSeconds(value int64) *JobSetSpecApplyConfiguration {
+	b.ActiveDeadlineSeconds = &value
 	return b
 }
 

--- a/client-go/applyconfiguration/jobset/v1alpha2/jobsetstatus.go
+++ b/client-go/applyconfiguration/jobset/v1alpha2/jobsetstatus.go
@@ -18,6 +18,7 @@ limitations under the License.
 package v1alpha2
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
@@ -28,6 +29,14 @@ import (
 type JobSetStatusApplyConfiguration struct {
 	// conditions track status
 	Conditions []v1.ConditionApplyConfiguration `json:"conditions,omitempty"`
+	// startTime is the timestamp from which activeDeadlineSeconds is measured, and
+	// also serves as the JobSet's active-start time. It is set when the JobSet
+	// first becomes active (unsuspended), cleared when the JobSet is suspended, and
+	// reset to the current time when the JobSet resumes, matching
+	// batch/v1.Job.status.startTime. It is maintained only while the
+	// JobSetActiveDeadlineSeconds feature gate is enabled, independent of whether
+	// activeDeadlineSeconds is set.
+	StartTime *metav1.Time `json:"startTime,omitempty"`
 	// restarts tracks the number of times the JobSet has been globally restarted.
 	// That is, restarts is the number of times the restart action RestartJobSet or RestartJobSetAndIgnoreMaxRestarts have been executed and led to the recreation of all Jobs.
 	Restarts *int32 `json:"restarts,omitempty"`
@@ -73,6 +82,14 @@ func (b *JobSetStatusApplyConfiguration) WithConditions(values ...*v1.ConditionA
 		}
 		b.Conditions = append(b.Conditions, *values[i])
 	}
+	return b
+}
+
+// WithStartTime sets the StartTime field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the StartTime field is set to the value of the last call.
+func (b *JobSetStatusApplyConfiguration) WithStartTime(value metav1.Time) *JobSetStatusApplyConfiguration {
+	b.StartTime = &value
 	return b
 }
 

--- a/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
+++ b/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
@@ -30,6 +30,10 @@ spec:
       jsonPath: .spec.suspend
       name: Suspended
       type: string
+    - description: Time the JobSet became active
+      jsonPath: .status.startTime
+      name: StartTime
+      type: date
     - description: Time this JobSet was created
       jsonPath: .metadata.creationTimestamp
       name: Age
@@ -59,6 +63,21 @@ spec:
           spec:
             description: spec is the specification for jobset
             properties:
+              activeDeadlineSeconds:
+                description: |-
+                  activeDeadlineSeconds is the maximum duration in seconds, relative to
+                  status.startTime, that the JobSet may be continuously active before the
+                  JobSet controller marks it Failed and deletes its active Jobs.
+
+                  The timer does not accrue while the JobSet is suspended: startTime is
+                  cleared on suspend and reset when the JobSet resumes. The value must be a
+                  positive integer. The field is mutable: operators may raise or lower the
+                  deadline on a running JobSet, matching batch/v1.Job. The controller
+                  recomputes the remaining time from status.startTime on the next reconcile,
+                  so no timer state is reset on update.
+                format: int64
+                minimum: 1
+                type: integer
               coordinator:
                 description: |-
                   coordinator can be used to assign a specific pod as the coordinator for
@@ -10717,6 +10736,17 @@ spec:
                   That is, restartsCountTowardsMax is the number of times the restart action RestartJobSet has been executed and led to the recreation of all Jobs.
                 format: int32
                 type: integer
+              startTime:
+                description: |-
+                  startTime is the timestamp from which activeDeadlineSeconds is measured, and
+                  also serves as the JobSet's active-start time. It is set when the JobSet
+                  first becomes active (unsuspended), cleared when the JobSet is suspended, and
+                  reset to the current time when the JobSet resumes, matching
+                  batch/v1.Job.status.startTime. It is maintained only while the
+                  JobSetActiveDeadlineSeconds feature gate is enabled, independent of whether
+                  activeDeadlineSeconds is set.
+                format: date-time
+                type: string
               terminalState:
                 description: |-
                   terminalState tracks the state of the JobSet when it finishes execution.

--- a/hack/python-sdk/swagger.json
+++ b/hack/python-sdk/swagger.json
@@ -174,6 +174,11 @@
       "description": "JobSetSpec defines the desired state of JobSet",
       "type": "object",
       "properties": {
+        "activeDeadlineSeconds": {
+          "description": "activeDeadlineSeconds is the maximum duration in seconds, relative to status.startTime, that the JobSet may be continuously active before the JobSet controller marks it Failed and deletes its active Jobs.\n\nThe timer does not accrue while the JobSet is suspended: startTime is cleared on suspend and reset when the JobSet resumes. The value must be a positive integer. The field is mutable: operators may raise or lower the deadline on a running JobSet, matching batch/v1.Job. The controller recomputes the remaining time from status.startTime on the next reconcile, so no timer state is reset on update.",
+          "type": "integer",
+          "format": "int64"
+        },
         "coordinator": {
           "description": "coordinator can be used to assign a specific pod as the coordinator for the JobSet. If defined, an annotation will be added to all Jobs and pods with coordinator pod, which contains the stable network endpoint where the coordinator pod can be reached. jobset.sigs.k8s.io/coordinator=\u003cpod hostname\u003e.\u003cheadless service\u003e",
           "$ref": "#/definitions/jobset.v1alpha2.Coordinator"
@@ -285,6 +290,10 @@
           "description": "restartsCountTowardsMax tracks the number of times the JobSet has been globally restarted that counts towards the maximum allowed number of restarts. That is, restartsCountTowardsMax is the number of times the restart action RestartJobSet has been executed and led to the recreation of all Jobs.",
           "type": "integer",
           "format": "int32"
+        },
+        "startTime": {
+          "description": "startTime is the timestamp from which activeDeadlineSeconds is measured, and also serves as the JobSet's active-start time. It is set when the JobSet first becomes active (unsuspended), cleared when the JobSet is suspended, and reset to the current time when the JobSet resumes, matching batch/v1.Job.status.startTime. It is maintained only while the JobSetActiveDeadlineSeconds feature gate is enabled, independent of whether activeDeadlineSeconds is set.",
+          "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.37.0/api/openapi-spec/swagger.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
         },
         "terminalState": {
           "description": "terminalState tracks the state of the JobSet when it finishes execution. It can be either Completed or Failed. Otherwise, it is empty by default.",

--- a/keps/1186-active-deadline-seconds/README.md
+++ b/keps/1186-active-deadline-seconds/README.md
@@ -125,11 +125,15 @@ Notes).
   for startup ordering (`DependsOn`, coordinator, leader readiness) counts
   against the deadline, so a JobSet stuck in startup is failed once the deadline
   passes.
-- `.status.startTime` is a general JobSet start timestamp, matching upstream
+- `.status.startTime` is a JobSet start timestamp modeled on upstream
   `batch/v1.Job`: it is set whenever the JobSet is active (unsuspended), cleared
-  on suspend, and reset on resume, regardless of whether `activeDeadlineSeconds`
-  is set. Ecosystem tools (CLI printers, dashboards) can rely on it as the
-  JobSet's active-start time.
+  on suspend, and reset on resume, **independent of whether
+  `activeDeadlineSeconds` is set**. It is, however, **maintained only while the
+  `JobSetActiveDeadlineSeconds` feature gate is enabled** — the reconcile loop
+  skips `startTime` maintenance entirely when the gate is off, so the alpha
+  feature has no status side effects while disabled (changed in review from the
+  original always-on design). Ecosystem tools (CLI printers, dashboards) can
+  rely on it as the JobSet's active-start time whenever the gate is on.
 - **Externally managed JobSets (`spec.managedBy`).** When `managedBy` names a
   controller other than the built-in `jobset.sigs.k8s.io/jobset-controller`, the
   built-in controller skips reconciliation entirely (it only runs
@@ -182,25 +186,35 @@ Add to `JobSetStatus`:
 
 ```go
 // startTime is the timestamp from which activeDeadlineSeconds is measured, and
-// also serves as the JobSet's general active-start time. It is set when the
-// JobSet first becomes active (unsuspended), cleared when the JobSet is
-// suspended, and reset to the current time when the JobSet resumes. It is
-// populated whenever the JobSet is active, independent of activeDeadlineSeconds,
-// matching batch/v1.Job.status.startTime.
+// also serves as the JobSet's active-start time. It is set when the JobSet
+// first becomes active (unsuspended), cleared when the JobSet is suspended, and
+// reset to the current time when the JobSet resumes, matching
+// batch/v1.Job.status.startTime. It is maintained only while the
+// JobSetActiveDeadlineSeconds feature gate is enabled, independent of whether
+// activeDeadlineSeconds is set.
 // +optional
 StartTime *metav1.Time `json:"startTime,omitempty"`
 ```
 
-For observability, `.status.startTime` is exposed as a printer column:
+For observability, `.status.startTime` is exposed as a printer column. It uses
+`type=date` (not `type=string`) so `kubectl` renders it as a relative age,
+consistent with the existing `Age` column:
 
 ```go
-// +kubebuilder:printcolumn:name="StartTime",type=string,JSONPath=`.status.startTime`,description="Time the JobSet became active"
+// +kubebuilder:printcolumn:name="StartTime",type=date,JSONPath=`.status.startTime`,description="Time the JobSet became active"
 ```
 
 Validation:
 
 - `+kubebuilder:validation:Minimum=1` enforces a positive value at the API
   server; no webhook code is needed for the range check.
+- Feature-gate guard: a validating webhook rejects *setting or changing*
+  `activeDeadlineSeconds` while the `JobSetActiveDeadlineSeconds` gate is
+  disabled, on both create and update. An unchanged value is left alone (so a
+  JobSet created while the gate was on can still be updated), and clearing the
+  field is always allowed. This keeps the alpha field from being introduced
+  while the feature is off. (Added in response to review; see
+  [Implementation History](#implementation-history).)
 - Mutability: the field is mutable, matching `batch/v1.Job`, where
   `activeDeadlineSeconds` is in the allowed set for spec updates
   (`ValidateJobSpecUpdate`). Operators and platform tools may raise or lower the
@@ -330,8 +344,9 @@ policy (early return on completion) → `syncExecutionAttempts` →
 `reconcileReplicatedJobs` → suspend/resume handling. This feature adds
 `startTime` maintenance at the top of the loop (right after the `jobSetFinished`
 early-exit) so `.status.startTime` is populated before any deadline or failure
-evaluation, then reorders the middle so the deadline check sits between the
-success and failure policies: `jobSetFinished` → **`startTime` maintenance** →
+evaluation, then — for JobSets that set `activeDeadlineSeconds` — reorders the
+middle so the deadline check sits between the success and failure policies:
+`jobSetFinished` → **`startTime` maintenance** →
 **success policy** (early return on completion) → **deadline check** (early
 return on expiry) → **failure policy** → `syncExecutionAttempts` → … Running
 `startTime` maintenance first guarantees `StartTime` is set on the first
@@ -347,24 +362,32 @@ below the `managedByExternalController` early-return, so for an externally
 managed JobSet neither `startTime` maintenance nor the deadline check runs (see
 [Notes/Constraints/Caveats](#notesconstraintscaveats)).
 
-**`startTime` maintenance** is general and not gated by `activeDeadlineSeconds`
-or the feature gate: `.status.startTime` tracks the JobSet's active-start time
-whenever the JobSet is active, matching upstream `batch/v1.Job`. `startTime` is
-an idempotent timestamp, so maintenance does not track a suspend→resume
-transition; it derives everything from the current suspend state
+**`startTime` maintenance** is gated by the `JobSetActiveDeadlineSeconds` feature
+gate but not by `activeDeadlineSeconds`: while the gate is on,
+`.status.startTime` tracks the JobSet's active-start time whenever the JobSet is
+active (whether or not `activeDeadlineSeconds` is set), matching upstream
+`batch/v1.Job`; while the gate is off, `startTime` is not touched at all.
+`startTime` is an idempotent timestamp, so maintenance does not track a
+suspend→resume transition; it derives everything from the current suspend state
 (`isSuspended = jobSetSuspended(js)`):
 
 - Not suspended with `StartTime == nil`: set `StartTime = now`. This covers both
   the first unsuspended start and resume after suspend (suspend clears
   `StartTime`, so resume re-sets it on the next reconcile).
 - Suspended (`isSuspended`): set `StartTime = nil`.
-- Global restart: `failurePolicyRecreateAll` (which already increments
-  `Status.Restarts`) also sets `StartTime = now`, since it begins a fresh run.
-  `failurePolicyRecreateJob` (single Job) does not touch it.
+- Global restart: the reconcile loop calls `resetStartTimeOnGlobalRestart`,
+  which sets `StartTime = now` when the failure policy bumped `Status.Restarts`
+  in this reconcile (a global `RestartJobSet`), since it begins a fresh run. A
+  single-Job `RestartJob` (which does not bump `Status.Restarts`) does not touch
+  it.
 
-Because `startTime` is maintained unconditionally, enabling or disabling the
-feature gate never changes it; only the deadline check reads it, and only the
-check is gated.
+Because the gate wraps `startTime` maintenance, disabling the gate makes the
+feature fully inert (no `startTime` writes); only the deadline check reads
+`startTime`, and both are gated. The success→deadline→failure reorder is
+additionally scoped to JobSets that actually set `activeDeadlineSeconds`: a
+JobSet that does not use the field keeps the original failure→success ordering
+even when the gate is on, so enabling the cluster-wide gate never changes the
+terminal outcome of a JobSet that does not use the feature.
 
 All writes go through the existing `statusUpdateOpts` so they are persisted
 atomically with the other status changes in that reconcile.
@@ -385,14 +408,16 @@ if remaining > 0 {
     return false, remaining, nil   // requeue after remaining, wake exactly at expiry
 }
 
-// Deadline exceeded: fail the JobSet and free resources in this reconcile.
-setJobSetFailedCondition(js, DeadlineExceededReason,
-    fmt.Sprintf("JobSet was active for %s, exceeding the %ds deadline",
-        clock.Since(js.Status.StartTime.Time), *js.Spec.ActiveDeadlineSeconds), opts)
-metrics.JobSetActiveDeadlineExceeded(js.Name, js.Namespace)
+// Deadline exceeded: delete active child Jobs first, then record the failure so
+// the condition and metric are emitted only once resources are actually freed.
+// A delete error retries from a not-yet-failed state, avoiding metric inflation.
 if err := r.deleteJobs(ctx, ownedJobs.active); err != nil {
     return true, 0, err
 }
+setJobSetFailedCondition(js, DeadlineExceededReason,
+    fmt.Sprintf("JobSet was active for longer than the specified deadline of %ds",
+        *js.Spec.ActiveDeadlineSeconds), opts)
+metrics.JobSetActiveDeadlineExceeded(js.Name, js.Namespace)
 return true, 0, nil   // expired: caller returns early after the status update
 ```
 
@@ -432,19 +457,29 @@ New metric:
 ### Feature Gate Disabled Behavior
 
 Gated by `JobSetActiveDeadlineSeconds` (`featuregate.Alpha`, default `false`).
-The gate controls only deadline enforcement; `.status.startTime` maintenance is
-general and runs regardless of the gate.
+This follows the same gate-disabled convention as KEP-1282 (execution-attempts),
+which gates its own `JobSet.status` field: the gate wraps the whole feature, so
+both `.status.startTime` maintenance and the deadline check are skipped when the
+gate is off and a disabled feature has no observable side effects. (This is a
+change from the original 1186 design, where `startTime` was maintained
+regardless of the gate; that design was the outlier versus 1282.)
 
-- Gate off: `executeActiveDeadlinePolicy` is a no-op. `.status.startTime` is
-  still maintained (set on active, cleared on suspend, reset on resume) so
-  ecosystem tools keep seeing it. An existing `activeDeadlineSeconds` value is
-  retained in spec (not stripped) but never enforced.
-- Gate on: enforcement resumes against the already-maintained `startTime`.
-  Because `startTime` reflects the JobSet's true active-start time, a JobSet
-  that has been continuously active past its deadline while the gate was off is
-  failed on the first reconcile after enable.
-- Gate on to off downgrade: enforcement stops; a JobSet already failed for the
-  deadline stays failed (terminal state is immutable).
+- Gate off: `executeActiveDeadlinePolicy` is a no-op and `.status.startTime` is
+  not touched — left `nil` for a JobSet that starts while the gate is off, and
+  any existing value **preserved without further updates**. An
+  `activeDeadlineSeconds` value already in the spec is retained (not stripped)
+  but never enforced; the webhook prevents *adding or changing* the field while
+  the gate is off.
+- Gate on (or re-enabled): maintenance and the deadline check resume, and
+  maintenance **resumes from the persisted `startTime`** when one exists.
+  Maintenance derives `startTime` from the current suspend state, so a JobSet
+  that was active (with a `startTime`) before the gate was turned off keeps that
+  timestamp: if it has been continuously active past its deadline it is failed
+  on the first reconcile after re-enable. A JobSet with no persisted `startTime`
+  gets `startTime = now` and measures the deadline from there.
+- Gate on to off downgrade: maintenance and enforcement stop; a JobSet already
+  failed for the deadline stays failed (terminal state is immutable), and
+  `startTime` is left at its last value (no further writes).
 
 ### Test Plan
 
@@ -464,11 +499,19 @@ requeue paths this feature builds on.
   started, suspended, remaining > 0 (requeues, no status change), remaining <= 0
   (sets the `Failed` condition, deletes active child Jobs, and signals early
   return), and future startTime (clock skew) treated as not expired.
-- `pkg/controllers`: `StartTime` is maintained independent of
-  `activeDeadlineSeconds` and the gate: it is set whenever the JobSet is active
-  (including when the field is unset or the gate is off), cleared on suspend,
-  and reset on resume and on the global `failurePolicyRecreateAll` restart path.
-  The gate gates only the deadline check, not `StartTime`.
+- `pkg/controllers`: `StartTime` is maintained whenever the gate is on,
+  independent of `activeDeadlineSeconds`: set whenever the JobSet is active
+  (including when the field is unset), cleared on suspend, reset on resume and on
+  the global `resetStartTimeOnGlobalRestart` path. When the gate is off it is not
+  maintained at all.
+- `pkg/controllers` (reconcile-level): success beats an expired deadline in the
+  same reconcile (Completed, not `DeadlineExceeded`); an expired deadline beats a
+  simultaneous child failure (`DeadlineExceeded`, `Status.Restarts` unchanged);
+  and a JobSet without `activeDeadlineSeconds` keeps the original
+  failure→success ordering with the gate on (the reorder does not apply to
+  non-users).
+- `pkg/metrics` / `pkg/controllers`: `jobset_active_deadline_exceeded_total`
+  increments by one when a JobSet is failed by the deadline.
 - `pkg/controllers`: when a child-Job failure and an elapsed deadline are
   observed in the same reconcile, the JobSet fails with `DeadlineExceeded` (the
   deadline is checked before the failure policy) and is not restarted.
@@ -480,7 +523,10 @@ requeue paths this feature builds on.
   (which runs before the deadline check), not failed by the deadline.
 - `pkg/webhooks` / CEL: `activeDeadlineSeconds` validation covering Minimum=1
   (reject zero and negative), and allowing updates on a running JobSet (raise,
-  lower, add, and remove) to confirm the field is mutable.
+  lower, add, and remove) to confirm the field is mutable when the gate is on.
+- `pkg/webhooks`: the feature-gate guard — setting `activeDeadlineSeconds` on
+  create or update while the gate is off is rejected, while an unchanged value
+  and clearing the field are allowed.
 - Target: cover the new code paths in the failure/ttl-adjacent packages, which
   are currently well covered.
 
@@ -499,8 +545,11 @@ Added under `test/integration/` (envtest):
   next reconcile; raising it extends the deadline.
 - `RestartJobSetAndIgnoreMaxRestarts` resets the timer each attempt (fresh
   per-attempt deadline, unbounded by `maxRestarts`).
-- Feature gate off: `activeDeadlineSeconds` is never enforced; enabling the gate
-  on an already-running JobSet begins enforcement from that point.
+- Feature gate off: `activeDeadlineSeconds` is never enforced and
+  `.status.startTime` is not maintained; enabling the gate on an already-running
+  JobSet resumes `startTime` maintenance and enforcement, from the persisted
+  `startTime` if one exists (matching KEP-1282's re-enable semantics), otherwise
+  from the enable point.
 - Externally managed JobSet (`managedBy` set to a non-built-in controller):
   validates the assumption that the built-in controller skips this feature for
   externally managed JobSets. With the gate on and the deadline elapsed, the
@@ -533,6 +582,16 @@ Added under `test/integration/` (envtest):
 - 2026-08-26: KEP drafted (provisional) from issue #1186 discussion.
 - 2026-09-05: Documented the activeDeadlineSeconds interaction with managedBy
   (follow-up to the #1306 KEP review).
+- 2026-09-05: Alpha implementation (API field, `.status.startTime`, feature gate
+  `JobSetActiveDeadlineSeconds`, controller enforcement, metric, unit and
+  integration tests).
+- 2026-09-07: Review follow-ups. Gate `.status.startTime` maintenance behind the
+  feature gate so a disabled feature has no side effects; scope the
+  success→deadline→failure reorder to JobSets that set `activeDeadlineSeconds`
+  so non-users keep failure→success ordering; add a validating-webhook guard
+  that rejects setting the field while the gate is off (create and update);
+  change the `StartTime` printer column to `type=date`; and add reconcile-level
+  ordering unit tests and a metric-increment test.
 
 ## Drawbacks
 

--- a/keps/1186-active-deadline-seconds/kep.yaml
+++ b/keps/1186-active-deadline-seconds/kep.yaml
@@ -2,7 +2,7 @@ title: Add ActiveDeadlineSeconds for JobSet
 kep-number: 1186
 authors:
   - "@yindia"
-status: provisional
+status: implementable
 creation-date: 2026-08-26
 reviewers:
   - "@kannon92"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -60,6 +60,10 @@ const (
 	FailedJobsReason  = "FailedJobs"
 	FailedJobsMessage = "jobset failed due to one or more job failures"
 
+	// Condition reason for when a JobSet fails due to exceeding its
+	// spec.activeDeadlineSeconds while continuously active.
+	DeadlineExceededReason = "DeadlineExceeded"
+
 	// Event reason and message for when a Jobset completes successfully.
 	AllJobsCompletedReason  = "AllJobsCompleted"
 	AllJobsCompletedMessage = "jobset completed successfully"

--- a/pkg/controllers/active_deadline.go
+++ b/pkg/controllers/active_deadline.go
@@ -1,0 +1,129 @@
+/*
+Copyright The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+	"sigs.k8s.io/jobset/pkg/constants"
+	"sigs.k8s.io/jobset/pkg/features"
+	"sigs.k8s.io/jobset/pkg/metrics"
+)
+
+// syncActiveDeadlineStartTime maintains .status.startTime, the JobSet's general
+// active-start timestamp (also the anchor for spec.activeDeadlineSeconds).
+//
+// It matches batch/v1.Job semantics and is maintained for any JobSet, independent
+// of whether activeDeadlineSeconds is set:
+//   - set to now when the JobSet is active (unsuspended) and startTime is unset,
+//   - cleared when the JobSet is suspended.
+//
+// The caller gates this behind JobSetActiveDeadlineSeconds, so a disabled feature
+// has no status side effects. Because suspend clears startTime, resume naturally
+// re-sets it on the next active reconcile. Global restarts reset it explicitly in
+// the reconcile loop via resetStartTimeOnGlobalRestart, which fires when
+// Status.Restarts increases.
+func (r *JobSetReconciler) syncActiveDeadlineStartTime(js *jobset.JobSet, updateStatusOpts *statusUpdateOpts) {
+	if jobSetSuspended(js) {
+		if js.Status.StartTime != nil {
+			js.Status.StartTime = nil
+			updateStatusOpts.shouldUpdate = true
+		}
+		return
+	}
+	if js.Status.StartTime == nil {
+		now := metav1.NewTime(r.clock.Now())
+		js.Status.StartTime = &now
+		updateStatusOpts.shouldUpdate = true
+	}
+}
+
+// resetStartTimeOnGlobalRestart resets .status.startTime to now when the failure
+// policy performed a global restart in this reconcile (detected by
+// Status.Restarts increasing), since a global restart begins a fresh run. It is
+// a no-op for single-Job restarts (which do not bump Status.Restarts) and
+// terminal failures. Like the rest of startTime maintenance it is a no-op while
+// the JobSetActiveDeadlineSeconds gate is disabled (guarded here), and uses the
+// injectable clock.
+func (r *JobSetReconciler) resetStartTimeOnGlobalRestart(js *jobset.JobSet, restartsBefore int32, updateStatusOpts *statusUpdateOpts) {
+	if !features.Enabled(features.JobSetActiveDeadlineSeconds) {
+		return
+	}
+	if js.Status.Restarts > restartsBefore && js.Status.StartTime != nil {
+		now := metav1.NewTime(r.clock.Now())
+		js.Status.StartTime = &now
+		updateStatusOpts.shouldUpdate = true
+	}
+}
+
+// executeActiveDeadlinePolicy enforces spec.activeDeadlineSeconds against
+// .status.startTime. It returns whether the deadline has expired, and if not,
+// the duration after which the JobSet should be requeued so the controller wakes
+// exactly at expiry (a wedged JobSet produces no child events on its own).
+//
+// On expiry the JobSet is marked Failed with reason DeadlineExceeded and its
+// active child Jobs are deleted in the same reconcile, freeing resources promptly.
+func (r *JobSetReconciler) executeActiveDeadlinePolicy(ctx context.Context, js *jobset.JobSet, ownedJobs *childJobs, updateStatusOpts *statusUpdateOpts) (bool, time.Duration, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	if !features.Enabled(features.JobSetActiveDeadlineSeconds) {
+		return false, 0, nil
+	}
+	if js.Spec.ActiveDeadlineSeconds == nil {
+		return false, 0, nil
+	}
+	// The deadline measures continuous active time; it does not accrue while suspended.
+	if jobSetSuspended(js) {
+		return false, 0, nil
+	}
+	if js.Status.StartTime == nil {
+		return false, 0, nil
+	}
+
+	adls := *js.Spec.ActiveDeadlineSeconds
+	// Guard against int64 nanosecond overflow for very large deadlines. Such a
+	// JobSet is effectively unbounded, so treat it as never expiring rather than
+	// wrapping to a negative duration (which would fail it immediately).
+	if adls > math.MaxInt64/int64(time.Second) {
+		return false, 0, nil
+	}
+
+	deadline := js.Status.StartTime.Add(time.Duration(adls) * time.Second)
+	remaining := deadline.Sub(r.clock.Now())
+	if remaining > 0 {
+		// Not expired yet (also covers clock skew where startTime is in the future).
+		return false, remaining, nil
+	}
+
+	// Deadline exceeded. Delete the active child Jobs first, then record the
+	// failure, so the Failed condition and metric are only emitted once the
+	// resources are actually freed. If deletion fails we return the error without
+	// touching the condition or metric; the next reconcile retries from a
+	// not-yet-failed state, avoiding metric inflation.
+	if err := r.deleteJobs(ctx, ownedJobs.active); err != nil {
+		return true, 0, err
+	}
+	msg := fmt.Sprintf("JobSet was active for longer than the specified deadline of %d seconds", adls)
+	log.V(2).Info("JobSet active deadline exceeded, failing JobSet", "activeDeadlineSeconds", adls)
+	setJobSetFailedCondition(js, constants.DeadlineExceededReason, msg, updateStatusOpts)
+	metrics.JobSetActiveDeadlineExceeded(js.Name, js.Namespace)
+	return true, 0, nil
+}

--- a/pkg/controllers/active_deadline_test.go
+++ b/pkg/controllers/active_deadline_test.go
@@ -1,0 +1,451 @@
+/*
+Copyright The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog/v2/ktesting"
+	clocktesting "k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+	"sigs.k8s.io/jobset/pkg/constants"
+	"sigs.k8s.io/jobset/pkg/features"
+	"sigs.k8s.io/jobset/pkg/metrics"
+	testutils "sigs.k8s.io/jobset/pkg/util/testing"
+)
+
+func TestSyncActiveDeadlineStartTime(t *testing.T) {
+	const (
+		jobSetName = "test-jobset"
+		ns         = "default"
+	)
+	now := metav1.Now()
+	earlier := metav1.NewTime(now.Add(-time.Hour))
+
+	tests := []struct {
+		name           string
+		jobset         *jobset.JobSet
+		expectStartSet bool // startTime should be non-nil after sync
+		expectCleared  bool // startTime was non-nil, expect nil after sync
+		expectChanged  bool // shouldUpdate expected
+		expectPreserve bool // startTime should keep its original value
+	}{
+		{
+			name:           "active jobset with no startTime gets one",
+			jobset:         testutils.MakeJobSet(jobSetName, ns).Obj(),
+			expectStartSet: true,
+			expectChanged:  true,
+		},
+		{
+			name:           "active jobset with existing startTime is preserved",
+			jobset:         testutils.MakeJobSet(jobSetName, ns).StartTime(earlier).Obj(),
+			expectStartSet: true,
+			expectPreserve: true,
+		},
+		{
+			name:          "suspended jobset with startTime gets cleared",
+			jobset:        testutils.MakeJobSet(jobSetName, ns).Suspend(true).StartTime(earlier).Obj(),
+			expectCleared: true,
+			expectChanged: true,
+		},
+		{
+			name:   "suspended jobset with no startTime stays nil",
+			jobset: testutils.MakeJobSet(jobSetName, ns).Suspend(true).Obj(),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.JobSetActiveDeadlineSeconds, true)
+			r := &JobSetReconciler{clock: clocktesting.NewFakeClock(now.Time)}
+			opts := &statusUpdateOpts{}
+			orig := tc.jobset.Status.StartTime.DeepCopy()
+
+			r.syncActiveDeadlineStartTime(tc.jobset, opts)
+
+			got := tc.jobset.Status.StartTime
+			if tc.expectStartSet {
+				require.NotNil(t, got, "expected startTime to be set")
+			}
+			if tc.expectCleared {
+				require.Nil(t, got, "expected startTime to be cleared")
+			}
+			if !tc.expectStartSet && !tc.expectCleared {
+				require.Nil(t, got, "expected startTime to stay nil")
+			}
+			if tc.expectPreserve {
+				require.NotNil(t, got)
+				require.True(t, got.Equal(orig), "expected startTime %v to be preserved, got %v", orig, got)
+			}
+			require.Equal(t, tc.expectChanged, opts.shouldUpdate)
+		})
+	}
+}
+
+func TestResetStartTimeOnGlobalRestart(t *testing.T) {
+	const (
+		jobSetName = "test-jobset"
+		ns         = "default"
+	)
+	now := metav1.Now()
+	old := metav1.NewTime(now.Add(-time.Hour))
+
+	tests := []struct {
+		name           string
+		restartsBefore int32
+		restartsAfter  int32
+		startTime      *metav1.Time
+		gateDisabled   bool // run with the feature gate off (default: on)
+		expectReset    bool
+		expectChanged  bool
+	}{
+		{
+			name:           "global restart bumps restarts: startTime reset to now",
+			restartsBefore: 2,
+			restartsAfter:  3,
+			startTime:      &old,
+			expectReset:    true,
+			expectChanged:  true,
+		},
+		{
+			name:           "single-Job restart (restarts unchanged): startTime untouched",
+			restartsBefore: 2,
+			restartsAfter:  2,
+			startTime:      &old,
+		},
+		{
+			name:           "restart bumped but startTime nil (suspended): stays nil",
+			restartsBefore: 2,
+			restartsAfter:  3,
+			startTime:      nil,
+		},
+		{
+			// Gate off: the function short-circuits, so no reset even on a global restart.
+			name:           "gate disabled: global restart is a no-op",
+			restartsBefore: 2,
+			restartsAfter:  3,
+			startTime:      &old,
+			gateDisabled:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.JobSetActiveDeadlineSeconds, !tc.gateDisabled)
+			r := &JobSetReconciler{clock: clocktesting.NewFakeClock(now.Time)}
+			js := testutils.MakeJobSet(jobSetName, ns).Obj()
+			js.Status.StartTime = tc.startTime
+			js.Status.Restarts = tc.restartsAfter
+			opts := &statusUpdateOpts{}
+
+			r.resetStartTimeOnGlobalRestart(js, tc.restartsBefore, opts)
+
+			if tc.expectReset {
+				require.NotNil(t, js.Status.StartTime)
+				require.True(t, js.Status.StartTime.Time.Equal(now.Time), "expected startTime reset to %v, got %v", now.Time, js.Status.StartTime)
+			} else if tc.startTime == nil {
+				require.Nil(t, js.Status.StartTime, "expected startTime to stay nil")
+			} else {
+				require.True(t, js.Status.StartTime.Equal(tc.startTime), "expected startTime unchanged %v, got %v", tc.startTime, js.Status.StartTime)
+			}
+			require.Equal(t, tc.expectChanged, opts.shouldUpdate)
+		})
+	}
+}
+
+func TestExecuteActiveDeadlinePolicy(t *testing.T) {
+	const (
+		jobSetName = "test-jobset"
+		ns         = "default"
+	)
+	now := metav1.Now()
+
+	tests := []struct {
+		name                string
+		gateEnabled         bool
+		jobset              *jobset.JobSet
+		expectExpired       bool
+		expectRequeueApprox time.Duration // >0 means requeue expected roughly equal
+		expectFailed        bool
+	}{
+		{
+			name:        "gate disabled: no-op even when deadline set and elapsed",
+			gateEnabled: false,
+			jobset: testutils.MakeJobSet(jobSetName, ns).ActiveDeadlineSeconds(10).
+				StartTime(metav1.NewTime(now.Add(-time.Hour))).Obj(),
+		},
+		{
+			name:        "deadline unset: no-op",
+			gateEnabled: true,
+			jobset:      testutils.MakeJobSet(jobSetName, ns).StartTime(now).Obj(),
+		},
+		{
+			name:        "suspended: no-op",
+			gateEnabled: true,
+			jobset: testutils.MakeJobSet(jobSetName, ns).Suspend(true).ActiveDeadlineSeconds(10).
+				StartTime(metav1.NewTime(now.Add(-time.Hour))).Obj(),
+		},
+		{
+			name:        "not started (nil startTime): no-op",
+			gateEnabled: true,
+			jobset:      testutils.MakeJobSet(jobSetName, ns).ActiveDeadlineSeconds(10).Obj(),
+		},
+		{
+			name:        "remaining > 0: requeue, no failure",
+			gateEnabled: true,
+			jobset: testutils.MakeJobSet(jobSetName, ns).ActiveDeadlineSeconds(60).
+				StartTime(metav1.NewTime(now.Add(-10 * time.Second))).Obj(),
+			expectRequeueApprox: 50 * time.Second,
+		},
+		{
+			name:        "deadline exceeded: fail",
+			gateEnabled: true,
+			jobset: testutils.MakeJobSet(jobSetName, ns).ActiveDeadlineSeconds(10).
+				StartTime(metav1.NewTime(now.Add(-time.Hour))).Obj(),
+			expectExpired: true,
+			expectFailed:  true,
+		},
+		{
+			name:        "future startTime (clock skew): treated as not expired",
+			gateEnabled: true,
+			jobset: testutils.MakeJobSet(jobSetName, ns).ActiveDeadlineSeconds(10).
+				StartTime(metav1.NewTime(now.Add(time.Hour))).Obj(),
+			expectRequeueApprox: time.Hour + 10*time.Second,
+		},
+		{
+			name:        "overflow-large deadline: treated as never expiring, no failure",
+			gateEnabled: true,
+			jobset: testutils.MakeJobSet(jobSetName, ns).ActiveDeadlineSeconds(math.MaxInt64).
+				StartTime(metav1.NewTime(now.Add(-time.Hour))).Obj(),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			features.SetFeatureGateDuringTest(t, features.JobSetActiveDeadlineSeconds, tc.gateEnabled)
+
+			r := &JobSetReconciler{clock: clocktesting.NewFakeClock(now.Time)}
+			opts := &statusUpdateOpts{}
+			// No active jobs, so deleteJobs is a no-op and needs no client.
+			expired, requeueAfter, err := r.executeActiveDeadlinePolicy(ctx, tc.jobset, &childJobs{}, opts)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectExpired, expired)
+			if tc.expectRequeueApprox > 0 {
+				// Allow small slack for test execution time.
+				diff := requeueAfter - tc.expectRequeueApprox
+				require.True(t, diff >= -time.Second && diff <= time.Second, "expected requeueAfter ~%v, got %v", tc.expectRequeueApprox, requeueAfter)
+			} else if !tc.expectExpired {
+				require.Zero(t, requeueAfter, "expected no requeue")
+			}
+			failed := apimeta.IsStatusConditionTrue(tc.jobset.Status.Conditions, string(jobset.JobSetFailed))
+			require.Equal(t, tc.expectFailed, failed)
+			if tc.expectFailed {
+				cond := apimeta.FindStatusCondition(tc.jobset.Status.Conditions, string(jobset.JobSetFailed))
+				require.NotNil(t, cond)
+				require.Equal(t, constants.DeadlineExceededReason, cond.Reason)
+			}
+		})
+	}
+}
+
+// adlsScheme builds a scheme with the types the reconcile-level tests need.
+func adlsScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	utilruntime.Must(jobset.AddToScheme(s))
+	utilruntime.Must(batchv1.AddToScheme(s))
+	utilruntime.Must(corev1.AddToScheme(s))
+	return s
+}
+
+// adlsJobIndex mirrors the controller's JobsIndexByJobSetKey index so the fake
+// client resolves getChildJobs by JobSet UID.
+func adlsJobIndex(obj client.Object) []string {
+	owner := metav1.GetControllerOf(obj.(*batchv1.Job))
+	if owner == nil || owner.Kind != "JobSet" {
+		return nil
+	}
+	return []string{string(owner.UID)}
+}
+
+// adlsRJobName is the single ReplicatedJob name used by adlsJobSet/adlsChildJob.
+const adlsRJobName = "rjob"
+
+// adlsChildJob builds a child Job owned by js, in the current run (restart 0),
+// optionally already finished with the given condition type.
+func adlsChildJob(js *jobset.JobSet, idx int, finished batchv1.JobConditionType) *batchv1.Job {
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s-%d", js.Name, adlsRJobName, idx),
+			Namespace: js.Namespace,
+			Labels: map[string]string{
+				constants.RestartsKey:       "0",
+				jobset.ReplicatedJobNameKey: adlsRJobName,
+				jobset.JobIndexKey:          strconv.Itoa(idx),
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: jobset.GroupVersion.String(),
+				Kind:       "JobSet",
+				Name:       js.Name,
+				UID:        js.UID,
+				Controller: ptr.To(true),
+			}},
+		},
+	}
+	if finished != "" {
+		job.Status.Conditions = []batchv1.JobCondition{{Type: finished, Status: corev1.ConditionTrue}}
+	}
+	return job
+}
+
+// adlsReconcile drives r.reconcile against a fake client seeded with the JobSet
+// and its child jobs, returning the mutated JobSet for assertions.
+func adlsReconcile(t *testing.T, gateOn bool, js *jobset.JobSet, jobs ...*batchv1.Job) *jobset.JobSet {
+	t.Helper()
+	_, ctx := ktesting.NewTestContext(t)
+	features.SetFeatureGateDuringTest(t, features.JobSetActiveDeadlineSeconds, gateOn)
+
+	scheme := adlsScheme()
+	objs := []client.Object{js}
+	for _, j := range jobs {
+		objs = append(objs, j)
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithStatusSubresource(&jobset.JobSet{}, &batchv1.Job{}).
+		WithIndex(&batchv1.Job{}, constants.JobsIndexByJobSetKey, adlsJobIndex).
+		Build()
+
+	r := &JobSetReconciler{
+		Client: c,
+		Scheme: scheme,
+		clock:  clocktesting.NewFakeClock(time.Now()),
+	}
+	_, err := r.reconcile(ctx, js, &statusUpdateOpts{})
+	require.NoError(t, err)
+	return js
+}
+
+// adlsJobSet builds a single-ReplicatedJob JobSet with an Any success policy.
+func adlsJobSet(replicas int32) *jobset.JobSet {
+	js := testutils.MakeJobSet("adls-order", "default").
+		SuccessPolicy(&jobset.SuccessPolicy{Operator: jobset.OperatorAny}).
+		ReplicatedJob(testutils.MakeReplicatedJob(adlsRJobName).
+			Job(testutils.MakeJobTemplate("job", "default").Obj()).
+			Replicas(replicas).
+			Obj()).
+		Obj()
+	js.UID = "adls-order-uid"
+	return js
+}
+
+func isCompleted(js *jobset.JobSet) bool {
+	return apimeta.IsStatusConditionTrue(js.Status.Conditions, string(jobset.JobSetCompleted))
+}
+
+func failedReason(js *jobset.JobSet) string {
+	c := apimeta.FindStatusCondition(js.Status.Conditions, string(jobset.JobSetFailed))
+	if c == nil || c.Status != metav1.ConditionTrue {
+		return ""
+	}
+	return c.Reason
+}
+
+// TestReconcileSuccessBeatsExpiredDeadline covers KEP precedence: a JobSet that
+// satisfies its success policy in the same reconcile where the deadline has
+// already expired is marked Completed, not failed with DeadlineExceeded.
+func TestReconcileSuccessBeatsExpiredDeadline(t *testing.T) {
+	js := adlsJobSet(1)
+	js.Spec.ActiveDeadlineSeconds = ptr.To[int64](10)
+	js.Status.StartTime = ptr.To(metav1.NewTime(time.Now().Add(-time.Hour))) // deadline long past
+
+	got := adlsReconcile(t, true, js, adlsChildJob(js, 0, batchv1.JobComplete))
+
+	require.True(t, isCompleted(got), "expected JobSet Completed via success policy")
+	require.NotEqual(t, constants.DeadlineExceededReason, failedReason(got), "must not be failed by the deadline")
+}
+
+// TestReconcileDeadlineBeatsFailurePolicy covers KEP semantics: when a child-Job
+// failure and an elapsed deadline are observed in the same reconcile, the JobSet
+// fails with DeadlineExceeded (checked before the failure policy) and is not
+// restarted.
+func TestReconcileDeadlineBeatsFailurePolicy(t *testing.T) {
+	js := adlsJobSet(1)
+	js.Spec.ActiveDeadlineSeconds = ptr.To[int64](10)
+	js.Spec.FailurePolicy = &jobset.FailurePolicy{MaxRestarts: 3} // would restart if reached
+	js.Status.StartTime = ptr.To(metav1.NewTime(time.Now().Add(-time.Hour)))
+
+	got := adlsReconcile(t, true, js, adlsChildJob(js, 0, batchv1.JobFailed))
+
+	require.Equal(t, constants.DeadlineExceededReason, failedReason(got), "expected DeadlineExceeded before failure policy")
+	require.Equal(t, int32(0), got.Status.Restarts, "must not restart when the deadline wins")
+}
+
+// TestReconcileNoDeadlineKeepsOriginalOrdering covers the reorder scoping: a
+// JobSet without activeDeadlineSeconds keeps the original failure -> success
+// ordering even when the gate is on, so enabling the gate never flips the
+// terminal outcome of a JobSet that does not use the feature. With a satisfiable
+// Any success policy and a simultaneous failed job, the failure policy wins
+// (original behavior), not success.
+func TestReconcileNoDeadlineKeepsOriginalOrdering(t *testing.T) {
+	js := adlsJobSet(2) // rjob-0 complete, rjob-1 failed
+	// No ActiveDeadlineSeconds set; nil FailurePolicy => failed job fails the JobSet.
+	got := adlsReconcile(t, true, js,
+		adlsChildJob(js, 0, batchv1.JobComplete),
+		adlsChildJob(js, 1, batchv1.JobFailed),
+	)
+
+	require.False(t, isCompleted(got), "success must not win: field unset keeps failure -> success ordering")
+	require.Equal(t, constants.FailedJobsReason, failedReason(got), "expected failure policy to fail the JobSet")
+}
+
+// TestExecuteActiveDeadlinePolicyIncrementsMetric verifies the
+// jobset_active_deadline_exceeded_total metric is incremented once on expiry.
+func TestExecuteActiveDeadlinePolicyIncrementsMetric(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	features.SetFeatureGateDuringTest(t, features.JobSetActiveDeadlineSeconds, true)
+
+	const name, ns = "adls-metric-js", "default"
+	js := testutils.MakeJobSet(name, ns).
+		ActiveDeadlineSeconds(10).
+		StartTime(metav1.NewTime(time.Now().Add(-time.Hour))).
+		Obj()
+
+	before := testutil.ToFloat64(metrics.ActiveDeadlineExceededTotal.WithLabelValues(name, ns))
+
+	r := &JobSetReconciler{clock: clocktesting.NewFakeClock(time.Now())}
+	expired, _, err := r.executeActiveDeadlinePolicy(ctx, js, &childJobs{}, &statusUpdateOpts{})
+	require.NoError(t, err)
+	require.True(t, expired)
+
+	after := testutil.ToFloat64(metrics.ActiveDeadlineExceededTotal.WithLabelValues(name, ns))
+	require.Equal(t, before+1, after, "expected active_deadline_exceeded_total to increment by 1")
+}

--- a/pkg/controllers/failure_policy.go
+++ b/pkg/controllers/failure_policy.go
@@ -192,6 +192,9 @@ func failurePolicyRecreateAll(ctx context.Context, js *jobset.JobSet, shouldCoun
 
 	// Increment JobSet global restarts. This will trigger reconciliation and result in deletions
 	// of old jobs not part of the current jobSet run.
+	// Note: the active-deadline .status.startTime is reset by the reconcile loop when it
+	// observes Status.Restarts increase (see resetStartTimeOnGlobalRestart), so it uses the
+	// controller's injectable clock rather than the wall clock here.
 	js.Status.Restarts += 1
 	if features.Enabled(features.ExecutionAttemptsTracking) {
 		if js.Status.ExecutionAttempts == nil {

--- a/pkg/controllers/jobset_controller.go
+++ b/pkg/controllers/jobset_controller.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"k8s.io/utils/clock"
 
@@ -204,19 +205,70 @@ func (r *JobSetReconciler) reconcile(ctx context.Context, js *jobset.JobSet, upd
 		setRestartingConditionFalse(js, constants.RestartingJobSetReasonJobsReady, constants.RestartingJobSetReasonJobsReadyMessage, updateStatusOpts)
 	}
 
-	// If any jobs have failed, execute the JobSet failure policy (if any).
-	if len(ownedJobs.failed) > 0 {
-		if err := executeFailurePolicy(ctx, js, ownedJobs, updateStatusOpts); err != nil {
-			log.Error(err, "executing failure policy")
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{}, nil
+	// Maintain .status.startTime (the JobSet active-start time and the anchor for
+	// spec.activeDeadlineSeconds) only while the feature gate is on, so a JobSet
+	// carries no active-deadline status side effects when disabled.
+	activeDeadlineGateEnabled := features.Enabled(features.JobSetActiveDeadlineSeconds)
+	if activeDeadlineGateEnabled {
+		r.syncActiveDeadlineStartTime(js, updateStatusOpts)
 	}
 
-	// If any jobs have succeeded, execute the JobSet success policy.
-	if len(ownedJobs.successful) > 0 {
-		if completed := executeSuccessPolicy(js, ownedJobs, updateStatusOpts); completed {
+	// deadlineRequeueAfter wakes the controller exactly at the active deadline.
+	// It stays 0 (no extra requeue) unless the feature is enabled and armed.
+	var deadlineRequeueAfter time.Duration
+
+	// The success -> deadline -> failure ordering applies only to JobSets that opt in
+	// via spec.activeDeadlineSeconds while the gate is on. Every other JobSet keeps the
+	// original failure -> success ordering, so enabling the cluster-wide gate never
+	// changes the terminal outcome of a JobSet that does not use the feature.
+	if activeDeadlineGateEnabled && js.Spec.ActiveDeadlineSeconds != nil {
+		// Success runs first so a completed JobSet always wins; the deadline runs
+		// before the failure policy so an expired JobSet fails with DeadlineExceeded
+		// instead of being restarted (which would reset or bypass the deadline).
+		if len(ownedJobs.successful) > 0 {
+			if completed := executeSuccessPolicy(js, ownedJobs, updateStatusOpts); completed {
+				return ctrl.Result{}, nil
+			}
+		}
+
+		expired, requeueAfter, err := r.executeActiveDeadlinePolicy(ctx, js, ownedJobs, updateStatusOpts)
+		if err != nil {
+			log.Error(err, "executing active deadline policy")
+			return ctrl.Result{}, err
+		}
+		if expired {
 			return ctrl.Result{}, nil
+		}
+		deadlineRequeueAfter = requeueAfter
+
+		if len(ownedJobs.failed) > 0 {
+			restartsBefore := js.Status.Restarts
+			if err := executeFailurePolicy(ctx, js, ownedJobs, updateStatusOpts); err != nil {
+				log.Error(err, "executing failure policy")
+				return ctrl.Result{}, err
+			}
+			// A global restart (Status.Restarts bumped) begins a fresh run, so reset
+			// the active-deadline timer using the injectable clock.
+			r.resetStartTimeOnGlobalRestart(js, restartsBefore, updateStatusOpts)
+			return ctrl.Result{}, nil
+		}
+	} else {
+		// Original failure -> success ordering, unchanged from before the feature.
+		if len(ownedJobs.failed) > 0 {
+			restartsBefore := js.Status.Restarts
+			if err := executeFailurePolicy(ctx, js, ownedJobs, updateStatusOpts); err != nil {
+				log.Error(err, "executing failure policy")
+				return ctrl.Result{}, err
+			}
+			// Keep startTime consistent across global restarts for JobSets without a
+			// deadline. Self-gated: a no-op while the feature gate is off.
+			r.resetStartTimeOnGlobalRestart(js, restartsBefore, updateStatusOpts)
+			return ctrl.Result{}, nil
+		}
+		if len(ownedJobs.successful) > 0 {
+			if completed := executeSuccessPolicy(js, ownedJobs, updateStatusOpts); completed {
+				return ctrl.Result{}, nil
+			}
 		}
 	}
 
@@ -285,7 +337,10 @@ func (r *JobSetReconciler) reconcile(ctx context.Context, js *jobset.JobSet, upd
 		}
 	}
 
-	return ctrl.Result{}, nil
+	// Requeue at the active deadline so a wedged JobSet (which produces no child
+	// events) is still failed at expiry. deadlineRequeueAfter is 0 when the deadline
+	// is unset, disabled, or the JobSet is suspended, which leaves behavior unchanged.
+	return ctrl.Result{RequeueAfter: deadlineRequeueAfter}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -59,6 +59,14 @@ const (
 	//
 	// Enables tracking and propagating JobSet execution attempts as a monotonic counter.
 	ExecutionAttemptsTracking featuregate.Feature = "ExecutionAttemptsTracking"
+
+	// owner: @yindia
+	// kep: https://github.com/kubernetes-sigs/jobset/blob/main/keps/1186-active-deadline-seconds/README.md
+	//
+	// Enables enforcement of the JobSet-level spec.activeDeadlineSeconds, which bounds the
+	// continuous active runtime of a JobSet before the controller marks it Failed and deletes
+	// its active Jobs. The .status.startTime field is maintained regardless of this gate.
+	JobSetActiveDeadlineSeconds featuregate.Feature = "JobSetActiveDeadlineSeconds"
 )
 
 func init() {
@@ -81,6 +89,8 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ElasticJobSet: {Default: false, PreRelease: featuregate.Alpha},
 
 	ExecutionAttemptsTracking: {Default: false, PreRelease: featuregate.Alpha},
+
+	JobSetActiveDeadlineSeconds: {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func SetFeatureGateDuringTest(tb testing.TB, f featuregate.Feature, value bool) {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -39,6 +39,14 @@ var (
 			Help:      `The total number of completed JobSets`,
 		}, []string{"jobset_name", "namespace"},
 	)
+
+	ActiveDeadlineExceededTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: constants.JobSetSubsystemName,
+			Name:      "active_deadline_exceeded_total",
+			Help:      `The total number of JobSets failed due to exceeding spec.activeDeadlineSeconds`,
+		}, []string{"jobset_name", "namespace"},
+	)
 )
 
 // JobSetFailed records the failed case
@@ -53,9 +61,16 @@ func JobSetCompleted(name, namespace string) {
 	CompletedTotal.WithLabelValues(name, namespace).Inc()
 }
 
+// JobSetActiveDeadlineExceeded records a JobSet failed due to exceeding its active deadline.
+// label values: name, namespace
+func JobSetActiveDeadlineExceeded(name, namespace string) {
+	ActiveDeadlineExceededTotal.WithLabelValues(name, namespace).Inc()
+}
+
 func Register() {
 	metrics.Registry.MustRegister(
 		FailedTotal,
 		CompletedTotal,
+		ActiveDeadlineExceededTotal,
 	)
 }

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -164,6 +164,18 @@ func (j *JobSetWrapper) PublishNotReadyAddresses(val bool) *JobSetWrapper {
 	return j
 }
 
+// ActiveDeadlineSeconds sets the value of JobSet.Spec.ActiveDeadlineSeconds
+func (j *JobSetWrapper) ActiveDeadlineSeconds(seconds int64) *JobSetWrapper {
+	j.Spec.ActiveDeadlineSeconds = &seconds
+	return j
+}
+
+// StartTime sets the value of JobSet.Status.StartTime
+func (j *JobSetWrapper) StartTime(t metav1.Time) *JobSetWrapper {
+	j.Status.StartTime = &t
+	return j
+}
+
 // TTLSecondsAfterFinished sets the value of JobSet.Spec.TTLSecondsAfterFinished
 func (j *JobSetWrapper) TTLSecondsAfterFinished(seconds int32) *JobSetWrapper {
 	j.Spec.TTLSecondsAfterFinished = &seconds

--- a/pkg/webhooks/jobset_webhook.go
+++ b/pkg/webhooks/jobset_webhook.go
@@ -176,6 +176,12 @@ func (j *jobSetWebhook) ValidateCreate(ctx context.Context, js *jobset.JobSet) (
 		}
 	}
 
+	// Validate JobSetActiveDeadlineSeconds feature gate.
+	// activeDeadlineSeconds should be settable only when the feature gate is enabled.
+	if !features.Enabled(features.JobSetActiveDeadlineSeconds) && js.Spec.ActiveDeadlineSeconds != nil {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "activeDeadlineSeconds"), *js.Spec.ActiveDeadlineSeconds, "cannot be set when JobSetActiveDeadlineSeconds feature gate is disabled"))
+	}
+
 	// Validate that depends On can't be set for the first replicated job.
 	if len(js.Spec.ReplicatedJobs) > 0 && js.Spec.ReplicatedJobs[0].DependsOn != nil {
 		allErrs = append(allErrs, fmt.Errorf("DependsOn can't be set for the first ReplicatedJob"))
@@ -391,6 +397,16 @@ func (j *jobSetWebhook) ValidateUpdate(ctx context.Context, oldJs, newJs *jobset
 			// Pod Scheduling Gates can be updated for batch/v1 Job: https://github.com/kubernetes/kubernetes/blob/ceb58a4dbc671b9d0a2de6d73a1616bc0c299863/pkg/apis/batch/validation/validation.go#L662
 			mungedSpec.ReplicatedJobs[index].Template.Spec.Template.Spec.SchedulingGates = oldRJob.Template.Spec.Template.Spec.SchedulingGates
 		}
+	}
+
+	// Validate JobSetActiveDeadlineSeconds feature gate: activeDeadlineSeconds can be
+	// set or changed only when the feature gate is enabled. An unchanged value is left
+	// alone so a JobSet created while the gate was on can still be updated otherwise,
+	// and clearing the field is always allowed.
+	if !features.Enabled(features.JobSetActiveDeadlineSeconds) &&
+		!ptr.Equal(newJs.Spec.ActiveDeadlineSeconds, oldJs.Spec.ActiveDeadlineSeconds) &&
+		newJs.Spec.ActiveDeadlineSeconds != nil {
+		errs = append(errs, field.Invalid(field.NewPath("spec", "activeDeadlineSeconds"), *newJs.Spec.ActiveDeadlineSeconds, "cannot be set when JobSetActiveDeadlineSeconds feature gate is disabled"))
 	}
 
 	// Note that SucccessPolicy and failurePolicy are made immutable via CEL.

--- a/pkg/webhooks/jobset_webhook_test.go
+++ b/pkg/webhooks/jobset_webhook_test.go
@@ -816,12 +816,13 @@ func TestJobSetDefaulting(t *testing.T) {
 }
 
 type validationTestCase struct {
-	name                 string
-	enableInPlaceRestart bool
-	enableRestartJob     bool
-	js                   *jobset.JobSet
-	want                 error
-	existingObjs         []runtime.Object // objects to pre-populate in the fake client
+	name                        string
+	enableInPlaceRestart        bool
+	enableRestartJob            bool
+	enableActiveDeadlineSeconds bool
+	js                          *jobset.JobSet
+	want                        error
+	existingObjs                []runtime.Object // objects to pre-populate in the fake client
 }
 
 // TestValidateCreate tests the ValidateCreate method of the jobset webhook.
@@ -3216,6 +3217,57 @@ func TestValidateCreate(t *testing.T) {
 		},
 	}
 
+	activeDeadlineSecondsTests := []validationTestCase{
+		{
+			name:                        "activeDeadlineSeconds cannot be set when JobSetActiveDeadlineSeconds feature gate is disabled",
+			enableActiveDeadlineSeconds: false,
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					SuccessPolicy:         &jobset.SuccessPolicy{},
+					ActiveDeadlineSeconds: ptr.To[int64](60),
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:      "job-1",
+							GroupName: "default",
+							Replicas:  1,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Template: validPodTemplateSpec,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: errors.Join(field.Invalid(field.NewPath("spec", "activeDeadlineSeconds"), int64(60), "cannot be set when JobSetActiveDeadlineSeconds feature gate is disabled")),
+		},
+		{
+			name:                        "activeDeadlineSeconds can be set when JobSetActiveDeadlineSeconds feature gate is enabled",
+			enableActiveDeadlineSeconds: true,
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					SuccessPolicy:         &jobset.SuccessPolicy{},
+					ActiveDeadlineSeconds: ptr.To[int64](60),
+					ReplicatedJobs: []jobset.ReplicatedJob{
+						{
+							Name:      "job-1",
+							GroupName: "default",
+							Replicas:  1,
+							Template: batchv1.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Template: validPodTemplateSpec,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+	}
+
 	testGroups := [][]validationTestCase{
 		uncategorizedTests,
 		jobsetControllerNameTests,
@@ -3223,6 +3275,7 @@ func TestValidateCreate(t *testing.T) {
 		dependsOnTests,
 		volumeClaimPolicyTests,
 		inPlaceRestartTests,
+		activeDeadlineSecondsTests,
 	}
 	var testCases []validationTestCase
 	for _, testGroup := range testGroups {
@@ -3236,6 +3289,7 @@ func TestValidateCreate(t *testing.T) {
 			testWebhook := &jobSetWebhook{client: testClient}
 			features.SetFeatureGateDuringTest(t, features.InPlaceRestart, tc.enableInPlaceRestart)
 			features.SetFeatureGateDuringTest(t, features.RestartJob, tc.enableRestartJob)
+			features.SetFeatureGateDuringTest(t, features.JobSetActiveDeadlineSeconds, tc.enableActiveDeadlineSeconds)
 			_, err := testWebhook.ValidateCreate(context.TODO(), tc.js.DeepCopy())
 			if err != nil && tc.want != nil {
 				// Verify it's specifically a 422 StatusError
@@ -3312,11 +3366,12 @@ func TestValidateUpdate(t *testing.T) {
 		},
 	}
 	testCases := []struct {
-		name                string
-		oldJs               *jobset.JobSet
-		js                  *jobset.JobSet
-		want                error
-		enableElasticJobSet bool
+		name                        string
+		oldJs                       *jobset.JobSet
+		js                          *jobset.JobSet
+		want                        error
+		enableElasticJobSet         bool
+		enableActiveDeadlineSeconds bool
 	}{
 		{
 			name: "update suspend",
@@ -4087,6 +4142,64 @@ func TestValidateUpdate(t *testing.T) {
 			}.ToAggregate(),
 			enableElasticJobSet: true,
 		},
+		{
+			name:                        "activeDeadlineSeconds cannot be set on update when JobSetActiveDeadlineSeconds feature gate is disabled",
+			enableActiveDeadlineSeconds: false,
+			oldJs: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: validReplicatedJobs,
+				},
+			},
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs:        validReplicatedJobs,
+					ActiveDeadlineSeconds: ptr.To[int64](60),
+				},
+			},
+			want: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "activeDeadlineSeconds"), int64(60), "cannot be set when JobSetActiveDeadlineSeconds feature gate is disabled"),
+			}.ToAggregate(),
+		},
+		{
+			name:                        "activeDeadlineSeconds can be set on update when JobSetActiveDeadlineSeconds feature gate is enabled",
+			enableActiveDeadlineSeconds: true,
+			oldJs: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs: validReplicatedJobs,
+				},
+			},
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs:        validReplicatedJobs,
+					ActiveDeadlineSeconds: ptr.To[int64](60),
+				},
+			},
+			want: nil,
+		},
+		{
+			name:                        "unchanged activeDeadlineSeconds does not block other updates when gate is disabled",
+			enableActiveDeadlineSeconds: false,
+			oldJs: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs:        validReplicatedJobs,
+					ActiveDeadlineSeconds: ptr.To[int64](60),
+				},
+			},
+			js: &jobset.JobSet{
+				ObjectMeta: validObjectMeta,
+				Spec: jobset.JobSetSpec{
+					ReplicatedJobs:        validReplicatedJobs,
+					ActiveDeadlineSeconds: ptr.To[int64](60),
+					Suspend:               ptr.To(true),
+				},
+			},
+			want: nil,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -4094,6 +4207,7 @@ func TestValidateUpdate(t *testing.T) {
 			fakeClient := fake.NewFakeClient()
 			webhook := &jobSetWebhook{client: fakeClient}
 			features.SetFeatureGateDuringTest(t, features.ElasticJobSet, tc.enableElasticJobSet)
+			features.SetFeatureGateDuringTest(t, features.JobSetActiveDeadlineSeconds, tc.enableActiveDeadlineSeconds)
 			newObj := tc.js.DeepCopy()
 			oldObj := tc.oldJs.DeepCopy()
 			_, err := webhook.ValidateUpdate(context.TODO(), oldObj, newObj)

--- a/sdk/python/jobset/models/jobset_v1alpha2_job_set_spec.py
+++ b/sdk/python/jobset/models/jobset_v1alpha2_job_set_spec.py
@@ -33,6 +33,7 @@ class JobsetV1alpha2JobSetSpec(BaseModel):
     """
     JobSetSpec defines the desired state of JobSet
     """ # noqa: E501
+    active_deadline_seconds: Optional[StrictInt] = Field(default=None, description="activeDeadlineSeconds is the maximum duration in seconds, relative to status.startTime, that the JobSet may be continuously active before the JobSet controller marks it Failed and deletes its active Jobs.  The timer does not accrue while the JobSet is suspended: startTime is cleared on suspend and reset when the JobSet resumes. The value must be a positive integer. The field is mutable: operators may raise or lower the deadline on a running JobSet, matching batch/v1.Job. The controller recomputes the remaining time from status.startTime on the next reconcile, so no timer state is reset on update.", alias="activeDeadlineSeconds")
     coordinator: Optional[JobsetV1alpha2Coordinator] = None
     failure_policy: Optional[JobsetV1alpha2FailurePolicy] = Field(default=None, alias="failurePolicy")
     managed_by: Optional[StrictStr] = Field(default=None, description="managedBy is used to indicate the controller or entity that manages a JobSet. The built-in JobSet controller reconciles JobSets which don't have this field at all or the field value is the reserved string `jobset.sigs.k8s.io/jobset-controller`, but skips reconciling JobSets with a custom value for this field. Note that ttlSecondsAfterFinished cleanup still applies to externally managed JobSets once the managing controller has recorded a terminal condition.  The value must be a valid domain-prefixed path (e.g. acme.io/foo) - all characters before the first \"/\" must be a valid subdomain as defined by RFC 1123. All characters trailing the first \"/\" must be valid HTTP Path characters as defined by RFC 3986. The value cannot exceed 63 characters. The field is immutable.", alias="managedBy")
@@ -43,7 +44,7 @@ class JobsetV1alpha2JobSetSpec(BaseModel):
     suspend: Optional[StrictBool] = Field(default=None, description="suspend suspends all running child Jobs when set to true.")
     ttl_seconds_after_finished: Optional[StrictInt] = Field(default=None, description="ttlSecondsAfterFinished limits the lifetime of a JobSet that has finished execution (either Complete or Failed). If this field is set, TTLSecondsAfterFinished after the JobSet finishes, it is eligible to be automatically deleted. When the JobSet is being deleted, its lifecycle guarantees (e.g. finalizers) will be honored. If this field is unset, the JobSet won't be automatically deleted. If this field is set to zero, the JobSet becomes eligible to be deleted immediately after it finishes. For JobSets that set managedBy to an external controller, TTL cleanup becomes eligible only after that controller records a terminal (Completed or Failed) condition.", alias="ttlSecondsAfterFinished")
     volume_claim_policies: Optional[List[JobsetV1alpha2VolumeClaimPolicy]] = Field(default=None, description="volumeClaimPolicies is a list of policies for persistent volume claims that pods are allowed to reference. JobSet controller automatically adds the required volume claims to the pod template. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template.", alias="volumeClaimPolicies")
-    __properties: ClassVar[List[str]] = ["coordinator", "failurePolicy", "managedBy", "network", "replicatedJobs", "startupPolicy", "successPolicy", "suspend", "ttlSecondsAfterFinished", "volumeClaimPolicies"]
+    __properties: ClassVar[List[str]] = ["activeDeadlineSeconds", "coordinator", "failurePolicy", "managedBy", "network", "replicatedJobs", "startupPolicy", "successPolicy", "suspend", "ttlSecondsAfterFinished", "volumeClaimPolicies"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -125,6 +126,7 @@ class JobsetV1alpha2JobSetSpec(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
+            "activeDeadlineSeconds": obj.get("activeDeadlineSeconds"),
             "coordinator": JobsetV1alpha2Coordinator.from_dict(obj["coordinator"]) if obj.get("coordinator") is not None else None,
             "failurePolicy": JobsetV1alpha2FailurePolicy.from_dict(obj["failurePolicy"]) if obj.get("failurePolicy") is not None else None,
             "managedBy": obj.get("managedBy"),

--- a/sdk/python/jobset/models/jobset_v1alpha2_job_set_status.py
+++ b/sdk/python/jobset/models/jobset_v1alpha2_job_set_status.py
@@ -17,6 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
+from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from jobset.models.io_k8s_apimachinery_pkg_apis_meta_v1_condition import IoK8sApimachineryPkgApisMetaV1Condition
@@ -35,8 +36,9 @@ class JobsetV1alpha2JobSetStatus(BaseModel):
     replicated_jobs_status: Optional[List[JobsetV1alpha2ReplicatedJobStatus]] = Field(default=None, description="replicatedJobsStatus tracks the number of JobsReady for each replicatedJob.", alias="replicatedJobsStatus")
     restarts: Optional[StrictInt] = Field(default=0, description="restarts tracks the number of times the JobSet has been globally restarted. That is, restarts is the number of times the restart action RestartJobSet or RestartJobSetAndIgnoreMaxRestarts have been executed and led to the recreation of all Jobs.")
     restarts_count_towards_max: Optional[StrictInt] = Field(default=None, description="restartsCountTowardsMax tracks the number of times the JobSet has been globally restarted that counts towards the maximum allowed number of restarts. That is, restartsCountTowardsMax is the number of times the restart action RestartJobSet has been executed and led to the recreation of all Jobs.", alias="restartsCountTowardsMax")
+    start_time: Optional[datetime] = Field(default=None, description="Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.", alias="startTime")
     terminal_state: Optional[StrictStr] = Field(default=None, description="terminalState tracks the state of the JobSet when it finishes execution. It can be either Completed or Failed. Otherwise, it is empty by default.", alias="terminalState")
-    __properties: ClassVar[List[str]] = ["conditions", "currentInPlaceRestartAttempt", "executionAttempts", "previousInPlaceRestartAttempt", "replicatedJobsStatus", "restarts", "restartsCountTowardsMax", "terminalState"]
+    __properties: ClassVar[List[str]] = ["conditions", "currentInPlaceRestartAttempt", "executionAttempts", "previousInPlaceRestartAttempt", "replicatedJobsStatus", "restarts", "restartsCountTowardsMax", "startTime", "terminalState"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -110,6 +112,7 @@ class JobsetV1alpha2JobSetStatus(BaseModel):
             "replicatedJobsStatus": [JobsetV1alpha2ReplicatedJobStatus.from_dict(_item) for _item in obj["replicatedJobsStatus"]] if obj.get("replicatedJobsStatus") is not None else None,
             "restarts": obj.get("restarts") if obj.get("restarts") is not None else 0,
             "restartsCountTowardsMax": obj.get("restartsCountTowardsMax"),
+            "startTime": obj.get("startTime"),
             "terminalState": obj.get("terminalState")
         })
         return _obj

--- a/sdk/python/test/test_jobset_v1alpha2_job_set.py
+++ b/sdk/python/test/test_jobset_v1alpha2_job_set.py
@@ -77,6 +77,7 @@ class TestJobsetV1alpha2JobSet(unittest.TestCase):
                     self_link = '', 
                     uid = '', ),
                 spec = jobset.models.jobset_v1alpha2_job_set_spec.JobsetV1alpha2JobSetSpec(
+                    active_deadline_seconds = 56, 
                     coordinator = jobset.models.jobset_v1alpha2_coordinator.JobsetV1alpha2Coordinator(
                         job_index = 56, 
                         pod_index = 56, 
@@ -298,6 +299,7 @@ class TestJobsetV1alpha2JobSet(unittest.TestCase):
                         ], 
                     restarts = 56, 
                     restarts_count_towards_max = 56, 
+                    start_time = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                     terminal_state = '', )
             )
         else:

--- a/sdk/python/test/test_jobset_v1alpha2_job_set_list.py
+++ b/sdk/python/test/test_jobset_v1alpha2_job_set_list.py
@@ -80,6 +80,7 @@ class TestJobsetV1alpha2JobSetList(unittest.TestCase):
                             self_link = '', 
                             uid = '', ), 
                         spec = jobset.models.jobset_v1alpha2_job_set_spec.JobsetV1alpha2JobSetSpec(
+                            active_deadline_seconds = 56, 
                             coordinator = jobset.models.jobset_v1alpha2_coordinator.JobsetV1alpha2Coordinator(
                                 job_index = 56, 
                                 pod_index = 56, 
@@ -189,6 +190,7 @@ class TestJobsetV1alpha2JobSetList(unittest.TestCase):
                                 ], 
                             restarts = 56, 
                             restarts_count_towards_max = 56, 
+                            start_time = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                             terminal_state = '', ), )
                     ],
                 kind = '',
@@ -246,6 +248,7 @@ class TestJobsetV1alpha2JobSetList(unittest.TestCase):
                             self_link = '', 
                             uid = '', ), 
                         spec = jobset.models.jobset_v1alpha2_job_set_spec.JobsetV1alpha2JobSetSpec(
+                            active_deadline_seconds = 56, 
                             coordinator = jobset.models.jobset_v1alpha2_coordinator.JobsetV1alpha2Coordinator(
                                 job_index = 56, 
                                 pod_index = 56, 
@@ -355,6 +358,7 @@ class TestJobsetV1alpha2JobSetList(unittest.TestCase):
                                 ], 
                             restarts = 56, 
                             restarts_count_towards_max = 56, 
+                            start_time = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                             terminal_state = '', ), )
                     ],
         )

--- a/sdk/python/test/test_jobset_v1alpha2_job_set_spec.py
+++ b/sdk/python/test/test_jobset_v1alpha2_job_set_spec.py
@@ -35,6 +35,7 @@ class TestJobsetV1alpha2JobSetSpec(unittest.TestCase):
         model = JobsetV1alpha2JobSetSpec()
         if include_optional:
             return JobsetV1alpha2JobSetSpec(
+                active_deadline_seconds = 56,
                 coordinator = jobset.models.jobset_v1alpha2_coordinator.JobsetV1alpha2Coordinator(
                     job_index = 56, 
                     pod_index = 56, 

--- a/sdk/python/test/test_jobset_v1alpha2_job_set_status.py
+++ b/sdk/python/test/test_jobset_v1alpha2_job_set_status.py
@@ -64,6 +64,7 @@ class TestJobsetV1alpha2JobSetStatus(unittest.TestCase):
                     ],
                 restarts = 56,
                 restarts_count_towards_max = 56,
+                start_time = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'),
                 terminal_state = ''
             )
         else:

--- a/site/content/en/docs/concepts/_index.md
+++ b/site/content/en/docs/concepts/_index.md
@@ -176,6 +176,24 @@ to automatically restart the JobSet. A restart is done by recreating all child j
 
 A JobSet is terminally failed when the number of failures reaches `spec.failurePolicy.maxRestarts`
 
+### Active deadline
+
+`spec.activeDeadlineSeconds` bounds how long a JobSet may be *continuously active*.
+When the deadline is exceeded, the JobSet controller marks the JobSet as `Failed`
+with condition reason `DeadlineExceeded` and deletes its active child Jobs, freeing
+their resources. This mirrors `batch/v1.Job.spec.activeDeadlineSeconds` at the
+JobSet level, and is independent of `maxRestarts`: the deadline bounds a single
+active attempt, while `maxRestarts` bounds how many times the JobSet restarts.
+
+The timer is measured from `.status.startTime` and does not accrue while the
+JobSet is suspended: `startTime` is cleared on suspend and reset on resume and on
+a global restart (`RestartJobSet`), so a Kueue-managed JobSet is not penalized for
+queued time. The field is mutable; the controller recomputes the remaining time on
+each reconcile.
+
+This feature is alpha and gated by the `JobSetActiveDeadlineSeconds` feature gate
+(disabled by default). `.status.startTime` is maintained regardless of the gate.
+
 ## Coordinator
 
 A specific pod can be assigned as coordinator using `spec.coordinator`. If

--- a/site/content/en/docs/reference/jobset.v1alpha2.md
+++ b/site/content/en/docs/reference/jobset.v1alpha2.md
@@ -392,6 +392,21 @@ becomes eligible only after that controller records a terminal
 (Completed or Failed) condition.</p>
 </td>
 </tr>
+<tr><td><code>activeDeadlineSeconds</code><br/>
+<code>int64</code>
+</td>
+<td>
+   <p>activeDeadlineSeconds is the maximum duration in seconds, relative to
+status.startTime, that the JobSet may be continuously active before the
+JobSet controller marks it Failed and deletes its active Jobs.</p>
+<p>The timer does not accrue while the JobSet is suspended: startTime is
+cleared on suspend and reset when the JobSet resumes. The value must be a
+positive integer. The field is mutable: operators may raise or lower the
+deadline on a running JobSet, matching batch/v1.Job. The controller
+recomputes the remaining time from status.startTime on the next reconcile,
+so no timer state is reset on update.</p>
+</td>
+</tr>
 <tr><td><code>volumeClaimPolicies</code><br/>
 <a href="#jobset-x-k8s-io-v1alpha2-VolumeClaimPolicy"><code>[]VolumeClaimPolicy</code></a>
 </td>
@@ -426,6 +441,19 @@ volumeMount in one container in the template.</p>
 </td>
 <td>
    <p>conditions track status</p>
+</td>
+</tr>
+<tr><td><code>startTime</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.Time</code></a>
+</td>
+<td>
+   <p>startTime is the timestamp from which activeDeadlineSeconds is measured, and
+also serves as the JobSet's active-start time. It is set when the JobSet
+first becomes active (unsuspended), cleared when the JobSet is suspended, and
+reset to the current time when the JobSet resumes, matching
+batch/v1.Job.status.startTime. It is maintained only while the
+JobSetActiveDeadlineSeconds feature gate is enabled, independent of whether
+activeDeadlineSeconds is set.</p>
 </td>
 </tr>
 <tr><td><code>restarts</code><br/>

--- a/test/integration/controller/active_deadline_test.go
+++ b/test/integration/controller/active_deadline_test.go
@@ -1,0 +1,436 @@
+/*
+Copyright The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllertest
+
+import (
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+	"sigs.k8s.io/jobset/pkg/constants"
+	"sigs.k8s.io/jobset/pkg/features"
+	testutil "sigs.k8s.io/jobset/test/util"
+)
+
+// shortDuration is used with Consistently to confirm a state holds for a while.
+const shortDuration = 3 * time.Second
+
+var _ = ginkgo.Describe("JobSet activeDeadlineSeconds", func() {
+	var ns *corev1.Namespace
+
+	ginkgo.BeforeEach(func() {
+		ns = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "jobset-adls-ns-"}}
+		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(testutil.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+	})
+
+	get := func(js *jobset.JobSet) *jobset.JobSet {
+		var fetched jobset.JobSet
+		gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: js.Name, Namespace: js.Namespace}, &fetched)).To(gomega.Succeed())
+		return &fetched
+	}
+
+	ginkgo.It("fails the JobSet with DeadlineExceeded once the deadline passes", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.JobSetActiveDeadlineSeconds, true)
+
+		js := testJobSet(ns).ActiveDeadlineSeconds(1).Obj()
+		gomega.Expect(k8sClient.Create(ctx, js)).To(gomega.Succeed())
+
+		ginkgo.By("checking the JobSet is failed with reason DeadlineExceeded")
+		gomega.Eventually(func() bool {
+			cond := apimeta.FindStatusCondition(get(js).Status.Conditions, string(jobset.JobSetFailed))
+			return cond != nil && cond.Status == metav1.ConditionTrue && cond.Reason == constants.DeadlineExceededReason
+		}, timeout, interval).Should(gomega.BeTrue())
+
+		ginkgo.By("checking the active child jobs are marked for deletion")
+		gomega.Eventually(func() int {
+			var jobList batchv1.JobList
+			gomega.Expect(k8sClient.List(ctx, &jobList, client.InNamespace(js.Namespace))).To(gomega.Succeed())
+			active := 0
+			for i := range jobList.Items {
+				if jobList.Items[i].DeletionTimestamp == nil {
+					active++
+				}
+			}
+			return active
+		}, timeout, interval).Should(gomega.Equal(0))
+	})
+
+	ginkgo.It("populates .status.startTime while active", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.JobSetActiveDeadlineSeconds, true)
+
+		js := testJobSet(ns).Obj() // no deadline; startTime is still maintained
+		gomega.Expect(k8sClient.Create(ctx, js)).To(gomega.Succeed())
+
+		gomega.Eventually(func() bool {
+			return get(js).Status.StartTime != nil
+		}, timeout, interval).Should(gomega.BeTrue())
+	})
+
+	ginkgo.It("does not enforce the deadline while suspended", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.JobSetActiveDeadlineSeconds, true)
+
+		js := testJobSet(ns).Suspend(true).ActiveDeadlineSeconds(1).Obj()
+		gomega.Expect(k8sClient.Create(ctx, js)).To(gomega.Succeed())
+
+		testutil.JobSetSuspended(ctx, k8sClient, js, timeout)
+
+		ginkgo.By("checking the suspended JobSet is not failed and has no startTime")
+		gomega.Consistently(func() bool {
+			fetched := get(js)
+			failed := apimeta.IsStatusConditionTrue(fetched.Status.Conditions, string(jobset.JobSetFailed))
+			return !failed && fetched.Status.StartTime == nil
+		}, shortDuration, interval).Should(gomega.BeTrue())
+	})
+
+	ginkgo.It("does not fail a JobSet that completes before the deadline", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.JobSetActiveDeadlineSeconds, true)
+
+		js := testJobSet(ns).ActiveDeadlineSeconds(3600).Obj()
+		gomega.Expect(k8sClient.Create(ctx, js)).To(gomega.Succeed())
+
+		gomega.Eventually(testutil.NumJobs, timeout, interval).WithArguments(ctx, k8sClient, js).Should(gomega.Equal(testutil.NumExpectedJobs(js)))
+
+		var jobList batchv1.JobList
+		gomega.Expect(k8sClient.List(ctx, &jobList, client.InNamespace(js.Namespace))).To(gomega.Succeed())
+		completeAllJobs(&jobList)
+
+		testutil.JobSetCompleted(ctx, k8sClient, js, timeout)
+	})
+
+	ginkgo.It("recomputes the deadline from startTime when activeDeadlineSeconds is lowered on a running JobSet", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.JobSetActiveDeadlineSeconds, true)
+
+		// Start with a long deadline so the JobSet runs normally and populates startTime.
+		js := testJobSet(ns).ActiveDeadlineSeconds(3600).Obj()
+		gomega.Expect(k8sClient.Create(ctx, js)).To(gomega.Succeed())
+		gomega.Eventually(func() bool {
+			return get(js).Status.StartTime != nil
+		}, timeout, interval).Should(gomega.BeTrue())
+
+		ginkgo.By("lowering activeDeadlineSeconds below the already-elapsed active time")
+		gomega.Eventually(func() error {
+			fetched := get(js)
+			fetched.Spec.ActiveDeadlineSeconds = ptr.To(int64(1))
+			return k8sClient.Update(ctx, fetched)
+		}, timeout, interval).Should(gomega.Succeed())
+
+		ginkgo.By("checking the JobSet is failed with reason DeadlineExceeded without a restart")
+		gomega.Eventually(func() bool {
+			fetched := get(js)
+			cond := apimeta.FindStatusCondition(fetched.Status.Conditions, string(jobset.JobSetFailed))
+			return cond != nil && cond.Status == metav1.ConditionTrue && cond.Reason == constants.DeadlineExceededReason
+		}, timeout, interval).Should(gomega.BeTrue())
+		gomega.Expect(get(js).Status.Restarts).To(gomega.Equal(int32(0)))
+	})
+
+	ginkgo.It("does not maintain startTime or fail the JobSet when the feature gate is disabled", func() {
+		// Gate intentionally left disabled (default false). Use a plain JobSet: the
+		// webhook rejects activeDeadlineSeconds while the gate is off, so a valid
+		// gate-off fixture cannot set the field. The gated deadline check with the
+		// field present is covered by the TestExecuteActiveDeadlinePolicy unit test.
+		js := testJobSet(ns).Obj()
+		gomega.Expect(k8sClient.Create(ctx, js)).To(gomega.Succeed())
+
+		ginkgo.By("checking the gate-off JobSet is never failed and has no startTime side effect")
+		gomega.Consistently(func() bool {
+			fetched := get(js)
+			failed := apimeta.IsStatusConditionTrue(fetched.Status.Conditions, string(jobset.JobSetFailed))
+			return !failed && fetched.Status.StartTime == nil
+		}, shortDuration, interval).Should(gomega.BeTrue())
+	})
+
+	ginkgo.It("begins startTime maintenance when the gate is enabled on a running JobSet", func() {
+		// Gate starts disabled (suite default). startTime maintenance is gate-driven,
+		// not field-driven, so no activeDeadlineSeconds is set here (that also keeps the
+		// setup consistent with the webhook, which rejects the field while the gate is off).
+		js := testJobSet(ns).Obj()
+		gomega.Expect(k8sClient.Create(ctx, js)).To(gomega.Succeed())
+
+		ginkgo.By("confirming startTime stays nil while the gate is off")
+		gomega.Consistently(func() *metav1.Time {
+			return get(js).Status.StartTime
+		}, shortDuration, interval).Should(gomega.BeNil())
+
+		ginkgo.By("enabling the gate and nudging a reconcile")
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.JobSetActiveDeadlineSeconds, true)
+		gomega.Eventually(func() error {
+			fetched := get(js)
+			if fetched.Annotations == nil {
+				fetched.Annotations = map[string]string{}
+			}
+			fetched.Annotations["test.jobset.sigs.k8s.io/nudge"] = "1"
+			return k8sClient.Update(ctx, fetched)
+		}, timeout, interval).Should(gomega.Succeed())
+
+		ginkgo.By("checking startTime is now maintained (no persisted value, so it starts at enable)")
+		gomega.Eventually(func() *metav1.Time {
+			return get(js).Status.StartTime
+		}, timeout, interval).ShouldNot(gomega.BeNil())
+	})
+
+	ginkgo.It("preserves and resumes from the persisted startTime across a gate off->on toggle", func() {
+		// Gate on: a long-deadline JobSet becomes active and records startTime.
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.JobSetActiveDeadlineSeconds, true)
+		js := testJobSet(ns).ActiveDeadlineSeconds(3600).Obj()
+		gomega.Expect(k8sClient.Create(ctx, js)).To(gomega.Succeed())
+
+		var persisted *metav1.Time
+		gomega.Eventually(func() *metav1.Time {
+			persisted = get(js).Status.StartTime
+			return persisted
+		}, timeout, interval).ShouldNot(gomega.BeNil())
+
+		ginkgo.By("disabling the gate leaves the existing startTime untouched")
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.JobSetActiveDeadlineSeconds, false)
+		gomega.Eventually(func() error {
+			fetched := get(js)
+			if fetched.Annotations == nil {
+				fetched.Annotations = map[string]string{}
+			}
+			fetched.Annotations["test.jobset.sigs.k8s.io/nudge"] = "off"
+			return k8sClient.Update(ctx, fetched)
+		}, timeout, interval).Should(gomega.Succeed())
+		gomega.Consistently(func() bool {
+			st := get(js).Status.StartTime
+			return st != nil && st.Equal(persisted)
+		}, shortDuration, interval).Should(gomega.BeTrue())
+
+		ginkgo.By("re-enabling the gate resumes from the persisted startTime (not reset to now)")
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.JobSetActiveDeadlineSeconds, true)
+		gomega.Eventually(func() error {
+			fetched := get(js)
+			if fetched.Annotations == nil {
+				fetched.Annotations = map[string]string{}
+			}
+			fetched.Annotations["test.jobset.sigs.k8s.io/nudge"] = "on"
+			return k8sClient.Update(ctx, fetched)
+		}, timeout, interval).Should(gomega.Succeed())
+		gomega.Consistently(func() bool {
+			st := get(js).Status.StartTime
+			return st != nil && st.Equal(persisted)
+		}, shortDuration, interval).Should(gomega.BeTrue())
+	})
+
+	ginkgo.It("does not set startTime or enforce the deadline for an externally managed JobSet", func() {
+		// Gate on and deadline elapsed: proves the managedBy early-return in Reconcile
+		// sits above both startTime maintenance and the deadline check, so the built-in
+		// controller touches neither for an externally managed JobSet.
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.JobSetActiveDeadlineSeconds, true)
+
+		js := testJobSet(ns).ManagedBy("example.com/external-controller").ActiveDeadlineSeconds(1).Obj()
+		gomega.Expect(k8sClient.Create(ctx, js)).To(gomega.Succeed())
+
+		ginkgo.By("checking the built-in controller neither sets startTime nor fails the JobSet")
+		gomega.Consistently(func() bool {
+			fetched := get(js)
+			failed := apimeta.IsStatusConditionTrue(fetched.Status.Conditions, string(jobset.JobSetFailed))
+			return !failed && fetched.Status.StartTime == nil
+		}, shortDuration, interval).Should(gomega.BeTrue())
+	})
+
+	ginkgo.It("rejects activeDeadlineSeconds of zero at the API server (Minimum=1)", func() {
+		// Schema validation is independent of the feature gate.
+		js := testJobSet(ns).ActiveDeadlineSeconds(0).Obj()
+		gomega.Expect(k8sClient.Create(ctx, js)).ToNot(gomega.Succeed())
+	})
+
+	ginkgo.It("restarts the deadline timer on resume (does not fail on pre-suspend elapsed time)", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.JobSetActiveDeadlineSeconds, true)
+
+		// Long deadline so the JobSet runs normally and populates startTime.
+		js := testJobSet(ns).ActiveDeadlineSeconds(3600).Obj()
+		gomega.Expect(k8sClient.Create(ctx, js)).To(gomega.Succeed())
+		gomega.Eventually(func() *metav1.Time {
+			return get(js).Status.StartTime
+		}, timeout, interval).ShouldNot(gomega.BeNil())
+		beforeSuspend := get(js).Status.StartTime
+		// metav1.Time is second-granular once round-tripped through the API server, so
+		// wait a full second to make the resumed anchor strictly later than this one.
+		time.Sleep(time.Second)
+
+		ginkgo.By("suspending the JobSet clears startTime")
+		gomega.Eventually(func() error {
+			fetched := get(js)
+			fetched.Spec.Suspend = ptr.To(true)
+			return k8sClient.Update(ctx, fetched)
+		}, timeout, interval).Should(gomega.Succeed())
+		gomega.Eventually(func() *metav1.Time {
+			return get(js).Status.StartTime
+		}, timeout, interval).Should(gomega.BeNil())
+
+		ginkgo.By("resuming the JobSet repopulates startTime with a later anchor, not the pre-suspend one")
+		gomega.Eventually(func() error {
+			fetched := get(js)
+			fetched.Spec.Suspend = ptr.To(false)
+			return k8sClient.Update(ctx, fetched)
+		}, timeout, interval).Should(gomega.Succeed())
+		gomega.Eventually(func(g gomega.Gomega) {
+			st := get(js).Status.StartTime
+			g.Expect(st).ToNot(gomega.BeNil())
+			g.Expect(st.After(beforeSuspend.Time)).To(gomega.BeTrue())
+		}, timeout, interval).Should(gomega.Succeed())
+		gomega.Consistently(func() bool {
+			return apimeta.IsStatusConditionTrue(get(js).Status.Conditions, string(jobset.JobSetFailed))
+		}, shortDuration, interval).Should(gomega.BeFalse())
+	})
+
+	ginkgo.It("resets the deadline timer on a global RestartJobSet restart", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.JobSetActiveDeadlineSeconds, true)
+
+		// Long deadline (won't fire) + a global restart policy. A failed child triggers
+		// RestartJobSet, which begins a fresh run and resets startTime.
+		js := testJobSet(ns).
+			ActiveDeadlineSeconds(3600).
+			FailurePolicy(&jobset.FailurePolicy{MaxRestarts: 1}).
+			Obj()
+		gomega.Expect(k8sClient.Create(ctx, js)).To(gomega.Succeed())
+		gomega.Eventually(testutil.NumJobs, timeout, interval).WithArguments(ctx, k8sClient, js).Should(gomega.Equal(testutil.NumExpectedJobs(js)))
+
+		ginkgo.By("recording the pre-restart startTime anchor")
+		gomega.Eventually(func() *metav1.Time {
+			return get(js).Status.StartTime
+		}, timeout, interval).ShouldNot(gomega.BeNil())
+		beforeRestart := get(js).Status.StartTime
+		// metav1.Time is second-granular once round-tripped through the API server, so
+		// wait a full second to make a genuine reset produce a strictly later anchor.
+		time.Sleep(time.Second)
+
+		ginkgo.By("failing a child job to drive a global restart")
+		var jobList batchv1.JobList
+		gomega.Expect(k8sClient.List(ctx, &jobList, client.InNamespace(js.Namespace))).To(gomega.Succeed())
+		gomega.Expect(jobList.Items).ToNot(gomega.BeEmpty())
+		failJob(&jobList.Items[0])
+
+		ginkgo.By("checking the global restart replaced the startTime anchor with a later one (timer reset, not retained)")
+		gomega.Eventually(func(g gomega.Gomega) {
+			fetched := get(js)
+			g.Expect(fetched.Status.Restarts).To(gomega.Equal(int32(1)))
+			g.Expect(fetched.Status.StartTime).ToNot(gomega.BeNil())
+			g.Expect(fetched.Status.StartTime.After(beforeRestart.Time)).To(gomega.BeTrue())
+		}, timeout, interval).Should(gomega.Succeed())
+		gomega.Expect(apimeta.IsStatusConditionTrue(get(js).Status.Conditions, string(jobset.JobSetFailed))).To(gomega.BeFalse())
+	})
+
+	ginkgo.It("does not reset startTime on a single-Job RestartJob restart", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.JobSetActiveDeadlineSeconds, true)
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.RestartJob, true)
+
+		// Long deadline (won't fire) + a RestartJob rule so a single failed Job is
+		// recreated without a global restart. startTime must be left unchanged.
+		js := testJobSet(ns).
+			ActiveDeadlineSeconds(3600).
+			FailurePolicy(&jobset.FailurePolicy{
+				MaxRestarts: 1,
+				Rules: []jobset.FailurePolicyRule{
+					{Action: jobset.RestartJob, OnJobFailureReasons: []string{batchv1.JobReasonPodFailurePolicy}},
+				},
+			}).
+			Obj()
+		gomega.Expect(k8sClient.Create(ctx, js)).To(gomega.Succeed())
+		gomega.Eventually(testutil.NumJobs, timeout, interval).WithArguments(ctx, k8sClient, js).Should(gomega.Equal(testutil.NumExpectedJobs(js)))
+
+		gomega.Eventually(func() *metav1.Time {
+			return get(js).Status.StartTime
+		}, timeout, interval).ShouldNot(gomega.BeNil())
+		startTimeBefore := get(js).Status.StartTime
+
+		ginkgo.By("failing a replicated-job-a job to drive a single-Job RestartJob")
+		var jobList batchv1.JobList
+		gomega.Expect(k8sClient.List(ctx, &jobList, client.InNamespace(js.Namespace))).To(gomega.Succeed())
+		failFirstMatchingJobWithOptions(&jobList, "replicated-job-a", &failJobOptions{reason: ptr.To(batchv1.JobReasonPodFailurePolicy)})
+
+		ginkgo.By("checking the single Job restarted with no global restart and an unchanged startTime")
+		matchJobRestarts(js, []int32{1})
+		gomega.Expect(get(js).Status.Restarts).To(gomega.Equal(int32(0)))
+		gomega.Expect(get(js).Status.StartTime.Equal(startTimeBefore)).To(gomega.BeTrue())
+		gomega.Expect(apimeta.IsStatusConditionTrue(get(js).Status.Conditions, string(jobset.JobSetFailed))).To(gomega.BeFalse())
+	})
+
+	ginkgo.It("extends the deadline when activeDeadlineSeconds is raised on a running JobSet", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.JobSetActiveDeadlineSeconds, true)
+
+		js := testJobSet(ns).ActiveDeadlineSeconds(3600).Obj()
+		gomega.Expect(k8sClient.Create(ctx, js)).To(gomega.Succeed())
+		gomega.Eventually(func() *metav1.Time {
+			return get(js).Status.StartTime
+		}, timeout, interval).ShouldNot(gomega.BeNil())
+
+		ginkgo.By("raising activeDeadlineSeconds on the running JobSet")
+		gomega.Eventually(func() error {
+			fetched := get(js)
+			fetched.Spec.ActiveDeadlineSeconds = ptr.To(int64(7200))
+			return k8sClient.Update(ctx, fetched)
+		}, timeout, interval).Should(gomega.Succeed())
+
+		ginkgo.By("checking the JobSet keeps running and is not failed by the deadline")
+		gomega.Consistently(func() bool {
+			return apimeta.IsStatusConditionTrue(get(js).Status.Conditions, string(jobset.JobSetFailed))
+		}, shortDuration, interval).Should(gomega.BeFalse())
+	})
+
+	ginkgo.It("resets the deadline timer on RestartJobSetAndIgnoreMaxRestarts, unbounded by maxRestarts", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.JobSetActiveDeadlineSeconds, true)
+
+		// MaxRestarts=0 would normally fail the JobSet on the first child failure, but
+		// the ignore action restarts it anyway and begins a fresh run (startTime reset).
+		js := testJobSet(ns).
+			ActiveDeadlineSeconds(3600).
+			FailurePolicy(&jobset.FailurePolicy{
+				MaxRestarts: 0,
+				Rules: []jobset.FailurePolicyRule{
+					{Action: jobset.RestartJobSetAndIgnoreMaxRestarts, OnJobFailureReasons: []string{}},
+				},
+			}).
+			Obj()
+		gomega.Expect(k8sClient.Create(ctx, js)).To(gomega.Succeed())
+		gomega.Eventually(testutil.NumJobs, timeout, interval).WithArguments(ctx, k8sClient, js).Should(gomega.Equal(testutil.NumExpectedJobs(js)))
+
+		ginkgo.By("recording the pre-restart startTime anchor")
+		gomega.Eventually(func() *metav1.Time {
+			return get(js).Status.StartTime
+		}, timeout, interval).ShouldNot(gomega.BeNil())
+		beforeRestart := get(js).Status.StartTime
+		time.Sleep(time.Second) // second-granular metav1.Time: ensure a reset yields a later anchor
+
+		ginkgo.By("failing a child job to drive a global restart that ignores maxRestarts")
+		var jobList batchv1.JobList
+		gomega.Expect(k8sClient.List(ctx, &jobList, client.InNamespace(js.Namespace))).To(gomega.Succeed())
+		gomega.Expect(jobList.Items).ToNot(gomega.BeEmpty())
+		failJob(&jobList.Items[0])
+
+		ginkgo.By("checking the restart replaced the startTime anchor with a later one (fresh per-attempt timer)")
+		gomega.Eventually(func(g gomega.Gomega) {
+			fetched := get(js)
+			g.Expect(fetched.Status.Restarts).To(gomega.Equal(int32(1)))
+			g.Expect(fetched.Status.StartTime).ToNot(gomega.BeNil())
+			g.Expect(fetched.Status.StartTime.After(beforeRestart.Time)).To(gomega.BeTrue())
+		}, timeout, interval).Should(gomega.Succeed())
+		gomega.Expect(apimeta.IsStatusConditionTrue(get(js).Status.Conditions, string(jobset.JobSetFailed))).To(gomega.BeFalse())
+	})
+})


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

Implements KEP-1186. Adds an optional `spec.activeDeadlineSeconds` that bounds how long a JobSet may be continuously active. When the deadline is exceeded, the controller marks the JobSet `Failed` with reason `DeadlineExceeded` and deletes its active child Jobs, matching `batch/v1.Job.spec.activeDeadlineSeconds`. This gives operators a hard upper bound so a wedged distributed run (stuck rendezvous, deadlocked collective, hung data loader) frees its accelerators instead of holding them until a human intervenes.

The timer is measured from a new `.status.startTime`, does not accrue while the JobSet is suspended, and resets on resume and on a global `RestartJobSet` restart. A single-Job `RestartJob` leaves it unchanged. The success policy is evaluated before the deadline, so a JobSet that completes is never failed by it; the deadline is evaluated before the failure policy, so an expired JobSet fails with `DeadlineExceeded` rather than being restarted.

Enforcement is behind the `JobSetActiveDeadlineSeconds` feature gate, alpha and off by default. `.status.startTime` is only maintained while the gate is enabled; when the gate is off the controller does not set or update it.

#### Which issue(s) this PR fixes:

Part of #1186

#### Special notes for your reviewer:

AI disclosure: AI assistance was used to generate code documentation (godoc comments). The implementation and design decisions are my own and I have reviewed all changes.

The interaction with `spec.managedBy` was documented separately in #1319 and is validated here by an integration test: an externally managed JobSet gets neither `startTime` nor deadline enforcement, since the `managedByExternalController` early-return sits above both.

#### Does this PR introduce a user-facing change?

```release-note
Added an alpha `spec.activeDeadlineSeconds` field, gated by the `JobSetActiveDeadlineSeconds` feature gate (off by default), that fails a JobSet with reason `DeadlineExceeded` and deletes its active Jobs once it has been continuously active beyond the deadline. Also added `.status.startTime`, the JobSet active-start timestamp, maintained only while the gate is enabled.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional active deadlines for JobSets to limit continuous active runtime.
  - JobSets exceeding their deadline are marked failed with `DeadlineExceeded`, and active child Jobs are removed.
  - Added active-period tracking with a visible `StartTime` column.
  - Deadlines pause while suspended and reset when resumed or globally restarted.
  - Added Python SDK support and Prometheus metrics.
- **Documentation**
  - Documented active deadline behavior and configuration.
- **Feature Gate**
  - Added an alpha feature gate, disabled by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

