### PR TITLE
docs: link to k8s-CronJobSet for cron scheduling

### DIFF
--- a/site/content/en/docs/overview/_index.md
+++ b/site/content/en/docs/overview/_index.md
@@ -74,6 +74,10 @@ See our github project for our [roadmap](https://github.com/orgs/kubernetes-sigs
 See the [troubleshooting](https://jobset.sigs.k8s.io/docs/troubleshooting/) guide for help resolving common issues.
 
 
+## Related projects
+
+- [k8s-CronJobSet](https://github.com/Rx-11/k8s-CronJobSet): a community project that runs JobSets on a cron schedule, similar to how a Kubernetes CronJob runs Jobs. Useful if you want to schedule recurring JobSet workloads such as periodic backups or batch jobs.
+
 ## Community, Discussion, Contribution, and Support
 
 Learn how to engage with the Kubernetes community on the [community page](http://kubernetes.io/community/).


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Adds a "Related projects" note on the overview page pointing to the community k8s-CronJobSet project, for users who want to run JobSets on a cron schedule. This follows the discussion in the issue, where maintainers preferred linking to the existing implementation rather than building CronJobSet into the repo.

#### Which issue(s) this PR fixes:

Fixes #1203

#### Special notes for your reviewer:

Happy to move the link to a different page if there is a preferred spot.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
